### PR TITLE
Implement value differ for map types

### DIFF
--- a/engine/diff.go
+++ b/engine/diff.go
@@ -54,6 +54,48 @@ func DiffValues(path string, old, new provider.Value) []ValueDiff {
 		return []ValueDiff{{Kind: DiffRemoved, Path: path, Old: old}}
 	}
 
+	// Structural map diffing.
+	if old.Kind == provider.KindMap && new.Kind == provider.KindMap {
+		return diffMaps(path, old.Map, new.Map)
+	}
+
 	// Both non-null, not equal → modified (scalar fallback).
 	return []ValueDiff{{Kind: DiffModified, Path: path, Old: old, New: new}}
+}
+
+// diffMaps produces per-key leaf-level diffs between two ordered maps.
+// Diffs are emitted in old-map key order (removals and modifications),
+// then new-map key order (additions).
+func diffMaps(path string, old, new *provider.OrderedMap) []ValueDiff {
+	var diffs []ValueDiff
+
+	// Walk old keys: detect removals and recurse into modifications.
+	for _, key := range old.Keys() {
+		childPath := path + "." + key
+		if path == "" {
+			childPath = key
+		}
+		oldVal, _ := old.Get(key)
+		newVal, found := new.Get(key)
+		if !found {
+			diffs = append(diffs, ValueDiff{Kind: DiffRemoved, Path: childPath, Old: oldVal})
+			continue
+		}
+		diffs = append(diffs, DiffValues(childPath, oldVal, newVal)...)
+	}
+
+	// Walk new keys: detect additions (keys already in old were handled above).
+	for _, key := range new.Keys() {
+		if _, found := old.Get(key); found {
+			continue
+		}
+		childPath := path + "." + key
+		if path == "" {
+			childPath = key
+		}
+		newVal, _ := new.Get(key)
+		diffs = append(diffs, ValueDiff{Kind: DiffAdded, Path: childPath, New: newVal})
+	}
+
+	return diffs
 }

