### PR TITLE
Implement list and map expression parsing (#7)

### DIFF
--- a/dcl/parser.go
+++ b/dcl/parser.go
@@ -127,6 +127,25 @@ func (p *parser) recoverToBlockEnd() {
 	}
 }
 
+// recoverToListEnd skips tokens until the matching closing bracket (tracking depth).
+func (p *parser) recoverToListEnd() {
+	depth := 1
+	for depth > 0 && p.cur.Type != TokenEOF {
+		if p.cur.Type == TokenLBracket {
+			depth++
+		} else if p.cur.Type == TokenRBracket {
+			depth--
+		}
+		if depth > 0 {
+			p.nextToken()
+		}
+	}
+	// Consume the closing bracket if present.
+	if p.cur.Type == TokenRBracket {
+		p.nextToken()
+	}
+}
+
 // --- parsing methods ---
 
 // parseFile parses the top-level structure: a sequence of blocks.
@@ -306,8 +325,113 @@ func (p *parser) parseExpression() (Expression, bool) {
 			Rng:   Range{Start: tok.Pos, End: tokenEnd(tok)},
 		}, true
 
+	case TokenLBracket:
+		return p.parseList()
+
+	case TokenLBrace:
+		return p.parseMap()
+
 	default:
 		p.addError(tok.Pos, fmt.Sprintf("expected value, got %s", tok.Type))
 		return nil, false
 	}
+}
+
+// parseList parses: [ elem, elem, ... ]
+func (p *parser) parseList() (Expression, bool) {
+	lbracket := p.cur
+	p.nextToken() // consume '['
+	p.skipNewlines()
+
+	var elems []Expression
+
+	for p.cur.Type != TokenRBracket && p.cur.Type != TokenRBrace && p.cur.Type != TokenEOF {
+		expr, ok := p.parseExpression()
+		if !ok {
+			p.recoverToListEnd()
+			return nil, false
+		}
+		elems = append(elems, expr)
+
+		p.skipNewlines()
+		if p.cur.Type == TokenComma {
+			p.nextToken() // consume ','
+			p.skipNewlines()
+			if p.cur.Type == TokenRBracket {
+				break // trailing comma
+			}
+		}
+	}
+
+	rbracket, ok := p.expect(TokenRBracket)
+	if !ok {
+		p.recoverToListEnd()
+		return nil, false
+	}
+
+	return &ListExpr{
+		Elements: elems,
+		Rng:      Range{Start: lbracket.Pos, End: tokenEnd(rbracket)},
+	}, true
+}
+
+// parseMap parses: { key = value, key = value, ... }
+func (p *parser) parseMap() (Expression, bool) {
+	lbrace := p.cur
+	p.nextToken() // consume '{'
+	p.skipNewlines()
+
+	var keys []string
+	var values []Expression
+
+	for p.cur.Type != TokenRBrace && p.cur.Type != TokenEOF {
+		if !p.parseMapEntry(&keys, &values) {
+			p.recoverToBlockEnd()
+			return nil, false
+		}
+
+		p.skipNewlines()
+		if p.cur.Type == TokenComma {
+			p.nextToken() // consume ','
+			p.skipNewlines()
+			if p.cur.Type == TokenRBrace {
+				break // trailing comma
+			}
+		}
+	}
+
+	rbrace, ok := p.expect(TokenRBrace)
+	if !ok {
+		p.recoverToBlockEnd()
+		return nil, false
+	}
+
+	return &MapExpr{
+		Keys:   keys,
+		Values: values,
+		Rng:    Range{Start: lbrace.Pos, End: tokenEnd(rbrace)},
+	}, true
+}
+
+// parseMapEntry parses a single: ident = expr
+func (p *parser) parseMapEntry(keys *[]string, values *[]Expression) bool {
+	if p.cur.Type != TokenIdent {
+		p.addError(p.cur.Pos, fmt.Sprintf("expected map key (identifier), got %s", p.cur.Type))
+		return false
+	}
+	key := p.cur.Literal
+	p.nextToken() // consume key
+
+	if _, ok := p.expect(TokenEquals); !ok {
+		return false
+	}
+
+	val, ok := p.parseExpression()
+	if !ok {
+		return false
+	}
+
+	*keys = append(*keys, key)
+	*values = append(*values, val)
+	return true
 }

--- a/dcl/parser_test.go
+++ b/dcl/parser_test.go
@@ -312,6 +312,239 @@ func TestParseEmptyBlock(t *testing.T) {
 	}
 }
 
