### PR TITLE
Implement reference extractor for engine pipeline (#35)

### DIFF
--- a/engine/refs.go
+++ b/engine/refs.go
@@ -1,0 +1,44 @@
+package engine
+
+import "github.com/MathewBravo/datastorectl/provider"
+
+// ExtractReferences walks a resource body and returns the ResourceID
+// of every cross-resource reference it contains.
+func ExtractReferences(r provider.Resource) []provider.ResourceID {
+	out := []provider.ResourceID{}
+	if r.Body == nil {
+		return out
+	}
+	for _, key := range r.Body.Keys() {
+		v, _ := r.Body.Get(key)
+		collectRefs(v, &out)
+	}
+	return out
+}
+
+// collectRefs recursively walks a Value tree, appending any
+// KindReference targets to out.
+func collectRefs(v provider.Value, out *[]provider.ResourceID) {
+	switch v.Kind {
+	case provider.KindReference:
+		if len(v.Ref) >= 2 {
+			*out = append(*out, provider.ResourceID{
+				Type: v.Ref[0],
+				Name: v.Ref[1],
+			})
+		}
+	case provider.KindList:
+		for _, elem := range v.List {
+			collectRefs(elem, out)
+		}
+	case provider.KindMap:
+		for _, key := range v.Map.Keys() {
+			val, _ := v.Map.Get(key)
+			collectRefs(val, out)
+		}
+	case provider.KindFunctionCall:
+		for _, arg := range v.FuncArgs {
+			collectRefs(arg, out)
+		}
+	}
+}

--- a/engine/refs_test.go
+++ b/engine/refs_test.go
@@ -1,0 +1,211 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+func TestExtractReferences_Basic(t *testing.T) {
+	t.Run("no_references", func(t *testing.T) {
+		body := provider.NewOrderedMap()
+		body.Set("name", provider.StringVal("mydb"))
+		body.Set("port", provider.IntVal(5432))
+
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "postgres", Name: "main"},
+			Body: body,
+		}
+		refs := ExtractReferences(r)
+		if len(refs) != 0 {
+			t.Fatalf("expected 0 refs, got %d", len(refs))
+		}
+	})
+
+	t.Run("single_reference", func(t *testing.T) {
+		body := provider.NewOrderedMap()
+		body.Set("host", provider.RefVal([]string{"db", "host"}))
+
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "app", Name: "web"},
+			Body: body,
+		}
+		refs := ExtractReferences(r)
+		if len(refs) != 1 {
+			t.Fatalf("expected 1 ref, got %d", len(refs))
+		}
+		if refs[0].Type != "db" || refs[0].Name != "host" {
+			t.Fatalf("expected {db host}, got %+v", refs[0])
+		}
+	})
+
+	t.Run("multiple_references", func(t *testing.T) {
+		body := provider.NewOrderedMap()
+		body.Set("host", provider.RefVal([]string{"db", "host"}))
+		body.Set("port", provider.RefVal([]string{"db", "port"}))
+
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "app", Name: "web"},
+			Body: body,
+		}
+		refs := ExtractReferences(r)
+		if len(refs) != 2 {
+			t.Fatalf("expected 2 refs, got %d", len(refs))
+		}
+		if refs[0].Type != "db" || refs[0].Name != "host" {
+			t.Fatalf("expected {db host} at [0], got %+v", refs[0])
+		}
+		if refs[1].Type != "db" || refs[1].Name != "port" {
+			t.Fatalf("expected {db port} at [1], got %+v", refs[1])
+		}
+	})
+
+	t.Run("nil_body", func(t *testing.T) {
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "app", Name: "web"},
+			Body: nil,
+		}
+		refs := ExtractReferences(r)
+		if refs == nil {
+			t.Fatal("expected non-nil empty slice, got nil")
+		}
+		if len(refs) != 0 {
+			t.Fatalf("expected 0 refs, got %d", len(refs))
+		}
+	})
+}
+
+func TestExtractReferences_Nested(t *testing.T) {
+	t.Run("ref_in_list", func(t *testing.T) {
+		body := provider.NewOrderedMap()
+		body.Set("items", provider.ListVal([]provider.Value{
+			provider.StringVal("literal"),
+			provider.RefVal([]string{"cache", "endpoint"}),
+			provider.IntVal(42),
+		}))
+
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "app", Name: "web"},
+			Body: body,
+		}
+		refs := ExtractReferences(r)
+		if len(refs) != 1 {
+			t.Fatalf("expected 1 ref, got %d", len(refs))
+		}
+		if refs[0].Type != "cache" || refs[0].Name != "endpoint" {
+			t.Fatalf("expected {cache endpoint}, got %+v", refs[0])
+		}
+	})
+
+	t.Run("ref_in_nested_map", func(t *testing.T) {
+		inner := provider.NewOrderedMap()
+		inner.Set("url", provider.RefVal([]string{"db", "url"}))
+
+		outer := provider.NewOrderedMap()
+		outer.Set("conn", provider.MapVal(inner))
+
+		body := provider.NewOrderedMap()
+		body.Set("config", provider.MapVal(outer))
+
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "app", Name: "web"},
+			Body: body,
+		}
+		refs := ExtractReferences(r)
+		if len(refs) != 1 {
+			t.Fatalf("expected 1 ref, got %d", len(refs))
+		}
+		if refs[0].Type != "db" || refs[0].Name != "url" {
+			t.Fatalf("expected {db url}, got %+v", refs[0])
+		}
+	})
+
+	t.Run("ref_in_function_arg", func(t *testing.T) {
+		body := provider.NewOrderedMap()
+		body.Set("password", provider.FuncCallVal("secret", []provider.Value{
+			provider.RefVal([]string{"vault", "db_pass"}),
+		}))
+
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "app", Name: "web"},
+			Body: body,
+		}
+		refs := ExtractReferences(r)
+		if len(refs) != 1 {
+			t.Fatalf("expected 1 ref, got %d", len(refs))
+		}
+		if refs[0].Type != "vault" || refs[0].Name != "db_pass" {
+			t.Fatalf("expected {vault db_pass}, got %+v", refs[0])
+		}
+	})
+
+	t.Run("mixed_nesting", func(t *testing.T) {
+		inner := provider.NewOrderedMap()
+		inner.Set("addr", provider.RefVal([]string{"db", "addr"}))
+
+		body := provider.NewOrderedMap()
+		body.Set("backends", provider.ListVal([]provider.Value{
+			provider.MapVal(inner),
+			provider.RefVal([]string{"cache", "endpoint"}),
+		}))
+
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "lb", Name: "main"},
+			Body: body,
+		}
+		refs := ExtractReferences(r)
+		if len(refs) != 2 {
+			t.Fatalf("expected 2 refs, got %d", len(refs))
+		}
+		if refs[0].Type != "db" || refs[0].Name != "addr" {
+			t.Fatalf("expected {db addr} at [0], got %+v", refs[0])
+		}
+		if refs[1].Type != "cache" || refs[1].Name != "endpoint" {
+			t.Fatalf("expected {cache endpoint} at [1], got %+v", refs[1])
+		}
+	})
+}
+
+func TestExtractReferences_EdgeCases(t *testing.T) {
+	t.Run("duplicate_refs_preserved", func(t *testing.T) {
+		body := provider.NewOrderedMap()
+		body.Set("a", provider.RefVal([]string{"db", "host"}))
+		body.Set("b", provider.RefVal([]string{"db", "host"}))
+
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "app", Name: "web"},
+			Body: body,
+		}
+		refs := ExtractReferences(r)
+		if len(refs) != 2 {
+			t.Fatalf("expected 2 refs (duplicates preserved), got %d", len(refs))
+		}
+	})
+
+	t.Run("short_ref_skipped", func(t *testing.T) {
+		body := provider.NewOrderedMap()
+		body.Set("bad", provider.RefVal([]string{"onlyonepart"}))
+
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "app", Name: "web"},
+			Body: body,
+		}
+		refs := ExtractReferences(r)
+		if len(refs) != 0 {
+			t.Fatalf("expected 0 refs (short ref skipped), got %d", len(refs))
+		}
+	})
+
+	t.Run("empty_body", func(t *testing.T) {
+		body := provider.NewOrderedMap()
+
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "app", Name: "web"},
+			Body: body,
+		}
+		refs := ExtractReferences(r)
+		if len(refs) != 0 {
+			t.Fatalf("expected 0 refs, got %d", len(refs))
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add `ExtractReferences` function that walks a `provider.Resource` body and collects every `KindReference` placeholder as a `provider.ResourceID`
- Recursive `collectRefs` helper handles all container kinds: lists, maps, and function call args
- Defensive: nil/empty bodies return `[]provider.ResourceID{}`, malformed refs (< 2 parts) are skipped, duplicates are preserved

## Design
- Uses `OrderedMap` public API (`Keys()` + `Get()`) for cross-package iteration
- No deduplication — callers (e.g. dependency graph) decide how to handle duplicates
- Follows the recursive switch-on-Kind pattern from `engine/convert.go`

## Tests
11 subtests across 3 groups covering basic extraction, nested structures (lists, maps, function args, mixed), and edge cases (duplicates, short refs, empty/nil bodies).

## Dependencies
Depends on #34 (file-to-ResourceSet converter). Prerequisite for #36 (reference resolver).

Closes #35