### PR TITLE
Implement Resource and ResourceID types for provider package (#28)

### DIFF
--- a/provider/resource.go
+++ b/provider/resource.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"github.com/MathewBravo/datastorectl/dcl"
+)
+
+// ResourceID uniquely identifies a resource by its provider type and name.
+type ResourceID struct {
+	Type string // provider resource type, e.g. "opensearch_ism_policy"
+	Name string // resource name, e.g. "hot_warm_delete"
+}
+
+// String returns the resource identifier as "Type.Name".
+func (id ResourceID) String() string {
+	return id.Type + "." + id.Name
+}
+
+// Resource represents a DCL resource flowing through the engine pipeline
+// (parse → plan → apply). Live-state resources fetched from providers
+// will have a zero-value SourceRange.
+type Resource struct {
+	ID          ResourceID
+	Body        *OrderedMap
+	SourceRange dcl.Range
+}

--- a/provider/resource_test.go
+++ b/provider/resource_test.go
@@ -1,0 +1,81 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+)
+
+func TestResourceIDString(t *testing.T) {
+	tests := []struct {
+		name string
+		id   ResourceID
+		want string
+	}{
+		{
+			name: "standard",
+			id:   ResourceID{Type: "opensearch_ism_policy", Name: "hot_warm_delete"},
+			want: "opensearch_ism_policy.hot_warm_delete",
+		},
+		{
+			name: "empty type",
+			id:   ResourceID{Type: "", Name: "hot_warm_delete"},
+			want: ".hot_warm_delete",
+		},
+		{
+			name: "empty name",
+			id:   ResourceID{Type: "opensearch_ism_policy", Name: ""},
+			want: "opensearch_ism_policy.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.id.String()
+			if got != tt.want {
+				t.Errorf("ResourceID.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceZeroSourceRange(t *testing.T) {
+	r := Resource{
+		ID:   ResourceID{Type: "s3_bucket", Name: "logs"},
+		Body: NewOrderedMap(),
+	}
+	zero := dcl.Range{}
+	if r.SourceRange != zero {
+		t.Errorf("expected zero-value SourceRange, got %v", r.SourceRange)
+	}
+}
+
+func TestResourceBody(t *testing.T) {
+	body := NewOrderedMap()
+	body.Set("policy_id", StringVal("hot_warm_delete"))
+	body.Set("min_index_age", IntVal(30))
+
+	r := Resource{
+		ID:   ResourceID{Type: "opensearch_ism_policy", Name: "hot_warm_delete"},
+		Body: body,
+	}
+
+	v, ok := r.Body.Get("policy_id")
+	if !ok {
+		t.Fatal("expected key policy_id to exist")
+	}
+	if v.Str != "hot_warm_delete" {
+		t.Errorf("policy_id = %q, want %q", v.Str, "hot_warm_delete")
+	}
+
+	v, ok = r.Body.Get("min_index_age")
+	if !ok {
+		t.Fatal("expected key min_index_age to exist")
+	}
+	if v.Int != 30 {
+		t.Errorf("min_index_age = %d, want 30", v.Int)
+	}
+
+	if r.Body.Len() != 2 {
+		t.Errorf("Body.Len() = %d, want 2", r.Body.Len())
+	}
+}


### PR DESCRIPTION
Closes #28

## Summary
- Add `ResourceID` struct (Type + Name) with `String()` method returning `"Type.Name"`
- Add `Resource` struct pairing a `ResourceID` with an `*OrderedMap` body and `dcl.Range` source location
- Table-driven tests covering `ResourceID.String()`, zero-value `SourceRange`, and `Body` access

## Test plan
- [x] `go build ./...` — clean compilation
- [x] `go test ./provider/... -v` — all new + existing tests pass
- [x] `go test ./... -v` — full suite passes
- [x] `go vet ./provider/...` — no warnings