+func TestParseListSimple(t *testing.T) {
+	src := `resource "app" {
+  tags = ["a", "b", "c"]
+}`
+	f := parseString(t, src)
+	if len(f.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(f.Blocks))
+	}
+	attrs := f.Blocks[0].Attributes
+	if len(attrs) != 1 {
+		t.Fatalf("expected 1 attribute, got %d", len(attrs))
+	}
+	list, ok := attrs[0].Value.(*ListExpr)
+	if !ok {
+		t.Fatalf("expected *ListExpr, got %T", attrs[0].Value)
+	}
+	if len(list.Elements) != 3 {
+		t.Fatalf("expected 3 elements, got %d", len(list.Elements))
+	}
+	for i, want := range []string{"a", "b", "c"} {
+		lit, ok := list.Elements[i].(*LiteralString)
+		if !ok {
+			t.Errorf("element %d: expected *LiteralString, got %T", i, list.Elements[i])
+			continue
+		}
+		if lit.Value != want {
+			t.Errorf("element %d: expected %q, got %q", i, want, lit.Value)
+		}
+	}
+}
+
+func TestParseListEmpty(t *testing.T) {
+	src := `resource "app" {
+  tags = []
+}`
+	f := parseString(t, src)
+	attrs := f.Blocks[0].Attributes
+	list, ok := attrs[0].Value.(*ListExpr)
+	if !ok {
+		t.Fatalf("expected *ListExpr, got %T", attrs[0].Value)
+	}
+	if len(list.Elements) != 0 {
+		t.Errorf("expected 0 elements, got %d", len(list.Elements))
+	}
+}
+
+func TestParseListTrailingComma(t *testing.T) {
+	src := `resource "app" {
+  ports = [8080, 8443,]
+}`
+	f := parseString(t, src)
+	attrs := f.Blocks[0].Attributes
+	list, ok := attrs[0].Value.(*ListExpr)
+	if !ok {
+		t.Fatalf("expected *ListExpr, got %T", attrs[0].Value)
+	}
+	if len(list.Elements) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(list.Elements))
+	}
+	for i, want := range []int64{8080, 8443} {
+		lit, ok := list.Elements[i].(*LiteralInt)
+		if !ok {
+			t.Errorf("element %d: expected *LiteralInt, got %T", i, list.Elements[i])
+			continue
+		}
+		if lit.Value != want {
+			t.Errorf("element %d: expected %d, got %d", i, want, lit.Value)
+		}
+	}
+}
+
+func TestParseListMultiline(t *testing.T) {
+	src := "resource \"app\" {\n  ports = [\n    8080,\n    8443\n  ]\n}"
+	f := parseString(t, src)
+	attrs := f.Blocks[0].Attributes
+	list, ok := attrs[0].Value.(*ListExpr)
+	if !ok {
+		t.Fatalf("expected *ListExpr, got %T", attrs[0].Value)
+	}
+	if len(list.Elements) != 2 {
+		t.Errorf("expected 2 elements, got %d", len(list.Elements))
+	}
+}
+
+func TestParseMapSimple(t *testing.T) {
+	src := `resource "app" {
+  labels = { env = "prod", tier = "web" }
+}`
+	f := parseString(t, src)
+	attrs := f.Blocks[0].Attributes
+	m, ok := attrs[0].Value.(*MapExpr)
+	if !ok {
+		t.Fatalf("expected *MapExpr, got %T", attrs[0].Value)
+	}
+	if len(m.Keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(m.Keys))
+	}
+	wantKeys := []string{"env", "tier"}
+	wantVals := []string{"prod", "web"}
+	for i := range wantKeys {
+		if m.Keys[i] != wantKeys[i] {
+			t.Errorf("key %d: expected %q, got %q", i, wantKeys[i], m.Keys[i])
+		}
+		lit, ok := m.Values[i].(*LiteralString)
+		if !ok {
+			t.Errorf("value %d: expected *LiteralString, got %T", i, m.Values[i])
+			continue
+		}
+		if lit.Value != wantVals[i] {
+			t.Errorf("value %d: expected %q, got %q", i, wantVals[i], lit.Value)
+		}
+	}
+}
+
+func TestParseMapEmpty(t *testing.T) {
+	src := `resource "app" {
+  meta = {}
+}`
+	f := parseString(t, src)
+	attrs := f.Blocks[0].Attributes
+	m, ok := attrs[0].Value.(*MapExpr)
+	if !ok {
+		t.Fatalf("expected *MapExpr, got %T", attrs[0].Value)
+	}
+	if len(m.Keys) != 0 {
+		t.Errorf("expected 0 keys, got %d", len(m.Keys))
+	}
+}
+
+func TestParseMapMultilineTrailingComma(t *testing.T) {
+	src := "resource \"app\" {\n  labels = {\n    env = \"prod\",\n    tier = \"web\",\n  }\n}"
+	f := parseString(t, src)
+	attrs := f.Blocks[0].Attributes
+	m, ok := attrs[0].Value.(*MapExpr)
+	if !ok {
+		t.Fatalf("expected *MapExpr, got %T", attrs[0].Value)
+	}
+	if len(m.Keys) != 2 {
+		t.Errorf("expected 2 keys, got %d", len(m.Keys))
+	}
+}
+
+func TestParseNestedListOfMaps(t *testing.T) {
+	src := "resource \"app\" {\n  servers = [{ host = \"a\" }, { host = \"b\" }]\n}"
+	f := parseString(t, src)
+	attrs := f.Blocks[0].Attributes
+	list, ok := attrs[0].Value.(*ListExpr)
+	if !ok {
+		t.Fatalf("expected *ListExpr, got %T", attrs[0].Value)
+	}
+	if len(list.Elements) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(list.Elements))
+	}
+	for i, want := range []string{"a", "b"} {
+		m, ok := list.Elements[i].(*MapExpr)
+		if !ok {
+			t.Errorf("element %d: expected *MapExpr, got %T", i, list.Elements[i])
+			continue
+		}
+		if len(m.Keys) != 1 || m.Keys[0] != "host" {
+			t.Errorf("element %d: expected key 'host', got %v", i, m.Keys)
+			continue
+		}
+		lit, ok := m.Values[0].(*LiteralString)
+		if !ok {
+			t.Errorf("element %d: expected *LiteralString value, got %T", i, m.Values[0])
+			continue
+		}
+		if lit.Value != want {
+			t.Errorf("element %d: expected value %q, got %q", i, want, lit.Value)
+		}
+	}
+}
+
+func TestParseNestedMapOfLists(t *testing.T) {
+	src := "resource \"app\" {\n  config = { ports = [80], hosts = [\"a\"] }\n}"
+	f := parseString(t, src)
+	attrs := f.Blocks[0].Attributes
+	m, ok := attrs[0].Value.(*MapExpr)
+	if !ok {
+		t.Fatalf("expected *MapExpr, got %T", attrs[0].Value)
+	}
+	if len(m.Keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(m.Keys))
+	}
+	for i, key := range []string{"ports", "hosts"} {
+		if m.Keys[i] != key {
+			t.Errorf("key %d: expected %q, got %q", i, key, m.Keys[i])
+		}
+		if _, ok := m.Values[i].(*ListExpr); !ok {
+			t.Errorf("value %d: expected *ListExpr, got %T", i, m.Values[i])
+		}
+	}
+}
+
+func TestParseListUnterminated(t *testing.T) {
+	src := `resource "app" {
+  tags = ["a", "b"
+}`
+	_, diags := Parse("test.dcl", []byte(src))
+	if !diags.HasErrors() {
+		t.Fatal("expected errors, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if d.Severity == SeverityError && containsSubstring(d.Message, "RBracket") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected diagnostic mentioning RBracket, got: %s", diags.Error())
+	}
+}
+
+func TestParseMapMissingEquals(t *testing.T) {
+	src := `resource "app" {
+  labels = { foo "bar" }
+}`
+	_, diags := Parse("test.dcl", []byte(src))
+	if !diags.HasErrors() {
+		t.Fatal("expected errors, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if d.Severity == SeverityError && containsSubstring(d.Message, "Equals") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected diagnostic mentioning Equals, got: %s", diags.Error())
+	}
+}
+
 // containsSubstring checks if s contains substr.
 func containsSubstring(s, substr string) bool {
 	return len(s) >= len(substr) && searchSubstring(s, substr)


### PR DESCRIPTION
## Summary
- Extend `parseExpression()` with `TokenLBracket` → `parseList()` and `TokenLBrace` → `parseMap()` cases
- Add `parseList()`, `parseMap()`, `parseMapEntry()` methods supporting empty collections, trailing commas, multiline syntax, and arbitrary nesting
- Add `recoverToListEnd()` bracket-depth recovery helper
- Add 11 new test functions covering simple/empty/trailing-comma/multiline lists and maps, nested list-of-maps, nested map-of-lists, and two error cases

## Test Plan
- [x] `go build ./...` passes
- [x] `go test ./dcl/ -v -run "TestParse"` — all 22 tests pass (11 existing + 11 new)
- [x] `go test ./dcl/ -race` — no races detected
- [x] `go vet ./dcl/...` — clean

Closes #7