--- a/engine/diff_test.go
+++ b/engine/diff_test.go
@@ -154,6 +154,158 @@ func TestDiffValues_ComplexFallback(t *testing.T) {
 		if diffs[0].Kind != DiffModified {
 			t.Fatalf("expected DiffModified, got %s", diffs[0].Kind)
 		}
+		if diffs[0].Path != "config.a" {
+			t.Fatalf("expected path %q, got %q", "config.a", diffs[0].Path)
+		}
+	})
+}
+
+func TestDiffValues_Maps(t *testing.T) {
+	t.Run("key_added", func(t *testing.T) {
+		old := makeMapVal("a", provider.IntVal(1))
+		nm := provider.NewOrderedMap()
+		nm.Set("a", provider.IntVal(1))
+		nm.Set("b", provider.IntVal(2))
+		new := provider.MapVal(nm)
+		diffs := DiffValues("root", old, new)
+		if len(diffs) != 1 {
+			t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
+		}
+		if diffs[0].Kind != DiffAdded || diffs[0].Path != "root.b" {
+			t.Fatalf("expected DiffAdded at root.b, got %s at %q", diffs[0].Kind, diffs[0].Path)
+		}
+	})
+
+	t.Run("key_removed", func(t *testing.T) {
+		om := provider.NewOrderedMap()
+		om.Set("a", provider.IntVal(1))
+		om.Set("b", provider.IntVal(2))
+		old := provider.MapVal(om)
+		new := makeMapVal("a", provider.IntVal(1))
+		diffs := DiffValues("root", old, new)
+		if len(diffs) != 1 {
+			t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
+		}
+		if diffs[0].Kind != DiffRemoved || diffs[0].Path != "root.b" {
+			t.Fatalf("expected DiffRemoved at root.b, got %s at %q", diffs[0].Kind, diffs[0].Path)
+		}
+	})
+
+	t.Run("value_modified", func(t *testing.T) {
+		old := makeMapVal("a", provider.IntVal(1))
+		new := makeMapVal("a", provider.IntVal(2))
+		diffs := DiffValues("root", old, new)
+		if len(diffs) != 1 {
+			t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
+		}
+		if diffs[0].Kind != DiffModified || diffs[0].Path != "root.a" {
+			t.Fatalf("expected DiffModified at root.a, got %s at %q", diffs[0].Kind, diffs[0].Path)
+		}
+	})
+
+	t.Run("multiple_changes", func(t *testing.T) {
+		om := provider.NewOrderedMap()
+		om.Set("a", provider.IntVal(1))
+		om.Set("b", provider.IntVal(2))
+		old := provider.MapVal(om)
+
+		nm := provider.NewOrderedMap()
+		nm.Set("a", provider.IntVal(3))
+		nm.Set("c", provider.IntVal(4))
+		new := provider.MapVal(nm)
+
+		diffs := DiffValues("root", old, new)
+		if len(diffs) != 3 {
+			t.Fatalf("expected 3 diffs, got %d: %v", len(diffs), diffs)
+		}
+		// Old key order first: modified a, removed b.
+		if diffs[0].Kind != DiffModified || diffs[0].Path != "root.a" {
+			t.Fatalf("diffs[0]: expected DiffModified at root.a, got %s at %q", diffs[0].Kind, diffs[0].Path)
+		}
+		if diffs[1].Kind != DiffRemoved || diffs[1].Path != "root.b" {
+			t.Fatalf("diffs[1]: expected DiffRemoved at root.b, got %s at %q", diffs[1].Kind, diffs[1].Path)
+		}
+		// Then new key order: added c.
+		if diffs[2].Kind != DiffAdded || diffs[2].Path != "root.c" {
+			t.Fatalf("diffs[2]: expected DiffAdded at root.c, got %s at %q", diffs[2].Kind, diffs[2].Path)
+		}
+	})
+
+	t.Run("nested_map", func(t *testing.T) {
+		old := makeMapVal("m", makeMapVal("x", provider.IntVal(1)))
+		new := makeMapVal("m", makeMapVal("x", provider.IntVal(2)))
+		diffs := DiffValues("root", old, new)
+		if len(diffs) != 1 {
+			t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
+		}
+		if diffs[0].Kind != DiffModified || diffs[0].Path != "root.m.x" {
+			t.Fatalf("expected DiffModified at root.m.x, got %s at %q", diffs[0].Kind, diffs[0].Path)
+		}
+	})
+
+	t.Run("nested_map_key_added", func(t *testing.T) {
+		old := makeMapVal("m", makeMapVal("x", provider.IntVal(1)))
+
+		inner := provider.NewOrderedMap()
+		inner.Set("x", provider.IntVal(1))
+		inner.Set("y", provider.IntVal(2))
+		new := makeMapVal("m", provider.MapVal(inner))
+
+		diffs := DiffValues("root", old, new)
+		if len(diffs) != 1 {
+			t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
+		}
+		if diffs[0].Kind != DiffAdded || diffs[0].Path != "root.m.y" {
+			t.Fatalf("expected DiffAdded at root.m.y, got %s at %q", diffs[0].Kind, diffs[0].Path)
+		}
+	})
+
+	t.Run("empty_to_populated", func(t *testing.T) {
+		old := provider.MapVal(provider.NewOrderedMap())
+		new := makeMapVal("a", provider.IntVal(1))
+		diffs := DiffValues("root", old, new)
+		if len(diffs) != 1 {
+			t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
+		}
+		if diffs[0].Kind != DiffAdded || diffs[0].Path != "root.a" {
+			t.Fatalf("expected DiffAdded at root.a, got %s at %q", diffs[0].Kind, diffs[0].Path)
+		}
+	})
+
+	t.Run("populated_to_empty", func(t *testing.T) {
+		old := makeMapVal("a", provider.IntVal(1))
+		new := provider.MapVal(provider.NewOrderedMap())
+		diffs := DiffValues("root", old, new)
+		if len(diffs) != 1 {
+			t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
+		}
+		if diffs[0].Kind != DiffRemoved || diffs[0].Path != "root.a" {
+			t.Fatalf("expected DiffRemoved at root.a, got %s at %q", diffs[0].Kind, diffs[0].Path)
+		}
+	})
+
+	t.Run("both_empty", func(t *testing.T) {
+		old := provider.MapVal(provider.NewOrderedMap())
+		new := provider.MapVal(provider.NewOrderedMap())
+		diffs := DiffValues("root", old, new)
+		if len(diffs) != 0 {
+			t.Fatalf("expected 0 diffs, got %d: %v", len(diffs), diffs)
+		}
+	})
+
+	t.Run("map_to_non_map", func(t *testing.T) {
+		old := makeMapVal("a", provider.IntVal(1))
+		new := provider.StringVal("not a map")
+		diffs := DiffValues("root", old, new)
+		if len(diffs) != 1 {
+			t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
+		}
+		if diffs[0].Kind != DiffModified {
+			t.Fatalf("expected DiffModified, got %s", diffs[0].Kind)
+		}
+		if diffs[0].Path != "root" {
+			t.Fatalf("expected path %q, got %q", "root", diffs[0].Path)
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add `diffMaps` function that walks the union of keys from both old and new `OrderedMap` values to produce per-key leaf-level diffs (added, removed, modified)
- Insert map dispatch branch in `DiffValues` between null checks and scalar fallback — only fires when both sides are `KindMap`; type changes (e.g. map→string) still fall through to scalar `DiffModified`
- Add `TestDiffValues_Maps` with 10 subtests covering key added/removed/modified, multiple changes, nested maps, empty maps, and map-to-non-map type change

## Test plan
- [x] `go build ./...` — clean
- [x] `go test -race ./engine/... -v` — all new + existing tests pass, no data races
- [x] `go test ./... -v` — full suite passes
- [x] `go vet ./engine/...` — no warnings

Closes #42