### PR TITLE
Implement multi-file loading for DCL parser

### DIFF
--- a/dcl/loader.go
+++ b/dcl/loader.go
@@ -1,2 +1,97 @@
 // loader.go implements single-file and recursive directory loading of .dcl files.
 package dcl
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// LoadFile reads a single file from disk and parses it.
+// On read failure, returns an empty *File with a single error diagnostic.
+func LoadFile(path string) (*File, Diagnostics) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		diag := Diagnostic{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("failed to read file: %s", err),
+		}
+		return &File{}, Diagnostics{diag}
+	}
+	return Parse(path, src)
+}
+
+// collectDCLFiles recursively collects all .dcl file paths under dir,
+// returning them sorted by full path.
+func collectDCLFiles(dir string) ([]string, error) {
+	var paths []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && filepath.Ext(path) == ".dcl" {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+// mergeFiles concatenates blocks and diagnostics from multiple parsed files
+// into a single *File with a zero-value Range.
+func mergeFiles(files []*File) *File {
+	merged := &File{}
+	for _, f := range files {
+		merged.Blocks = append(merged.Blocks, f.Blocks...)
+		merged.Diagnostics.Append(f.Diagnostics)
+	}
+	return merged
+}
+
+// LoadDirectory discovers all .dcl files under dir (recursively),
+// parses each one, and merges the results into a single *File.
+func LoadDirectory(dir string) (*File, Diagnostics) {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		msg := fmt.Sprintf("path is not a directory: %s", dir)
+		if err != nil {
+			msg = fmt.Sprintf("failed to access directory: %s", err)
+		}
+		diag := Diagnostic{
+			Severity: SeverityError,
+			Message:  msg,
+		}
+		return &File{}, Diagnostics{diag}
+	}
+
+	paths, err := collectDCLFiles(dir)
+	if err != nil {
+		diag := Diagnostic{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("failed to walk directory: %s", err),
+		}
+		return &File{}, Diagnostics{diag}
+	}
+
+	if len(paths) == 0 {
+		diag := Diagnostic{
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("no .dcl files found in %s", dir),
+		}
+		return &File{}, Diagnostics{diag}
+	}
+
+	files := make([]*File, 0, len(paths))
+	for _, p := range paths {
+		f, _ := LoadFile(p)
+		files = append(files, f)
+	}
+
+	merged := mergeFiles(files)
+	return merged, merged.Diagnostics
+}

--- a/dcl/loader_test.go
+++ b/dcl/loader_test.go
@@ -1,0 +1,213 @@
+package dcl
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeDCLFile writes content to dir/name and returns the full path.
+func writeDCLFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// --- LoadFile tests ---
+
+func TestLoadFile_Simple(t *testing.T) {
+	dir := t.TempDir()
+	path := writeDCLFile(t, dir, "main.dcl", `resource "db" { host = "localhost" }`)
+
+	f, diags := LoadFile(path)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Error())
+	}
+	if len(f.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(f.Blocks))
+	}
+	if f.Blocks[0].Rng.Start.Filename != path {
+		t.Errorf("expected filename %q, got %q", path, f.Blocks[0].Rng.Start.Filename)
+	}
+}
+
+func TestLoadFile_NonexistentPath(t *testing.T) {
+	f, diags := LoadFile("/nonexistent/path/file.dcl")
+	if !diags.HasErrors() {
+		t.Fatal("expected errors for nonexistent path")
+	}
+	if len(f.Blocks) != 0 {
+		t.Fatalf("expected 0 blocks, got %d", len(f.Blocks))
+	}
+	if got := diags[0].Message; !strings.Contains(got, "/nonexistent/path/file.dcl") {
+		t.Errorf("expected message to contain path, got: %s", got)
+	}
+}
+
+func TestLoadFile_ParseErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := writeDCLFile(t, dir, "bad.dcl", `resource "db" { host = }`)
+
+	f, diags := LoadFile(path)
+	if !diags.HasErrors() {
+		t.Fatal("expected parse errors")
+	}
+	if f == nil {
+		t.Fatal("expected non-nil File")
+	}
+	for _, d := range diags {
+		if d.Range.Start.Filename != "" && d.Range.Start.Filename != path {
+			t.Errorf("expected filename %q on diagnostic, got %q", path, d.Range.Start.Filename)
+		}
+	}
+}
+
+// --- LoadDirectory tests ---
+
+func TestLoadDirectory_TwoFilesMerged(t *testing.T) {
+	dir := t.TempDir()
+	writeDCLFile(t, dir, "a.dcl", `resource "alpha" { name = "a" }`)
+	writeDCLFile(t, dir, "b.dcl", `resource "beta" { name = "b" }`)
+
+	f, diags := LoadDirectory(dir)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Error())
+	}
+	if len(f.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(f.Blocks))
+	}
+	if f.Blocks[0].Type != "resource" || f.Blocks[0].Label != "alpha" {
+		t.Errorf("expected first block to be alpha, got %s %s", f.Blocks[0].Type, f.Blocks[0].Label)
+	}
+	if f.Blocks[1].Type != "resource" || f.Blocks[1].Label != "beta" {
+		t.Errorf("expected second block to be beta, got %s %s", f.Blocks[1].Type, f.Blocks[1].Label)
+	}
+}
+
+func TestLoadDirectory_SingleFile(t *testing.T) {
+	dir := t.TempDir()
+	writeDCLFile(t, dir, "only.dcl", `resource "solo" { id = 1 }`)
+
+	f, diags := LoadDirectory(dir)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Error())
+	}
+	if len(f.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(f.Blocks))
+	}
+}
+
+func TestLoadDirectory_RecursiveSubdirs(t *testing.T) {
+	dir := t.TempDir()
+	writeDCLFile(t, dir, "a.dcl", `resource "top" { level = "root" }`)
+	writeDCLFile(t, dir, "sub/b.dcl", `resource "nested" { level = "sub" }`)
+
+	f, diags := LoadDirectory(dir)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Error())
+	}
+	if len(f.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(f.Blocks))
+	}
+	if f.Blocks[0].Label != "top" {
+		t.Errorf("expected first block label 'top', got %q", f.Blocks[0].Label)
+	}
+	if f.Blocks[1].Label != "nested" {
+		t.Errorf("expected second block label 'nested', got %q", f.Blocks[1].Label)
+	}
+}
+
+func TestLoadDirectory_LexicographicOrder(t *testing.T) {
+	dir := t.TempDir()
+	writeDCLFile(t, dir, "z.dcl", `resource "zulu" { order = 3 }`)
+	writeDCLFile(t, dir, "a.dcl", `resource "alpha" { order = 1 }`)
+	writeDCLFile(t, dir, "m/b.dcl", `resource "mid" { order = 2 }`)
+
+	f, diags := LoadDirectory(dir)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Error())
+	}
+	if len(f.Blocks) != 3 {
+		t.Fatalf("expected 3 blocks, got %d", len(f.Blocks))
+	}
+	// Sorted by full path: a.dcl, m/b.dcl, z.dcl
+	expected := []string{"alpha", "mid", "zulu"}
+	for i, want := range expected {
+		if f.Blocks[i].Label != want {
+			t.Errorf("block[%d]: expected label %q, got %q", i, want, f.Blocks[i].Label)
+		}
+	}
+}
+
+func TestLoadDirectory_NoDCLFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeDCLFile(t, dir, "readme.txt", "not a dcl file")
+
+	f, diags := LoadDirectory(dir)
+	if !diags.HasErrors() {
+		t.Fatal("expected error for no .dcl files")
+	}
+	if len(f.Blocks) != 0 {
+		t.Fatalf("expected 0 blocks, got %d", len(f.Blocks))
+	}
+	if got := diags[0].Message; !strings.Contains(got, "no .dcl files") {
+		t.Errorf("expected 'no .dcl files' in message, got: %s", got)
+	}
+}
+
+func TestLoadDirectory_NonexistentPath(t *testing.T) {
+	f, diags := LoadDirectory("/nonexistent/dir/path")
+	if !diags.HasErrors() {
+		t.Fatal("expected errors for nonexistent path")
+	}
+	if len(f.Blocks) != 0 {
+		t.Fatalf("expected 0 blocks, got %d", len(f.Blocks))
+	}
+}
+
+func TestLoadDirectory_MixedValidAndErrored(t *testing.T) {
+	dir := t.TempDir()
+	writeDCLFile(t, dir, "good.dcl", `resource "ok" { status = "fine" }`)
+	writeDCLFile(t, dir, "bad.dcl", `resource "broken" { status = }`)
+
+	f, diags := LoadDirectory(dir)
+	if !diags.HasErrors() {
+		t.Fatal("expected errors from broken file")
+	}
+	foundOk := false
+	for _, b := range f.Blocks {
+		if b.Label == "ok" {
+			foundOk = true
+		}
+	}
+	if !foundOk {
+		t.Error("expected block from good.dcl to be present")
+	}
+}
+
+func TestLoadDirectory_FilenameOnNodes(t *testing.T) {
+	dir := t.TempDir()
+	pathA := writeDCLFile(t, dir, "first.dcl", `resource "one" { x = 1 }`)
+	pathB := writeDCLFile(t, dir, "second.dcl", `resource "two" { y = 2 }`)
+
+	f, diags := LoadDirectory(dir)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected errors: %s", diags.Error())
+	}
+	if len(f.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(f.Blocks))
+	}
+	if f.Blocks[0].Rng.Start.Filename != pathA {
+		t.Errorf("block[0]: expected filename %q, got %q", pathA, f.Blocks[0].Rng.Start.Filename)
+	}
+	if f.Blocks[1].Rng.Start.Filename != pathB {
+		t.Errorf("block[1]: expected filename %q, got %q", pathB, f.Blocks[1].Rng.Start.Filename)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `LoadFile` (single-file read + parse) and `LoadDirectory` (recursive `.dcl` discovery, parse, merge) to the `dcl` package
- Implements `collectDCLFiles` helper using `filepath.WalkDir` with deterministic full-path sorting
- Implements `mergeFiles` helper that concatenates blocks/diagnostics into a single `*File` with zero-value `Range`
- Errors are accumulated (not fail-fast), consistent with the error recovery philosophy from #11

## Test plan
- [x] `TestLoadFile_Simple` — single file parses with correct `Pos.Filename`
- [x] `TestLoadFile_NonexistentPath` — returns error diagnostic containing the path
- [x] `TestLoadFile_ParseErrors` — partial results with correct filename on diagnostics
- [x] `TestLoadDirectory_TwoFilesMerged` — two files produce 2 blocks in correct order
- [x] `TestLoadDirectory_SingleFile` — single file in directory
- [x] `TestLoadDirectory_RecursiveSubdirs` — discovers files in subdirectories
- [x] `TestLoadDirectory_LexicographicOrder` — blocks ordered by sorted full path
- [x] `TestLoadDirectory_NoDCLFiles` — error when no `.dcl` files found
- [x] `TestLoadDirectory_NonexistentPath` — error for missing directory
- [x] `TestLoadDirectory_MixedValidAndErrored` — valid blocks preserved alongside error diagnostics
- [x] `TestLoadDirectory_FilenameOnNodes` — each block's `Pos.Filename` matches its source file
- [x] `go vet ./dcl/` — clean
- [x] Full test suite passes with no regressions

Closes #12