### PR TITLE
Implement token types and lexer for DCL

### DIFF
--- a/dcl/lexer.go
+++ b/dcl/lexer.go
@@ -1,2 +1,269 @@
 // lexer.go implements a hand-written scanner that produces tokens from DCL source.
 package dcl
+
+import "strings"
+
+// Lexer scans DCL source text into tokens.
+type Lexer struct {
+	filename string
+	src      []byte
+	pos      int // byte offset
+	line     int // 1-based
+	col      int // 1-based
+	diags    Diagnostics
+}
+
+// NewLexer creates a Lexer for the given source.
+func NewLexer(filename string, src []byte) *Lexer {
+	return &Lexer{
+		filename: filename,
+		src:      src,
+		pos:      0,
+		line:     1,
+		col:      1,
+	}
+}
+
+// Diagnostics returns the diagnostics accumulated during scanning.
+func (l *Lexer) Diagnostics() Diagnostics {
+	return l.diags
+}
+
+// NextToken returns the next token and advances the lexer state.
+func (l *Lexer) NextToken() Token {
+	l.skipWhitespace()
+
+	if l.atEnd() {
+		return Token{Type: TokenEOF, Pos: l.makePos()}
+	}
+
+	startPos := l.makePos()
+	ch := l.peek()
+
+	switch {
+	case ch == '\n':
+		l.advance()
+		return Token{Type: TokenNewline, Literal: "\n", Pos: startPos}
+	case ch == '#':
+		return l.scanComment(startPos)
+	case ch == '"':
+		return l.scanString(startPos)
+	case isDigit(ch):
+		return l.scanNumber(startPos)
+	case isIdentStart(ch):
+		return l.scanIdentifier(startPos)
+	case ch == '{':
+		l.advance()
+		return Token{Type: TokenLBrace, Literal: "{", Pos: startPos}
+	case ch == '}':
+		l.advance()
+		return Token{Type: TokenRBrace, Literal: "}", Pos: startPos}
+	case ch == '[':
+		l.advance()
+		return Token{Type: TokenLBracket, Literal: "[", Pos: startPos}
+	case ch == ']':
+		l.advance()
+		return Token{Type: TokenRBracket, Literal: "]", Pos: startPos}
+	case ch == '(':
+		l.advance()
+		return Token{Type: TokenLParen, Literal: "(", Pos: startPos}
+	case ch == ')':
+		l.advance()
+		return Token{Type: TokenRParen, Literal: ")", Pos: startPos}
+	case ch == '=':
+		l.advance()
+		return Token{Type: TokenEquals, Literal: "=", Pos: startPos}
+	case ch == ',':
+		l.advance()
+		return Token{Type: TokenComma, Literal: ",", Pos: startPos}
+	case ch == '.':
+		l.advance()
+		return Token{Type: TokenDot, Literal: ".", Pos: startPos}
+	default:
+		ch := l.advance()
+		l.addDiagnostic(startPos, l.makePos(), "unexpected character: "+string(rune(ch)))
+		return Token{Type: TokenIllegal, Literal: string(rune(ch)), Pos: startPos}
+	}
+}
+
+// --- scan helpers ---
+
+func (l *Lexer) scanComment(start Pos) Token {
+	l.advance() // consume '#'
+	var b strings.Builder
+	for !l.atEnd() && l.peek() != '\n' {
+		b.WriteByte(l.advance())
+	}
+	return Token{Type: TokenComment, Literal: b.String(), Pos: start}
+}
+
+func (l *Lexer) scanString(start Pos) Token {
+	l.advance() // consume opening '"'
+	var b strings.Builder
+	for {
+		if l.atEnd() {
+			l.addDiagnostic(start, l.makePos(), "unterminated string")
+			return Token{Type: TokenIllegal, Literal: b.String(), Pos: start}
+		}
+		ch := l.peek()
+		if ch == '\n' {
+			l.addDiagnostic(start, l.makePos(), "unterminated string")
+			return Token{Type: TokenIllegal, Literal: b.String(), Pos: start}
+		}
+		if ch == '"' {
+			l.advance() // consume closing '"'
+			return Token{Type: TokenString, Literal: b.String(), Pos: start}
+		}
+		if ch == '$' && l.peekAt(1) == '{' {
+			l.addDiagnosticWithSuggestion(start, l.makePos(),
+				"string interpolation with ${} is not supported",
+				"use secret() for sensitive values or a reference for resource attributes")
+			// consume rest of string until closing quote, newline, or EOF
+			for !l.atEnd() && l.peek() != '"' && l.peek() != '\n' {
+				l.advance()
+			}
+			if !l.atEnd() && l.peek() == '"' {
+				l.advance()
+			}
+			return Token{Type: TokenIllegal, Literal: b.String(), Pos: start}
+		}
+		if ch == '\\' {
+			l.advance() // consume '\'
+			if l.atEnd() {
+				l.addDiagnostic(start, l.makePos(), "unterminated string")
+				return Token{Type: TokenIllegal, Literal: b.String(), Pos: start}
+			}
+			esc := l.advance()
+			switch esc {
+			case 'n':
+				b.WriteByte('\n')
+			case 't':
+				b.WriteByte('\t')
+			case '\\':
+				b.WriteByte('\\')
+			case '"':
+				b.WriteByte('"')
+			default:
+				escPos := Pos{
+					Filename: l.filename,
+					Line:     l.line,
+					Column:   l.col - 1, // point at the escaped char
+					Offset:   l.pos - 1,
+				}
+				l.addDiagnostic(start, escPos, "unknown escape sequence: \\"+string(rune(esc)))
+				return Token{Type: TokenIllegal, Literal: b.String(), Pos: start}
+			}
+			continue
+		}
+		b.WriteByte(l.advance())
+	}
+}
+
+func (l *Lexer) scanNumber(start Pos) Token {
+	var b strings.Builder
+	for !l.atEnd() && isDigit(l.peek()) {
+		b.WriteByte(l.advance())
+	}
+	// Check for float: '.' followed by digit
+	if !l.atEnd() && l.peek() == '.' && l.pos+1 < len(l.src) && isDigit(l.src[l.pos+1]) {
+		b.WriteByte(l.advance()) // consume '.'
+		for !l.atEnd() && isDigit(l.peek()) {
+			b.WriteByte(l.advance())
+		}
+		return Token{Type: TokenFloat, Literal: b.String(), Pos: start}
+	}
+	return Token{Type: TokenInt, Literal: b.String(), Pos: start}
+}
+
+func (l *Lexer) scanIdentifier(start Pos) Token {
+	var b strings.Builder
+	for !l.atEnd() && isIdentPart(l.peek()) {
+		b.WriteByte(l.advance())
+	}
+	lit := b.String()
+	return Token{Type: lookupIdent(lit), Literal: lit, Pos: start}
+}
+
+// --- low-level helpers ---
+
+func (l *Lexer) peek() byte {
+	if l.pos >= len(l.src) {
+		return 0
+	}
+	return l.src[l.pos]
+}
+
+func (l *Lexer) peekAt(offset int) byte {
+	idx := l.pos + offset
+	if idx >= len(l.src) {
+		return 0
+	}
+	return l.src[idx]
+}
+
+func (l *Lexer) advance() byte {
+	ch := l.src[l.pos]
+	l.pos++
+	if ch == '\n' {
+		l.line++
+		l.col = 1
+	} else {
+		l.col++
+	}
+	return ch
+}
+
+func (l *Lexer) atEnd() bool {
+	return l.pos >= len(l.src)
+}
+
+func (l *Lexer) makePos() Pos {
+	return Pos{
+		Filename: l.filename,
+		Line:     l.line,
+		Column:   l.col,
+		Offset:   l.pos,
+	}
+}
+
+func (l *Lexer) skipWhitespace() {
+	for !l.atEnd() {
+		ch := l.peek()
+		if ch == ' ' || ch == '\t' || ch == '\r' {
+			l.advance()
+		} else {
+			break
+		}
+	}
+}
+
+func (l *Lexer) addDiagnostic(start, end Pos, message string) {
+	l.diags = append(l.diags, Diagnostic{
+		Severity: SeverityError,
+		Message:  message,
+		Range:    Range{Start: start, End: end},
+	})
+}
+
+func (l *Lexer) addDiagnosticWithSuggestion(start, end Pos, message, suggestion string) {
+	l.diags = append(l.diags, Diagnostic{
+		Severity:   SeverityError,
+		Message:    message,
+		Range:      Range{Start: start, End: end},
+		Suggestion: suggestion,
+	})
+}
+
+// --- character classifiers ---
+
+func isDigit(ch byte) bool {
+	return ch >= '0' && ch <= '9'
+}
+
+func isIdentStart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+}
+
+func isIdentPart(ch byte) bool {
+	return isIdentStart(ch) || isDigit(ch)
+}

