### PR TITLE
Implement AST node types for DCL (#5)

### DIFF
--- a/dcl/ast.go
+++ b/dcl/ast.go
@@ -1,2 +1,130 @@
 // ast.go defines the AST node types produced by the parser.
 package dcl
+
+// Node — all AST nodes carry a source Range. Unexported to close the set.
+type Node interface {
+	nodeRange() Range
+}
+
+// Expression — marker for nodes that can appear as values. Embeds Node.
+type Expression interface {
+	Node
+	exprNode()
+}
+
+// --- Structural types ---
+
+// File is the top-level AST node representing an entire DCL source file.
+type File struct {
+	Blocks      []Block
+	Diagnostics Diagnostics
+	Rng         Range
+}
+
+func (f *File) nodeRange() Range { return f.Rng }
+
+// Block represents a labeled or unlabeled block (e.g. "resource db { ... }").
+type Block struct {
+	Type       string
+	Label      string // empty = unlabeled
+	Attributes []Attribute
+	Blocks     []Block
+	Rng        Range
+}
+
+func (b *Block) nodeRange() Range { return b.Rng }
+
+// Attribute represents a key = value pair inside a block.
+type Attribute struct {
+	Key   string
+	Value Expression
+	Rng   Range
+}
+
+func (a *Attribute) nodeRange() Range { return a.Rng }
+
+// --- Expression types ---
+
+// LiteralString represents a string literal.
+type LiteralString struct {
+	Value string
+	Rng   Range
+}
+
+func (l *LiteralString) nodeRange() Range { return l.Rng }
+func (l *LiteralString) exprNode()        {}
+
+// LiteralInt represents an integer literal.
+type LiteralInt struct {
+	Value int64
+	Rng   Range
+}
+
+func (l *LiteralInt) nodeRange() Range { return l.Rng }
+func (l *LiteralInt) exprNode()        {}
+
+// LiteralFloat represents a floating-point literal.
+type LiteralFloat struct {
+	Value float64
+	Rng   Range
+}
+
+func (l *LiteralFloat) nodeRange() Range { return l.Rng }
+func (l *LiteralFloat) exprNode()        {}
+
+// LiteralBool represents a boolean literal.
+type LiteralBool struct {
+	Value bool
+	Rng   Range
+}
+
+func (l *LiteralBool) nodeRange() Range { return l.Rng }
+func (l *LiteralBool) exprNode()        {}
+
+// ListExpr represents a list expression (e.g. [1, 2, 3]).
+type ListExpr struct {
+	Elements []Expression
+	Rng      Range
+}
+
+func (l *ListExpr) nodeRange() Range { return l.Rng }
+func (l *ListExpr) exprNode()        {}
+
+// MapExpr represents a map expression with parallel key/value slices
+// to preserve insertion order.
+type MapExpr struct {
+	Keys   []string
+	Values []Expression
+	Rng    Range
+}
+
+func (m *MapExpr) nodeRange() Range { return m.Rng }
+func (m *MapExpr) exprNode()        {}
+
+// Identifier represents a simple name reference.
+type Identifier struct {
+	Name string
+	Rng  Range
+}
+
+func (i *Identifier) nodeRange() Range { return i.Rng }
+func (i *Identifier) exprNode()        {}
+
+// Reference represents a dotted reference with 2+ segments (e.g. "db.host").
+type Reference struct {
+	Parts []string
+	Rng   Range
+}
+
+func (r *Reference) nodeRange() Range { return r.Rng }
+func (r *Reference) exprNode()        {}
+
+// FunctionCall represents a function invocation (e.g. "env("HOME")").
+type FunctionCall struct {
+	Name string
+	Args []Expression
+	Rng  Range
+}
+
+func (f *FunctionCall) nodeRange() Range { return f.Rng }
+func (f *FunctionCall) exprNode()        {}

--- a/dcl/ast_test.go
+++ b/dcl/ast_test.go
@@ -1,0 +1,173 @@
+package dcl
+
+import "testing"
+
+func TestExpressionInterfaceSatisfaction(t *testing.T) {
+	rng := Range{
+		Start: Pos{Filename: "test.dcl", Line: 1, Column: 1, Offset: 0},
+		End:   Pos{Filename: "test.dcl", Line: 1, Column: 10, Offset: 9},
+	}
+
+	tests := []struct {
+		name string
+		expr Expression
+	}{
+		{"LiteralString", &LiteralString{Value: "hello", Rng: rng}},
+		{"LiteralInt", &LiteralInt{Value: 42, Rng: rng}},
+		{"LiteralFloat", &LiteralFloat{Value: 3.14, Rng: rng}},
+		{"LiteralBool", &LiteralBool{Value: true, Rng: rng}},
+		{"ListExpr", &ListExpr{Rng: rng}},
+		{"MapExpr", &MapExpr{Rng: rng}},
+		{"Identifier", &Identifier{Name: "foo", Rng: rng}},
+		{"Reference", &Reference{Parts: []string{"db", "host"}, Rng: rng}},
+		{"FunctionCall", &FunctionCall{Name: "env", Rng: rng}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.expr.nodeRange()
+			if got != rng {
+				t.Errorf("%s.nodeRange() = %v, want %v", tt.name, got, rng)
+			}
+		})
+	}
+}
+
+func TestNodeInterfaceSatisfaction(t *testing.T) {
+	rng := Range{
+		Start: Pos{Filename: "test.dcl", Line: 2, Column: 1, Offset: 10},
+		End:   Pos{Filename: "test.dcl", Line: 5, Column: 2, Offset: 50},
+	}
+
+	tests := []struct {
+		name string
+		node Node
+	}{
+		{"File", &File{Rng: rng}},
+		{"Block", &Block{Rng: rng}},
+		{"Attribute", &Attribute{Rng: rng}},
+		{"LiteralString", &LiteralString{Rng: rng}},
+		{"LiteralInt", &LiteralInt{Rng: rng}},
+		{"LiteralFloat", &LiteralFloat{Rng: rng}},
+		{"LiteralBool", &LiteralBool{Rng: rng}},
+		{"ListExpr", &ListExpr{Rng: rng}},
+		{"MapExpr", &MapExpr{Rng: rng}},
+		{"Identifier", &Identifier{Rng: rng}},
+		{"Reference", &Reference{Rng: rng}},
+		{"FunctionCall", &FunctionCall{Rng: rng}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.node.nodeRange()
+			if got != rng {
+				t.Errorf("%s.nodeRange() = %v, want %v", tt.name, got, rng)
+			}
+		})
+	}
+}
+
+func TestFileNodeRange(t *testing.T) {
+	tests := []struct {
+		name string
+		file File
+		want Range
+	}{
+		{
+			"empty file",
+			File{
+				Rng: Range{
+					Start: Pos{Filename: "empty.dcl", Line: 1, Column: 1, Offset: 0},
+					End:   Pos{Filename: "empty.dcl", Line: 1, Column: 1, Offset: 0},
+				},
+			},
+			Range{
+				Start: Pos{Filename: "empty.dcl", Line: 1, Column: 1, Offset: 0},
+				End:   Pos{Filename: "empty.dcl", Line: 1, Column: 1, Offset: 0},
+			},
+		},
+		{
+			"file with blocks",
+			File{
+				Blocks: []Block{
+					{Type: "resource", Label: "db", Rng: Range{
+						Start: Pos{Line: 1, Column: 1},
+						End:   Pos{Line: 3, Column: 2},
+					}},
+					{Type: "resource", Label: "cache", Rng: Range{
+						Start: Pos{Line: 5, Column: 1},
+						End:   Pos{Line: 8, Column: 2},
+					}},
+				},
+				Rng: Range{
+					Start: Pos{Filename: "multi.dcl", Line: 1, Column: 1, Offset: 0},
+					End:   Pos{Filename: "multi.dcl", Line: 8, Column: 2, Offset: 100},
+				},
+			},
+			Range{
+				Start: Pos{Filename: "multi.dcl", Line: 1, Column: 1, Offset: 0},
+				End:   Pos{Filename: "multi.dcl", Line: 8, Column: 2, Offset: 100},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.file.nodeRange()
+			if got != tt.want {
+				t.Errorf("File.nodeRange() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConstructionAndRangePropagation(t *testing.T) {
+	// Build a realistic AST: File → Block → Attribute → LiteralString
+	strRng := Range{
+		Start: Pos{Filename: "app.dcl", Line: 2, Column: 10, Offset: 25},
+		End:   Pos{Filename: "app.dcl", Line: 2, Column: 22, Offset: 37},
+	}
+	lit := &LiteralString{Value: "localhost", Rng: strRng}
+
+	attrRng := Range{
+		Start: Pos{Filename: "app.dcl", Line: 2, Column: 3, Offset: 18},
+		End:   Pos{Filename: "app.dcl", Line: 2, Column: 22, Offset: 37},
+	}
+	attr := Attribute{Key: "host", Value: lit, Rng: attrRng}
+
+	blockRng := Range{
+		Start: Pos{Filename: "app.dcl", Line: 1, Column: 1, Offset: 0},
+		End:   Pos{Filename: "app.dcl", Line: 3, Column: 2, Offset: 40},
+	}
+	block := Block{
+		Type:       "resource",
+		Label:      "db",
+		Attributes: []Attribute{attr},
+		Rng:        blockRng,
+	}
+
+	fileRng := Range{
+		Start: Pos{Filename: "app.dcl", Line: 1, Column: 1, Offset: 0},
+		End:   Pos{Filename: "app.dcl", Line: 3, Column: 2, Offset: 40},
+	}
+	file := &File{
+		Blocks: []Block{block},
+		Rng:    fileRng,
+	}
+
+	tests := []struct {
+		name string
+		node Node
+		want Range
+	}{
+		{"file range", file, fileRng},
+		{"block range", &block, blockRng},
+		{"attribute range", &attr, attrRng},
+		{"literal string range", lit, strRng},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.node.nodeRange()
+			if got != tt.want {
+				t.Errorf("%s: nodeRange() = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Define `Node` and `Expression` interfaces (unexported methods to close the type set)
- Add 3 structural types: `File`, `Block`, `Attribute`
- Add 9 expression types: `LiteralString`, `LiteralInt`, `LiteralFloat`, `LiteralBool`, `ListExpr`, `MapExpr`, `Identifier`, `Reference`, `FunctionCall`
- All 12 types satisfy `Node` via `nodeRange()`, 9 expression types additionally satisfy `Expression` via `exprNode()`

Closes #5

## Test Plan
- [x] `TestExpressionInterfaceSatisfaction` — all 9 expression types assigned to `Expression`, `nodeRange()` returns correct `Range`
- [x] `TestNodeInterfaceSatisfaction` — all 12 types assigned to `Node`, `nodeRange()` correct
- [x] `TestFileNodeRange` — empty file and file with multiple blocks
- [x] `TestConstructionAndRangePropagation` — realistic AST tree (File → Block → Attribute → LiteralString), range verified at each level
- [x] `go build ./...` — clean
- [x] `go vet ./dcl/...` — clean