### PR TITLE
Implement recursive-descent parser for DCL (#6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ vendor/
 .vscode/
 *.swp
 *.swo
+
+# Worktrees
+.worktrees/

--- a/dcl/parser.go
+++ b/dcl/parser.go
@@ -1,2 +1,313 @@
-// parser.go implements a recursive-descent parser that produces an AST from tokens.
+// parser.go implements a recursive-descent parser that converts tokens into an AST.
 package dcl
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Parse parses DCL source into an AST File node.
+func Parse(filename string, src []byte) (*File, Diagnostics) {
+	lex := NewLexer(filename, src)
+	p := &parser{lex: lex}
+
+	// Prime two-token lookahead buffer.
+	p.cur = p.readNonComment()
+	p.peek = p.readNonComment()
+
+	file := p.parseFile()
+
+	// Merge lexer diagnostics into parser diagnostics.
+	all := make(Diagnostics, 0, len(lex.Diagnostics())+len(p.diags))
+	all = append(all, lex.Diagnostics()...)
+	all = append(all, p.diags...)
+	file.Diagnostics = all
+
+	return file, all
+}
+
+type parser struct {
+	lex   *Lexer
+	cur   Token // current token
+	peek  Token // one-token lookahead
+	diags Diagnostics
+}
+
+// tokenEnd computes the end Pos from a token's start position and literal length.
+// For strings it adds 2 to account for the surrounding quotes (which are stripped
+// from Token.Literal by the lexer). Single-line tokens only.
+func tokenEnd(tok Token) Pos {
+	length := len(tok.Literal)
+	if tok.Type == TokenString {
+		length += 2 // account for quotes
+	}
+	return Pos{
+		Filename: tok.Pos.Filename,
+		Line:     tok.Pos.Line,
+		Column:   tok.Pos.Column + length,
+		Offset:   tok.Pos.Offset + length,
+	}
+}
+
+// --- token management ---
+
+// readNonComment reads the next token from the lexer, skipping comments.
+func (p *parser) readNonComment() Token {
+	for {
+		tok := p.lex.NextToken()
+		if tok.Type != TokenComment {
+			return tok
+		}
+	}
+}
+
+// nextToken shifts peek→cur and reads a new peek.
+func (p *parser) nextToken() {
+	p.cur = p.peek
+	p.peek = p.readNonComment()
+}
+
+// skipNewlines consumes consecutive newline tokens.
+func (p *parser) skipNewlines() {
+	for p.cur.Type == TokenNewline {
+		p.nextToken()
+	}
+}
+
+// expect asserts the current token is of the given type, advances, and returns it.
+// If the type doesn't match, it records an error and returns ok=false.
+func (p *parser) expect(typ TokenType) (Token, bool) {
+	if p.cur.Type == typ {
+		tok := p.cur
+		p.nextToken()
+		return tok, true
+	}
+	p.addError(p.cur.Pos, fmt.Sprintf("expected %s, got %s", typ, p.cur.Type))
+	return p.cur, false
+}
+
+// addError appends an error diagnostic at the given position.
+func (p *parser) addError(pos Pos, msg string) {
+	p.diags = append(p.diags, Diagnostic{
+		Severity: SeverityError,
+		Message:  msg,
+		Range:    Range{Start: pos, End: pos},
+	})
+}
+
+// --- error recovery ---
+
+// recoverToNextStatement skips tokens until a newline, }, or EOF.
+// If a newline is found it is consumed.
+func (p *parser) recoverToNextStatement() {
+	for p.cur.Type != TokenNewline && p.cur.Type != TokenRBrace && p.cur.Type != TokenEOF {
+		p.nextToken()
+	}
+	if p.cur.Type == TokenNewline {
+		p.nextToken()
+	}
+}
+
+// recoverToBlockEnd skips tokens until the matching closing brace (tracking depth).
+func (p *parser) recoverToBlockEnd() {
+	depth := 1
+	for depth > 0 && p.cur.Type != TokenEOF {
+		if p.cur.Type == TokenLBrace {
+			depth++
+		} else if p.cur.Type == TokenRBrace {
+			depth--
+		}
+		if depth > 0 {
+			p.nextToken()
+		}
+	}
+	// Consume the closing brace if present.
+	if p.cur.Type == TokenRBrace {
+		p.nextToken()
+	}
+}
+
+// --- parsing methods ---
+
+// parseFile parses the top-level structure: a sequence of blocks.
+func (p *parser) parseFile() *File {
+	fileStart := p.cur.Pos
+	var blocks []Block
+
+	for {
+		p.skipNewlines()
+
+		if p.cur.Type == TokenEOF {
+			break
+		}
+
+		if p.cur.Type != TokenIdent {
+			p.addError(p.cur.Pos, fmt.Sprintf("expected block type (identifier), got %s", p.cur.Type))
+			p.recoverToNextStatement()
+			continue
+		}
+
+		// Disambiguation: ident + peek = → top-level attribute error.
+		if p.peek.Type == TokenEquals {
+			p.addError(p.cur.Pos, "attributes are not allowed at the top level")
+			p.recoverToNextStatement()
+			continue
+		}
+
+		// ident + peek string/{ → block.
+		block, ok := p.parseBlock()
+		if ok {
+			blocks = append(blocks, block)
+		}
+	}
+
+	fileEnd := p.cur.Pos // EOF position
+	return &File{
+		Blocks: blocks,
+		Rng:    Range{Start: fileStart, End: fileEnd},
+	}
+}
+
+// parseBlock parses: type ["label"] { attrs... }
+func (p *parser) parseBlock() (Block, bool) {
+	typeToken := p.cur
+	p.nextToken() // consume type identifier
+
+	var label string
+	if p.cur.Type == TokenString {
+		label = p.cur.Literal
+		p.nextToken()
+	}
+
+	// Expect opening brace.
+	if _, ok := p.expect(TokenLBrace); !ok {
+		p.recoverToNextStatement()
+		return Block{}, false
+	}
+
+	var attrs []Attribute
+
+	for {
+		p.skipNewlines()
+
+		if p.cur.Type == TokenRBrace || p.cur.Type == TokenEOF {
+			break
+		}
+
+		if p.cur.Type != TokenIdent {
+			p.addError(p.cur.Pos, fmt.Sprintf("expected attribute name (identifier), got %s", p.cur.Type))
+			p.recoverToNextStatement()
+			continue
+		}
+
+		// Disambiguation inside block body.
+		if p.peek.Type == TokenEquals {
+			attr, ok := p.parseAttribute()
+			if ok {
+				attrs = append(attrs, attr)
+			}
+			continue
+		}
+
+		// ident + peek string/{/ident looks like a nested block — not supported yet.
+		if p.peek.Type == TokenString || p.peek.Type == TokenLBrace || p.peek.Type == TokenIdent {
+			p.addError(p.cur.Pos, "nested blocks are not yet supported")
+			p.recoverToNextStatement()
+			continue
+		}
+
+		p.addError(p.cur.Pos, fmt.Sprintf("expected '=' after attribute name, got %s", p.peek.Type))
+		p.recoverToNextStatement()
+	}
+
+	// Consume closing brace.
+	rbrace, ok := p.expect(TokenRBrace)
+	if !ok {
+		p.recoverToBlockEnd()
+		return Block{}, false
+	}
+
+	return Block{
+		Type:       typeToken.Literal,
+		Label:      label,
+		Attributes: attrs,
+		Rng:        Range{Start: typeToken.Pos, End: tokenEnd(rbrace)},
+	}, true
+}
+
+// parseAttribute parses: key = value
+func (p *parser) parseAttribute() (Attribute, bool) {
+	keyToken := p.cur
+	p.nextToken() // consume key
+
+	p.nextToken() // consume '='
+
+	expr, ok := p.parseExpression()
+	if !ok {
+		p.recoverToNextStatement()
+		return Attribute{}, false
+	}
+
+	return Attribute{
+		Key:   keyToken.Literal,
+		Value: expr,
+		Rng:   Range{Start: keyToken.Pos, End: expr.nodeRange().End},
+	}, true
+}
+
+// parseExpression parses a literal value: string, int, float, or bool.
+func (p *parser) parseExpression() (Expression, bool) {
+	tok := p.cur
+	switch tok.Type {
+	case TokenString:
+		p.nextToken()
+		return &LiteralString{
+			Value: tok.Literal,
+			Rng:   Range{Start: tok.Pos, End: tokenEnd(tok)},
+		}, true
+
+	case TokenInt:
+		val, err := strconv.ParseInt(tok.Literal, 10, 64)
+		if err != nil {
+			p.addError(tok.Pos, fmt.Sprintf("invalid integer: %s", tok.Literal))
+			p.nextToken()
+			return nil, false
+		}
+		p.nextToken()
+		return &LiteralInt{
+			Value: val,
+			Rng:   Range{Start: tok.Pos, End: tokenEnd(tok)},
+		}, true
+
+	case TokenFloat:
+		val, err := strconv.ParseFloat(tok.Literal, 64)
+		if err != nil {
+			p.addError(tok.Pos, fmt.Sprintf("invalid float: %s", tok.Literal))
+			p.nextToken()
+			return nil, false
+		}
+		p.nextToken()
+		return &LiteralFloat{
+			Value: val,
+			Rng:   Range{Start: tok.Pos, End: tokenEnd(tok)},
+		}, true
+
+	case TokenTrue:
+		p.nextToken()
+		return &LiteralBool{
+			Value: true,
+			Rng:   Range{Start: tok.Pos, End: tokenEnd(tok)},
+		}, true
+
+	case TokenFalse:
+		p.nextToken()
+		return &LiteralBool{
+			Value: false,
+			Rng:   Range{Start: tok.Pos, End: tokenEnd(tok)},
+		}, true
+
+	default:
+		p.addError(tok.Pos, fmt.Sprintf("expected value, got %s", tok.Type))
+		return nil, false
+	}
+}

--- a/dcl/parser_test.go
+++ b/dcl/parser_test.go
@@ -1,0 +1,327 @@
+package dcl
+
+import "testing"
+
+// parseString is a test helper that calls Parse and fatals on unexpected errors.
+func parseString(t *testing.T, src string) *File {
+	t.Helper()
+	f, diags := Parse("test.dcl", []byte(src))
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors:\n%s", diags.Error())
+	}
+	return f
+}
+
+func TestParseEmptyFile(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{"empty", ""},
+		{"whitespace", "  "},
+		{"newlines", "\n\n"},
+		{"comment", "# comment\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := parseString(t, tt.src)
+			if len(f.Blocks) != 0 {
+				t.Errorf("expected 0 blocks, got %d", len(f.Blocks))
+			}
+		})
+	}
+}
+
+func TestParseLabeledBlock(t *testing.T) {
+	src := `resource "my_thing" { }`
+	f := parseString(t, src)
+	if len(f.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(f.Blocks))
+	}
+	b := f.Blocks[0]
+	if b.Type != "resource" {
+		t.Errorf("expected type %q, got %q", "resource", b.Type)
+	}
+	if b.Label != "my_thing" {
+		t.Errorf("expected label %q, got %q", "my_thing", b.Label)
+	}
+}
+
+func TestParseUnlabeledBlock(t *testing.T) {
+	src := `defaults { }`
+	f := parseString(t, src)
+	if len(f.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(f.Blocks))
+	}
+	b := f.Blocks[0]
+	if b.Type != "defaults" {
+		t.Errorf("expected type %q, got %q", "defaults", b.Type)
+	}
+	if b.Label != "" {
+		t.Errorf("expected empty label, got %q", b.Label)
+	}
+}
+
+func TestParseMultipleAttributesMixedTypes(t *testing.T) {
+	src := `resource "db" {
+  host = "localhost"
+  port = 5432
+  weight = 1.5
+  primary = true
+  readonly = false
+}`
+	f := parseString(t, src)
+	if len(f.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(f.Blocks))
+	}
+	attrs := f.Blocks[0].Attributes
+	if len(attrs) != 5 {
+		t.Fatalf("expected 5 attributes, got %d", len(attrs))
+	}
+
+	tests := []struct {
+		key      string
+		wantType string
+		wantVal  interface{}
+	}{
+		{"host", "*dcl.LiteralString", "localhost"},
+		{"port", "*dcl.LiteralInt", int64(5432)},
+		{"weight", "*dcl.LiteralFloat", 1.5},
+		{"primary", "*dcl.LiteralBool", true},
+		{"readonly", "*dcl.LiteralBool", false},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			a := attrs[i]
+			if a.Key != tt.key {
+				t.Errorf("expected key %q, got %q", tt.key, a.Key)
+			}
+			switch v := a.Value.(type) {
+			case *LiteralString:
+				if tt.wantVal != v.Value {
+					t.Errorf("expected %v, got %v", tt.wantVal, v.Value)
+				}
+			case *LiteralInt:
+				if tt.wantVal != v.Value {
+					t.Errorf("expected %v, got %v", tt.wantVal, v.Value)
+				}
+			case *LiteralFloat:
+				if tt.wantVal != v.Value {
+					t.Errorf("expected %v, got %v", tt.wantVal, v.Value)
+				}
+			case *LiteralBool:
+				if tt.wantVal != v.Value {
+					t.Errorf("expected %v, got %v", tt.wantVal, v.Value)
+				}
+			default:
+				t.Errorf("unexpected expression type %T", a.Value)
+			}
+		})
+	}
+}
+
+func TestParseCommentsIgnored(t *testing.T) {
+	src := `# before block
+resource "db" {
+  # inside block
+  host = "localhost"
+}
+# after block`
+	f := parseString(t, src)
+	if len(f.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(f.Blocks))
+	}
+	if len(f.Blocks[0].Attributes) != 1 {
+		t.Errorf("expected 1 attribute, got %d", len(f.Blocks[0].Attributes))
+	}
+}
+
+func TestParseErrorMissingValueAfterEquals(t *testing.T) {
+	src := `resource "db" {
+  host =
+}`
+	_, diags := Parse("test.dcl", []byte(src))
+	if !diags.HasErrors() {
+		t.Fatal("expected errors, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if d.Severity == SeverityError {
+			found = true
+			if !containsSubstring(d.Message, "expected value") {
+				t.Errorf("expected diagnostic to mention 'expected value', got %q", d.Message)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected at least one error diagnostic")
+	}
+}
+
+func TestParseErrorTopLevelAttribute(t *testing.T) {
+	tests := []struct {
+		name       string
+		src        string
+		wantBlocks int
+	}{
+		{
+			name:       "only attribute",
+			src:        `host = "x"`,
+			wantBlocks: 0,
+		},
+		{
+			name: "attribute then block",
+			src: `host = "x"
+resource "db" { }`,
+			wantBlocks: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, diags := Parse("test.dcl", []byte(tt.src))
+			if !diags.HasErrors() {
+				t.Fatal("expected errors, got none")
+			}
+			found := false
+			for _, d := range diags {
+				if containsSubstring(d.Message, "top level") {
+					found = true
+				}
+			}
+			if !found {
+				t.Error("expected diagnostic about top-level attribute")
+			}
+			if len(f.Blocks) != tt.wantBlocks {
+				t.Errorf("expected %d blocks, got %d", tt.wantBlocks, len(f.Blocks))
+			}
+		})
+	}
+}
+
+func TestParsePositionAccuracy(t *testing.T) {
+	src := "resource \"db\" {\n  host = \"localhost\"\n}"
+	f := parseString(t, src)
+
+	// File range: starts at 1:1, ends at EOF.
+	if f.Rng.Start.Line != 1 || f.Rng.Start.Column != 1 {
+		t.Errorf("file start: expected 1:1, got %d:%d", f.Rng.Start.Line, f.Rng.Start.Column)
+	}
+
+	if len(f.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(f.Blocks))
+	}
+	b := f.Blocks[0]
+
+	// Block range: starts at 1:1 ("resource"), ends after "}" on line 3.
+	if b.Rng.Start.Line != 1 || b.Rng.Start.Column != 1 {
+		t.Errorf("block start: expected 1:1, got %d:%d", b.Rng.Start.Line, b.Rng.Start.Column)
+	}
+	if b.Rng.End.Line != 3 || b.Rng.End.Column != 2 {
+		t.Errorf("block end: expected 3:2, got %d:%d", b.Rng.End.Line, b.Rng.End.Column)
+	}
+
+	if len(b.Attributes) != 1 {
+		t.Fatalf("expected 1 attribute, got %d", len(b.Attributes))
+	}
+	a := b.Attributes[0]
+
+	// Attribute starts at line 2, col 3 ("host").
+	if a.Rng.Start.Line != 2 || a.Rng.Start.Column != 3 {
+		t.Errorf("attr start: expected 2:3, got %d:%d", a.Rng.Start.Line, a.Rng.Start.Column)
+	}
+
+	// Attribute value is "localhost" — string literal starts at col 10 (the opening quote).
+	lit, ok := a.Value.(*LiteralString)
+	if !ok {
+		t.Fatalf("expected *LiteralString, got %T", a.Value)
+	}
+	if lit.Rng.Start.Line != 2 || lit.Rng.Start.Column != 10 {
+		t.Errorf("literal start: expected 2:10, got %d:%d", lit.Rng.Start.Line, lit.Rng.Start.Column)
+	}
+	// "localhost" is 9 chars + 2 quotes = 11, so end col = 10 + 11 = 21
+	if lit.Rng.End.Line != 2 || lit.Rng.End.Column != 21 {
+		t.Errorf("literal end: expected 2:21, got %d:%d", lit.Rng.End.Line, lit.Rng.End.Column)
+	}
+}
+
+func TestParseMultipleBlocks(t *testing.T) {
+	src := `resource "db" {
+  host = "localhost"
+}
+
+resource "cache" {
+  host = "redis"
+}`
+	f := parseString(t, src)
+	if len(f.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(f.Blocks))
+	}
+	if f.Blocks[0].Label != "db" {
+		t.Errorf("block 0: expected label %q, got %q", "db", f.Blocks[0].Label)
+	}
+	if f.Blocks[1].Label != "cache" {
+		t.Errorf("block 1: expected label %q, got %q", "cache", f.Blocks[1].Label)
+	}
+}
+
+func TestParseErrorRecovery(t *testing.T) {
+	src := `resource "db" {
+  bad =
+  host = "localhost"
+}`
+	f, diags := Parse("test.dcl", []byte(src))
+	if !diags.HasErrors() {
+		t.Fatal("expected errors, got none")
+	}
+
+	errorCount := 0
+	for _, d := range diags {
+		if d.Severity == SeverityError {
+			errorCount++
+		}
+	}
+	if errorCount != 1 {
+		t.Errorf("expected 1 error, got %d", errorCount)
+	}
+
+	if len(f.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(f.Blocks))
+	}
+	attrs := f.Blocks[0].Attributes
+	if len(attrs) != 1 {
+		t.Fatalf("expected 1 attribute after recovery, got %d", len(attrs))
+	}
+	if attrs[0].Key != "host" {
+		t.Errorf("expected recovered attr key %q, got %q", "host", attrs[0].Key)
+	}
+}
+
+func TestParseEmptyBlock(t *testing.T) {
+	src := `defaults {
+  # just a comment
+
+
+}`
+	f := parseString(t, src)
+	if len(f.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(f.Blocks))
+	}
+	if len(f.Blocks[0].Attributes) != 0 {
+		t.Errorf("expected 0 attributes, got %d", len(f.Blocks[0].Attributes))
+	}
+}
+
+// containsSubstring checks if s contains substr.
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func searchSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Adds a recursive-descent parser (`dcl/parser.go`) that converts tokens into an AST, supporting top-level blocks (labeled and unlabeled) and simple literal attributes (string, int, float, bool)
- Implements two-token lookahead, comment skipping, error recovery (`recoverToNextStatement`, `recoverToBlockEnd`), and merged lexer+parser diagnostics
- Adds 11 test functions (15 subtests) covering empty files, labeled/unlabeled blocks, mixed attribute types, comments, position accuracy, multiple blocks, error recovery, and error diagnostics

## Test Plan
- [x] `go build ./...` passes
- [x] `go vet ./dcl/...` passes
- [x] `go test ./dcl/ -v -run TestParse` — all 11 tests pass

Closes #6