--- a/dcl/lexer_test.go
+++ b/dcl/lexer_test.go
@@ -1,0 +1,375 @@
+package dcl
+
+import "testing"
+
+// collectTokens drains the lexer until EOF and returns all tokens (including EOF).
+func collectTokens(l *Lexer) []Token {
+	var tokens []Token
+	for {
+		tok := l.NextToken()
+		tokens = append(tokens, tok)
+		if tok.Type == TokenEOF {
+			return tokens
+		}
+	}
+}
+
+func TestLexerEmptyInput(t *testing.T) {
+	l := NewLexer("test.dcl", []byte(""))
+	tok := l.NextToken()
+	if tok.Type != TokenEOF {
+		t.Fatalf("expected EOF, got %v", tok)
+	}
+	if tok.Pos.Line != 1 || tok.Pos.Column != 1 {
+		t.Errorf("EOF pos = %d:%d, want 1:1", tok.Pos.Line, tok.Pos.Column)
+	}
+}
+
+func TestLexerComment(t *testing.T) {
+	l := NewLexer("", []byte("# this is a comment"))
+	tok := l.NextToken()
+	if tok.Type != TokenComment {
+		t.Fatalf("expected Comment, got %v", tok)
+	}
+	if tok.Literal != " this is a comment" {
+		t.Errorf("literal = %q, want %q", tok.Literal, " this is a comment")
+	}
+}
+
+func TestLexerStringLiteral(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`"hello"`, "hello"},
+		{`""`, ""},
+	}
+	for _, tc := range tests {
+		l := NewLexer("", []byte(tc.input))
+		tok := l.NextToken()
+		if tok.Type != TokenString {
+			t.Errorf("input %s: expected String, got %v", tc.input, tok)
+			continue
+		}
+		if tok.Literal != tc.want {
+			t.Errorf("input %s: literal = %q, want %q", tc.input, tok.Literal, tc.want)
+		}
+	}
+}
+
+func TestLexerStringEscapes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`"hello\nworld"`, "hello\nworld"},
+		{`"tab\there"`, "tab\there"},
+		{`"back\\slash"`, "back\\slash"},
+		{`"say \"hi\""`, `say "hi"`},
+	}
+	for _, tc := range tests {
+		l := NewLexer("", []byte(tc.input))
+		tok := l.NextToken()
+		if tok.Type != TokenString {
+			t.Errorf("input %s: expected String, got %v", tc.input, tok)
+			continue
+		}
+		if tok.Literal != tc.want {
+			t.Errorf("input %s: literal = %q, want %q", tc.input, tok.Literal, tc.want)
+		}
+	}
+}
+
+func TestLexerStringInterpolation(t *testing.T) {
+	l := NewLexer("", []byte(`"hello ${name}"`))
+	tok := l.NextToken()
+	if tok.Type != TokenIllegal {
+		t.Fatalf("expected Illegal, got %v", tok)
+	}
+	diags := l.Diagnostics()
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostic for string interpolation")
+	}
+	if diags[0].Message != "string interpolation with ${} is not supported" {
+		t.Errorf("message = %q", diags[0].Message)
+	}
+	if diags[0].Suggestion == "" {
+		t.Error("expected suggestion on interpolation diagnostic")
+	}
+}
+
+func TestLexerUnterminatedString(t *testing.T) {
+	tests := []string{`"hello`, `"hello\`}
+	for _, input := range tests {
+		l := NewLexer("", []byte(input))
+		tok := l.NextToken()
+		if tok.Type != TokenIllegal {
+			t.Errorf("input %q: expected Illegal, got %v", input, tok)
+		}
+		if len(l.Diagnostics()) == 0 {
+			t.Errorf("input %q: expected diagnostic", input)
+		}
+	}
+}
+
+func TestLexerIntegers(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"42", "42"},
+		{"0", "0"},
+	}
+	for _, tc := range tests {
+		l := NewLexer("", []byte(tc.input))
+		tok := l.NextToken()
+		if tok.Type != TokenInt {
+			t.Errorf("input %s: expected Int, got %v", tc.input, tok)
+		}
+		if tok.Literal != tc.want {
+			t.Errorf("input %s: literal = %q, want %q", tc.input, tok.Literal, tc.want)
+		}
+	}
+}
+
+func TestLexerFloats(t *testing.T) {
+	l := NewLexer("", []byte("3.14"))
+	tok := l.NextToken()
+	if tok.Type != TokenFloat {
+		t.Fatalf("expected Float, got %v", tok)
+	}
+	if tok.Literal != "3.14" {
+		t.Errorf("literal = %q, want %q", tok.Literal, "3.14")
+	}
+}
+
+func TestLexerNumberEdgeCases(t *testing.T) {
+	// 123.abc → Int("123"), Dot, Ident("abc")
+	l := NewLexer("", []byte("123.abc"))
+	tokens := collectTokens(l)
+	expected := []struct {
+		tt  TokenType
+		lit string
+	}{
+		{TokenInt, "123"},
+		{TokenDot, "."},
+		{TokenIdent, "abc"},
+		{TokenEOF, ""},
+	}
+	if len(tokens) != len(expected) {
+		t.Fatalf("got %d tokens, want %d", len(tokens), len(expected))
+	}
+	for i, e := range expected {
+		if tokens[i].Type != e.tt || tokens[i].Literal != e.lit {
+			t.Errorf("token[%d] = %v(%q), want %v(%q)", i, tokens[i].Type, tokens[i].Literal, e.tt, e.lit)
+		}
+	}
+
+	// 123. → Int("123"), Dot
+	l2 := NewLexer("", []byte("123."))
+	tokens2 := collectTokens(l2)
+	if tokens2[0].Type != TokenInt || tokens2[0].Literal != "123" {
+		t.Errorf("token[0] = %v(%q), want Int(123)", tokens2[0].Type, tokens2[0].Literal)
+	}
+	if tokens2[1].Type != TokenDot {
+		t.Errorf("token[1] = %v, want Dot", tokens2[1].Type)
+	}
+}
+
+func TestLexerBooleans(t *testing.T) {
+	l := NewLexer("", []byte("true false"))
+	tok1 := l.NextToken()
+	tok2 := l.NextToken()
+	if tok1.Type != TokenTrue || tok1.Literal != "true" {
+		t.Errorf("expected True(true), got %v(%q)", tok1.Type, tok1.Literal)
+	}
+	if tok2.Type != TokenFalse || tok2.Literal != "false" {
+		t.Errorf("expected False(false), got %v(%q)", tok2.Type, tok2.Literal)
+	}
+}
+
+func TestLexerIdentifiers(t *testing.T) {
+	tests := []string{"foo", "_bar", "x123"}
+	for _, input := range tests {
+		l := NewLexer("", []byte(input))
+		tok := l.NextToken()
+		if tok.Type != TokenIdent {
+			t.Errorf("input %q: expected Ident, got %v", input, tok)
+		}
+		if tok.Literal != input {
+			t.Errorf("input %q: literal = %q", input, tok.Literal)
+		}
+	}
+}
+
+func TestLexerPunctuation(t *testing.T) {
+	tests := []struct {
+		input string
+		want  TokenType
+	}{
+		{"{", TokenLBrace},
+		{"}", TokenRBrace},
+		{"[", TokenLBracket},
+		{"]", TokenRBracket},
+		{"(", TokenLParen},
+		{")", TokenRParen},
+		{"=", TokenEquals},
+		{",", TokenComma},
+		{".", TokenDot},
+	}
+	for _, tc := range tests {
+		l := NewLexer("", []byte(tc.input))
+		tok := l.NextToken()
+		if tok.Type != tc.want {
+			t.Errorf("input %q: expected %v, got %v", tc.input, tc.want, tok.Type)
+		}
+	}
+}
+
+func TestLexerMultiTokenSequence(t *testing.T) {
+	input := `context "prod" {
+  region = "us-east-1"
+}`
+	l := NewLexer("test.dcl", []byte(input))
+	tokens := collectTokens(l)
+
+	expected := []TokenType{
+		TokenIdent,   // context
+		TokenString,  // "prod"
+		TokenLBrace,  // {
+		TokenNewline, // \n
+		TokenIdent,   // region
+		TokenEquals,  // =
+		TokenString,  // "us-east-1"
+		TokenNewline, // \n
+		TokenRBrace,  // }
+		TokenEOF,
+	}
+	if len(tokens) != len(expected) {
+		t.Fatalf("got %d tokens, want %d:\n%v", len(tokens), len(expected), tokens)
+	}
+	for i, e := range expected {
+		if tokens[i].Type != e {
+			t.Errorf("token[%d] = %v, want %v", i, tokens[i].Type, e)
+		}
+	}
+}
+
+func TestLexerPositionTracking(t *testing.T) {
+	input := "abc\ndef\nghi"
+	l := NewLexer("", []byte(input))
+	tokens := collectTokens(l)
+
+	// abc at 1:1, \n at 1:4, def at 2:1, \n at 2:4, ghi at 3:1, EOF at 3:4
+	wantPositions := []struct {
+		line, col int
+	}{
+		{1, 1}, // abc
+		{1, 4}, // \n
+		{2, 1}, // def
+		{2, 4}, // \n
+		{3, 1}, // ghi
+		{3, 4}, // EOF
+	}
+	if len(tokens) != len(wantPositions) {
+		t.Fatalf("got %d tokens, want %d", len(tokens), len(wantPositions))
+	}
+	for i, wp := range wantPositions {
+		if tokens[i].Pos.Line != wp.line || tokens[i].Pos.Column != wp.col {
+			t.Errorf("token[%d] (%v) pos = %d:%d, want %d:%d",
+				i, tokens[i].Type, tokens[i].Pos.Line, tokens[i].Pos.Column, wp.line, wp.col)
+		}
+	}
+}
+
+func TestLexerIllegalCharacter(t *testing.T) {
+	l := NewLexer("", []byte("@"))
+	tok := l.NextToken()
+	if tok.Type != TokenIllegal {
+		t.Fatalf("expected Illegal, got %v", tok)
+	}
+	if tok.Literal != "@" {
+		t.Errorf("literal = %q, want %q", tok.Literal, "@")
+	}
+	if len(l.Diagnostics()) == 0 {
+		t.Error("expected diagnostic for illegal character")
+	}
+}
+
+func TestLexerWhitespaceHandling(t *testing.T) {
+	l := NewLexer("", []byte("  \t  foo  \t  "))
+	tokens := collectTokens(l)
+	// Should produce: Ident("foo"), EOF
+	if len(tokens) != 2 {
+		t.Fatalf("got %d tokens, want 2: %v", len(tokens), tokens)
+	}
+	if tokens[0].Type != TokenIdent || tokens[0].Literal != "foo" {
+		t.Errorf("token[0] = %v(%q), want Ident(foo)", tokens[0].Type, tokens[0].Literal)
+	}
+	if tokens[1].Type != TokenEOF {
+		t.Errorf("token[1] = %v, want EOF", tokens[1].Type)
+	}
+}
+
+func TestLexerNewlineVariants(t *testing.T) {
+	// \r\n should produce single newline (\r is whitespace, \n is newline token)
+	l := NewLexer("", []byte("\r\n"))
+	tokens := collectTokens(l)
+	if len(tokens) != 2 {
+		t.Fatalf("got %d tokens, want 2: %v", len(tokens), tokens)
+	}
+	if tokens[0].Type != TokenNewline {
+		t.Errorf("token[0] = %v, want Newline", tokens[0].Type)
+	}
+
+	// \n\n produces two newlines
+	l2 := NewLexer("", []byte("\n\n"))
+	tokens2 := collectTokens(l2)
+	if len(tokens2) != 3 { // Newline, Newline, EOF
+		t.Fatalf("got %d tokens, want 3: %v", len(tokens2), tokens2)
+	}
+	if tokens2[0].Type != TokenNewline || tokens2[1].Type != TokenNewline {
+		t.Errorf("expected two Newline tokens, got %v %v", tokens2[0].Type, tokens2[1].Type)
+	}
+}
+
+func TestLexerStringWithNewline(t *testing.T) {
+	// A literal newline inside a string is unterminated
+	l := NewLexer("", []byte("\"hello\nworld\""))
+	tok := l.NextToken()
+	if tok.Type != TokenIllegal {
+		t.Fatalf("expected Illegal, got %v", tok)
+	}
+	diags := l.Diagnostics()
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostic for unterminated string")
+	}
+	if diags[0].Message != "unterminated string" {
+		t.Errorf("message = %q, want %q", diags[0].Message, "unterminated string")
+	}
+}
+
+func TestLexerRepeatedEOF(t *testing.T) {
+	l := NewLexer("", []byte(""))
+	for i := 0; i < 3; i++ {
+		tok := l.NextToken()
+		if tok.Type != TokenEOF {
+			t.Errorf("call %d: expected EOF, got %v", i+1, tok)
+		}
+	}
+}
+
+func TestLexerUnknownEscape(t *testing.T) {
+	l := NewLexer("", []byte(`"\a"`))
+	tok := l.NextToken()
+	if tok.Type != TokenIllegal {
+		t.Fatalf("expected Illegal, got %v", tok)
+	}
+	diags := l.Diagnostics()
+	if len(diags) == 0 {
+		t.Fatal("expected diagnostic for unknown escape")
+	}
+	if diags[0].Message != `unknown escape sequence: \a` {
+		t.Errorf("message = %q", diags[0].Message)
+	}
+}

--- a/dcl/token.go
+++ b/dcl/token.go
@@ -1,2 +1,102 @@
 // token.go defines the TokenType enum and Token struct used by the lexer.
 package dcl
+
+import "fmt"
+
+// TokenType classifies a lexical token.
+type TokenType int
+
+const (
+	TokenIllegal  TokenType = iota // zero value — uninitialised or invalid
+	TokenEOF                       // end of input
+	TokenNewline                   // \n (significant for statement termination)
+	TokenComment                   // # …
+	TokenIdent                     // identifier
+	TokenString                    // "…"
+	TokenInt                       // 123
+	TokenFloat                     // 3.14
+	TokenTrue                      // true
+	TokenFalse                     // false
+	TokenLBrace                    // {
+	TokenRBrace                    // }
+	TokenLBracket                  // [
+	TokenRBracket                  // ]
+	TokenLParen                    // (
+	TokenRParen                    // )
+	TokenEquals                    // =
+	TokenComma                     // ,
+	TokenDot                       // .
+)
+
+func (t TokenType) String() string {
+	switch t {
+	case TokenIllegal:
+		return "Illegal"
+	case TokenEOF:
+		return "EOF"
+	case TokenNewline:
+		return "Newline"
+	case TokenComment:
+		return "Comment"
+	case TokenIdent:
+		return "Ident"
+	case TokenString:
+		return "String"
+	case TokenInt:
+		return "Int"
+	case TokenFloat:
+		return "Float"
+	case TokenTrue:
+		return "True"
+	case TokenFalse:
+		return "False"
+	case TokenLBrace:
+		return "LBrace"
+	case TokenRBrace:
+		return "RBrace"
+	case TokenLBracket:
+		return "LBracket"
+	case TokenRBracket:
+		return "RBracket"
+	case TokenLParen:
+		return "LParen"
+	case TokenRParen:
+		return "RParen"
+	case TokenEquals:
+		return "Equals"
+	case TokenComma:
+		return "Comma"
+	case TokenDot:
+		return "Dot"
+	default:
+		return fmt.Sprintf("TokenType(%d)", int(t))
+	}
+}
+
+// Token represents a single lexical token with its source position.
+type Token struct {
+	Type    TokenType
+	Literal string
+	Pos     Pos
+}
+
+func (t Token) String() string {
+	if t.Literal == "" {
+		return t.Type.String()
+	}
+	return fmt.Sprintf("%s(%q)", t.Type, t.Literal)
+}
+
+// keywords maps reserved words to their token types.
+var keywords = map[string]TokenType{
+	"true":  TokenTrue,
+	"false": TokenFalse,
+}
+
+// lookupIdent returns the keyword TokenType for ident, or TokenIdent.
+func lookupIdent(ident string) TokenType {
+	if tok, ok := keywords[ident]; ok {
+		return tok
+	}
+	return TokenIdent
+}

--- a/dcl/token_test.go
+++ b/dcl/token_test.go
@@ -1,0 +1,66 @@
+package dcl
+
+import "testing"
+
+func TestTokenTypeString(t *testing.T) {
+	tests := []struct {
+		tt   TokenType
+		want string
+	}{
+		{TokenIllegal, "Illegal"},
+		{TokenEOF, "EOF"},
+		{TokenNewline, "Newline"},
+		{TokenComment, "Comment"},
+		{TokenIdent, "Ident"},
+		{TokenString, "String"},
+		{TokenInt, "Int"},
+		{TokenFloat, "Float"},
+		{TokenTrue, "True"},
+		{TokenFalse, "False"},
+		{TokenLBrace, "LBrace"},
+		{TokenRBrace, "RBrace"},
+		{TokenLBracket, "LBracket"},
+		{TokenRBracket, "RBracket"},
+		{TokenLParen, "LParen"},
+		{TokenRParen, "RParen"},
+		{TokenEquals, "Equals"},
+		{TokenComma, "Comma"},
+		{TokenDot, "Dot"},
+		{TokenType(999), "TokenType(999)"},
+	}
+	for _, tc := range tests {
+		if got := tc.tt.String(); got != tc.want {
+			t.Errorf("TokenType(%d).String() = %q, want %q", int(tc.tt), got, tc.want)
+		}
+	}
+}
+
+func TestTokenString(t *testing.T) {
+	tok := Token{Type: TokenIdent, Literal: "foo"}
+	if got := tok.String(); got != `Ident("foo")` {
+		t.Errorf("Token.String() = %q, want %q", got, `Ident("foo")`)
+	}
+
+	eof := Token{Type: TokenEOF}
+	if got := eof.String(); got != "EOF" {
+		t.Errorf("Token.String() = %q, want %q", got, "EOF")
+	}
+}
+
+func TestLookupIdent(t *testing.T) {
+	tests := []struct {
+		ident string
+		want  TokenType
+	}{
+		{"true", TokenTrue},
+		{"false", TokenFalse},
+		{"context", TokenIdent},
+		{"TRUE", TokenIdent}, // case-sensitive
+		{"False", TokenIdent},
+	}
+	for _, tc := range tests {
+		if got := lookupIdent(tc.ident); got != tc.want {
+			t.Errorf("lookupIdent(%q) = %v, want %v", tc.ident, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4

## Summary
- Implement `TokenType` enum (18 types) and `Token` struct with `String()` methods, keyword map, and `lookupIdent` helper in `dcl/token.go`
- Implement hand-written `Lexer` with `NewLexer()`, `NextToken()`, and scan methods for comments, strings (with escape handling), numbers (int/float), identifiers, and punctuation in `dcl/lexer.go`
- String interpolation `${}` detected and reported as diagnostic with suggestion
- Accurate source position tracking (line/column) across multi-line input

## Test Plan
- [x] `TestTokenTypeString` — all 18 types + unknown fallback
- [x] `TestTokenString` — formatting with and without literal
- [x] `TestLookupIdent` — keyword lookup, case sensitivity
- [x] `TestLexerEmptyInput`, `TestLexerRepeatedEOF` — EOF behavior
- [x] `TestLexerComment`, `TestLexerStringLiteral`, `TestLexerStringEscapes` — literal scanning
- [x] `TestLexerStringInterpolation`, `TestLexerUnterminatedString`, `TestLexerUnknownEscape` — error diagnostics
- [x] `TestLexerIntegers`, `TestLexerFloats`, `TestLexerNumberEdgeCases` — number scanning
- [x] `TestLexerBooleans`, `TestLexerIdentifiers`, `TestLexerPunctuation` — keywords and symbols
- [x] `TestLexerMultiTokenSequence` — full `context "prod" { ... }` block
- [x] `TestLexerPositionTracking` — line/column accuracy across newlines
- [x] `TestLexerWhitespaceHandling`, `TestLexerNewlineVariants`, `TestLexerStringWithNewline`, `TestLexerIllegalCharacter`
- All 23 tests passing, `go build ./...` clean