### PR TITLE
Implement Plan and ResourceChange types (#45)

### DIFF
--- a/engine/plan.go
+++ b/engine/plan.go
@@ -1,0 +1,87 @@
+package engine
+
+import (
+	"fmt"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// ChangeType classifies what action a resource change represents.
+type ChangeType int
+
+const (
+	ChangeNoOp   ChangeType = iota // resource is unchanged
+	ChangeCreate                   // resource exists in desired but not live
+	ChangeUpdate                   // resource exists in both but differs
+	ChangeDelete                   // resource exists in live but not desired
+)
+
+func (c ChangeType) String() string {
+	switch c {
+	case ChangeNoOp:
+		return "no-op"
+	case ChangeCreate:
+		return "create"
+	case ChangeUpdate:
+		return "update"
+	case ChangeDelete:
+		return "delete"
+	default:
+		return fmt.Sprintf("ChangeType(%d)", int(c))
+	}
+}
+
+// ResourceChange describes a single planned change to a resource.
+type ResourceChange struct {
+	ID      provider.ResourceID
+	Type    ChangeType
+	Desired *provider.Resource // nil for deletes
+	Live    *provider.Resource // nil for creates
+	Diff    ResourceDiff
+}
+
+// Plan holds the full set of resource changes the engine intends to apply.
+type Plan struct {
+	Changes []ResourceChange
+}
+
+// HasChanges reports whether the plan contains any non-no-op changes.
+func (p Plan) HasChanges() bool {
+	for _, c := range p.Changes {
+		if c.Type != ChangeNoOp {
+			return true
+		}
+	}
+	return false
+}
+
+// Creates returns all changes with type ChangeCreate.
+func (p Plan) Creates() []ResourceChange {
+	return p.filterByType(ChangeCreate)
+}
+
+// Updates returns all changes with type ChangeUpdate.
+func (p Plan) Updates() []ResourceChange {
+	return p.filterByType(ChangeUpdate)
+}
+
+// Deletes returns all changes with type ChangeDelete.
+func (p Plan) Deletes() []ResourceChange {
+	return p.filterByType(ChangeDelete)
+}
+
+func (p Plan) filterByType(t ChangeType) []ResourceChange {
+	var out []ResourceChange
+	for _, c := range p.Changes {
+		if c.Type == t {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// Summary returns a human-readable summary of the plan.
+func (p Plan) Summary() string {
+	creates, updates, deletes := len(p.Creates()), len(p.Updates()), len(p.Deletes())
+	return fmt.Sprintf("Plan: %d to create, %d to update, %d to delete", creates, updates, deletes)
+}

--- a/engine/plan_test.go
+++ b/engine/plan_test.go
@@ -1,0 +1,179 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+func TestChangeType_String(t *testing.T) {
+	tests := []struct {
+		ct   ChangeType
+		want string
+	}{
+		{ChangeNoOp, "no-op"},
+		{ChangeCreate, "create"},
+		{ChangeUpdate, "update"},
+		{ChangeDelete, "delete"},
+		{ChangeType(99), "ChangeType(99)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.ct.String(); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestPlan_HasChanges(t *testing.T) {
+	t.Run("empty_plan", func(t *testing.T) {
+		p := Plan{}
+		if p.HasChanges() {
+			t.Fatal("expected no changes for empty plan")
+		}
+	})
+
+	t.Run("only_no_ops", func(t *testing.T) {
+		p := Plan{Changes: []ResourceChange{
+			{Type: ChangeNoOp},
+			{Type: ChangeNoOp},
+		}}
+		if p.HasChanges() {
+			t.Fatal("expected no changes for no-op only plan")
+		}
+	})
+
+	t.Run("has_create", func(t *testing.T) {
+		p := Plan{Changes: []ResourceChange{
+			{Type: ChangeNoOp},
+			{Type: ChangeCreate},
+		}}
+		if !p.HasChanges() {
+			t.Fatal("expected changes when plan has a create")
+		}
+	})
+
+	t.Run("has_update", func(t *testing.T) {
+		p := Plan{Changes: []ResourceChange{{Type: ChangeUpdate}}}
+		if !p.HasChanges() {
+			t.Fatal("expected changes when plan has an update")
+		}
+	})
+
+	t.Run("has_delete", func(t *testing.T) {
+		p := Plan{Changes: []ResourceChange{{Type: ChangeDelete}}}
+		if !p.HasChanges() {
+			t.Fatal("expected changes when plan has a delete")
+		}
+	})
+}
+
+func TestPlan_Filters(t *testing.T) {
+	rid := func(typ, name string) provider.ResourceID {
+		return provider.ResourceID{Type: typ, Name: name}
+	}
+
+	p := Plan{Changes: []ResourceChange{
+		{ID: rid("a", "1"), Type: ChangeCreate},
+		{ID: rid("a", "2"), Type: ChangeUpdate},
+		{ID: rid("a", "3"), Type: ChangeDelete},
+		{ID: rid("a", "4"), Type: ChangeNoOp},
+		{ID: rid("b", "1"), Type: ChangeCreate},
+		{ID: rid("b", "2"), Type: ChangeUpdate},
+	}}
+
+	t.Run("creates", func(t *testing.T) {
+		got := p.Creates()
+		if len(got) != 2 {
+			t.Fatalf("expected 2 creates, got %d", len(got))
+		}
+		if got[0].ID.Name != "1" || got[1].ID.Name != "1" {
+			t.Fatalf("unexpected creates: %v", got)
+		}
+	})
+
+	t.Run("updates", func(t *testing.T) {
+		got := p.Updates()
+		if len(got) != 2 {
+			t.Fatalf("expected 2 updates, got %d", len(got))
+		}
+	})
+
+	t.Run("deletes", func(t *testing.T) {
+		got := p.Deletes()
+		if len(got) != 1 {
+			t.Fatalf("expected 1 delete, got %d", len(got))
+		}
+		if got[0].ID != rid("a", "3") {
+			t.Fatalf("expected a.3, got %s", got[0].ID)
+		}
+	})
+
+	t.Run("empty_filter", func(t *testing.T) {
+		empty := Plan{}
+		if got := empty.Creates(); got != nil {
+			t.Fatalf("expected nil creates, got %v", got)
+		}
+	})
+}
+
+func TestPlan_Summary(t *testing.T) {
+	t.Run("mixed_changes", func(t *testing.T) {
+		p := Plan{Changes: []ResourceChange{
+			{Type: ChangeCreate},
+			{Type: ChangeCreate},
+			{Type: ChangeUpdate},
+			{Type: ChangeDelete},
+			{Type: ChangeNoOp},
+		}}
+		want := "Plan: 2 to create, 1 to update, 1 to delete"
+		if got := p.Summary(); got != want {
+			t.Fatalf("expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("no_changes", func(t *testing.T) {
+		p := Plan{}
+		want := "Plan: 0 to create, 0 to update, 0 to delete"
+		if got := p.Summary(); got != want {
+			t.Fatalf("expected %q, got %q", want, got)
+		}
+	})
+}
+
+func TestResourceChange_Fields(t *testing.T) {
+	body := provider.NewOrderedMap()
+	body.Set("a", provider.IntVal(1))
+	desired := provider.Resource{
+		ID:   provider.ResourceID{Type: "r", Name: "x"},
+		Body: body,
+	}
+	diff := ResourceDiff{
+		ID:    desired.ID,
+		Diffs: []ValueDiff{{Kind: DiffAdded, Path: "a"}},
+	}
+	rc := ResourceChange{
+		ID:      desired.ID,
+		Type:    ChangeCreate,
+		Desired: &desired,
+		Live:    nil,
+		Diff:    diff,
+	}
+
+	if rc.ID.String() != "r.x" {
+		t.Fatalf("expected ID r.x, got %s", rc.ID)
+	}
+	if rc.Type != ChangeCreate {
+		t.Fatalf("expected ChangeCreate, got %s", rc.Type)
+	}
+	if rc.Desired == nil {
+		t.Fatal("expected non-nil Desired")
+	}
+	if rc.Live != nil {
+		t.Fatal("expected nil Live for create")
+	}
+	if len(rc.Diff.Diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(rc.Diff.Diffs))
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ChangeType` enum (`ChangeCreate`, `ChangeUpdate`, `ChangeDelete`, `ChangeNoOp`) with `String()` method
- Add `ResourceChange` struct linking resource ID, change type, desired/live resource pointers, and `ResourceDiff`
- Add `Plan` struct with `HasChanges()`, `Creates()`, `Updates()`, `Deletes()`, and `Summary()` methods
- ~90 lines of implementation, ~170 lines of tests covering all types, filters, edge cases, and summary formatting

## Test plan
- [x] `go build ./...` — clean compilation
- [x] `go test -race ./engine/... -v` — all new + existing tests pass, no data races
- [x] `go test ./...` — full suite passes
- [x] `go vet ./engine/...` — no warnings

Closes #45