### PR TITLE
Implement Provider interface and Operation type (#29)

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+)
+
+// Operation describes the kind of mutation to apply to a resource.
+type Operation int
+
+const (
+	OpCreate Operation = iota
+	OpUpdate
+	OpDelete
+)
+
+func (op Operation) String() string {
+	switch op {
+	case OpCreate:
+		return "create"
+	case OpUpdate:
+		return "update"
+	case OpDelete:
+		return "delete"
+	default:
+		return fmt.Sprintf("Operation(%d)", int(op))
+	}
+}
+
+// Provider is the contract that every provider implementation must satisfy.
+// The engine calls Configure → Discover → Normalize → Validate → Apply
+// to manage infrastructure resources.
+type Provider interface {
+	Configure(ctx context.Context, config *OrderedMap) dcl.Diagnostics
+	Discover(ctx context.Context) ([]Resource, dcl.Diagnostics)
+	Normalize(ctx context.Context, r Resource) (Resource, dcl.Diagnostics)
+	Validate(ctx context.Context, r Resource) dcl.Diagnostics
+	Apply(ctx context.Context, op Operation, r Resource) dcl.Diagnostics
+}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1,0 +1,46 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Compile-time check that Operation implements fmt.Stringer.
+var _ fmt.Stringer = Operation(0)
+
+func TestOperationString(t *testing.T) {
+	tests := []struct {
+		op   Operation
+		want string
+	}{
+		{OpCreate, "create"},
+		{OpUpdate, "update"},
+		{OpDelete, "delete"},
+		{Operation(99), "Operation(99)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.op.String(); got != tt.want {
+				t.Errorf("Operation(%d).String() = %q, want %q", int(tt.op), got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOperationConstants(t *testing.T) {
+	tests := []struct {
+		op   Operation
+		want int
+	}{
+		{OpCreate, 0},
+		{OpUpdate, 1},
+		{OpDelete, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.op.String(), func(t *testing.T) {
+			if got := int(tt.op); got != tt.want {
+				t.Errorf("int(%s) = %d, want %d", tt.op, got, tt.want)
+			}
+		})
+	}
+}

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"github.com/MathewBravo/datastorectl/dcl"
+)
+
+// ResourceID uniquely identifies a resource by its provider type and name.
+type ResourceID struct {
+	Type string // provider resource type, e.g. "opensearch_ism_policy"
+	Name string // resource name, e.g. "hot_warm_delete"
+}
+
+// String returns the resource identifier as "Type.Name".
+func (id ResourceID) String() string {
+	return id.Type + "." + id.Name
+}
+
+// Resource represents a DCL resource flowing through the engine pipeline
+// (parse → plan → apply). Live-state resources fetched from providers
+// will have a zero-value SourceRange.
+type Resource struct {
+	ID          ResourceID
+	Body        *OrderedMap
+	SourceRange dcl.Range
+}

--- a/provider/resource_test.go
+++ b/provider/resource_test.go
@@ -1,0 +1,81 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+)
+
+func TestResourceIDString(t *testing.T) {
+	tests := []struct {
+		name string
+		id   ResourceID
+		want string
+	}{
+		{
+			name: "standard",
+			id:   ResourceID{Type: "opensearch_ism_policy", Name: "hot_warm_delete"},
+			want: "opensearch_ism_policy.hot_warm_delete",
+		},
+		{
+			name: "empty type",
+			id:   ResourceID{Type: "", Name: "hot_warm_delete"},
+			want: ".hot_warm_delete",
+		},
+		{
+			name: "empty name",
+			id:   ResourceID{Type: "opensearch_ism_policy", Name: ""},
+			want: "opensearch_ism_policy.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.id.String()
+			if got != tt.want {
+				t.Errorf("ResourceID.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceZeroSourceRange(t *testing.T) {
+	r := Resource{
+		ID:   ResourceID{Type: "s3_bucket", Name: "logs"},
+		Body: NewOrderedMap(),
+	}
+	zero := dcl.Range{}
+	if r.SourceRange != zero {
+		t.Errorf("expected zero-value SourceRange, got %v", r.SourceRange)
+	}
+}
+
+func TestResourceBody(t *testing.T) {
+	body := NewOrderedMap()
+	body.Set("policy_id", StringVal("hot_warm_delete"))
+	body.Set("min_index_age", IntVal(30))
+
+	r := Resource{
+		ID:   ResourceID{Type: "opensearch_ism_policy", Name: "hot_warm_delete"},
+		Body: body,
+	}
+
+	v, ok := r.Body.Get("policy_id")
+	if !ok {
+		t.Fatal("expected key policy_id to exist")
+	}
+	if v.Str != "hot_warm_delete" {
+		t.Errorf("policy_id = %q, want %q", v.Str, "hot_warm_delete")
+	}
+
+	v, ok = r.Body.Get("min_index_age")
+	if !ok {
+		t.Fatal("expected key min_index_age to exist")
+	}
+	if v.Int != 30 {
+		t.Errorf("min_index_age = %d, want 30", v.Int)
+	}
+
+	if r.Body.Len() != 2 {
+		t.Errorf("Body.Len() = %d, want 2", r.Body.Len())
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ResourceID` and `Resource` types for the provider package (#28)
- Add `Operation` enum (`OpCreate`, `OpUpdate`, `OpDelete`) with `String()` method following the `dcl.Severity` iota pattern
- Define `Provider` interface with the 5-method engine contract: `Configure`, `Discover`, `Normalize`, `Validate`, `Apply`
- All methods accept `context.Context` (providers make network calls) and return `dcl.Diagnostics`

## Test Plan
- [x] `TestOperationString` — verifies all three ops plus unknown value formatting
- [x] `TestOperationConstants` — guards against iota drift (OpCreate=0, OpUpdate=1, OpDelete=2)
- [x] Compile-time `fmt.Stringer` interface check
- [x] `go build ./...` — clean
- [x] `go test ./... -v` — all pass
- [x] `go vet ./provider/...` — no warnings