### PR TITLE
Implement result types

### DIFF
--- a/engine/result.go
+++ b/engine/result.go
@@ -1,0 +1,88 @@
+package engine
+
+import (
+	"fmt"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// ResultStatus classifies the outcome of applying a resource change.
+type ResultStatus int
+
+const (
+	StatusSuccess ResultStatus = iota
+	StatusFailed
+	StatusSkipped
+)
+
+func (s ResultStatus) String() string {
+	switch s {
+	case StatusSuccess:
+		return "success"
+	case StatusFailed:
+		return "failed"
+	case StatusSkipped:
+		return "skipped"
+	default:
+		return fmt.Sprintf("ResultStatus(%d)", int(s))
+	}
+}
+
+// ResourceResult records the outcome of applying a single resource change.
+type ResourceResult struct {
+	ID         provider.ResourceID
+	Status     ResultStatus
+	Error      error
+	ChangeType ChangeType
+}
+
+// ApplyResult aggregates the results of applying an entire plan.
+type ApplyResult struct {
+	Results []ResourceResult
+}
+
+// HasErrors reports whether any resource failed during apply.
+func (r *ApplyResult) HasErrors() bool {
+	for _, res := range r.Results {
+		if res.Status == StatusFailed {
+			return true
+		}
+	}
+	return false
+}
+
+// Failed returns all results with StatusFailed.
+func (r *ApplyResult) Failed() []ResourceResult {
+	return r.filterByStatus(StatusFailed)
+}
+
+// Skipped returns all results with StatusSkipped.
+func (r *ApplyResult) Skipped() []ResourceResult {
+	return r.filterByStatus(StatusSkipped)
+}
+
+// Summary returns a human-readable summary of apply outcomes.
+func (r *ApplyResult) Summary() string {
+	var succeeded, failed, skipped int
+	for _, res := range r.Results {
+		switch res.Status {
+		case StatusSuccess:
+			succeeded++
+		case StatusFailed:
+			failed++
+		case StatusSkipped:
+			skipped++
+		}
+	}
+	return fmt.Sprintf("Apply complete: %d succeeded, %d failed, %d skipped", succeeded, failed, skipped)
+}
+
+func (r *ApplyResult) filterByStatus(s ResultStatus) []ResourceResult {
+	var out []ResourceResult
+	for _, res := range r.Results {
+		if res.Status == s {
+			out = append(out, res)
+		}
+	}
+	return out
+}

--- a/engine/result_test.go
+++ b/engine/result_test.go
@@ -1,0 +1,169 @@
+package engine
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResultStatus_String(t *testing.T) {
+	tests := []struct {
+		status ResultStatus
+		want   string
+	}{
+		{StatusSuccess, "success"},
+		{StatusFailed, "failed"},
+		{StatusSkipped, "skipped"},
+		{ResultStatus(99), "ResultStatus(99)"},
+	}
+	for _, tt := range tests {
+		if got := tt.status.String(); got != tt.want {
+			t.Errorf("ResultStatus(%d).String() = %q, want %q", int(tt.status), got, tt.want)
+		}
+	}
+}
+
+func TestApplyResult_HasErrors(t *testing.T) {
+	t.Run("no_results", func(t *testing.T) {
+		r := &ApplyResult{}
+		if r.HasErrors() {
+			t.Error("expected no errors for empty result")
+		}
+	})
+
+	t.Run("all_success", func(t *testing.T) {
+		r := &ApplyResult{Results: []ResourceResult{
+			{ID: rid("r", "a"), Status: StatusSuccess, ChangeType: ChangeCreate},
+			{ID: rid("r", "b"), Status: StatusSuccess, ChangeType: ChangeUpdate},
+		}}
+		if r.HasErrors() {
+			t.Error("expected no errors when all succeeded")
+		}
+	})
+
+	t.Run("has_failure", func(t *testing.T) {
+		r := &ApplyResult{Results: []ResourceResult{
+			{ID: rid("r", "a"), Status: StatusSuccess, ChangeType: ChangeCreate},
+			{ID: rid("r", "b"), Status: StatusFailed, Error: errors.New("boom"), ChangeType: ChangeUpdate},
+		}}
+		if !r.HasErrors() {
+			t.Error("expected errors when a resource failed")
+		}
+	})
+
+	t.Run("skipped_is_not_error", func(t *testing.T) {
+		r := &ApplyResult{Results: []ResourceResult{
+			{ID: rid("r", "a"), Status: StatusSkipped, ChangeType: ChangeCreate},
+		}}
+		if r.HasErrors() {
+			t.Error("skipped should not count as error")
+		}
+	})
+}
+
+func TestApplyResult_Failed(t *testing.T) {
+	r := &ApplyResult{Results: []ResourceResult{
+		{ID: rid("r", "a"), Status: StatusSuccess, ChangeType: ChangeCreate},
+		{ID: rid("r", "b"), Status: StatusFailed, Error: errors.New("b failed"), ChangeType: ChangeUpdate},
+		{ID: rid("r", "c"), Status: StatusSkipped, ChangeType: ChangeCreate},
+		{ID: rid("r", "d"), Status: StatusFailed, Error: errors.New("d failed"), ChangeType: ChangeDelete},
+	}}
+
+	failed := r.Failed()
+	if len(failed) != 2 {
+		t.Fatalf("expected 2 failed, got %d", len(failed))
+	}
+	if failed[0].ID != rid("r", "b") {
+		t.Errorf("failed[0]: expected r.b, got %v", failed[0].ID)
+	}
+	if failed[1].ID != rid("r", "d") {
+		t.Errorf("failed[1]: expected r.d, got %v", failed[1].ID)
+	}
+}
+
+func TestApplyResult_Skipped(t *testing.T) {
+	r := &ApplyResult{Results: []ResourceResult{
+		{ID: rid("r", "a"), Status: StatusSuccess, ChangeType: ChangeCreate},
+		{ID: rid("r", "b"), Status: StatusSkipped, ChangeType: ChangeCreate},
+		{ID: rid("r", "c"), Status: StatusFailed, Error: errors.New("fail"), ChangeType: ChangeDelete},
+		{ID: rid("r", "d"), Status: StatusSkipped, ChangeType: ChangeUpdate},
+	}}
+
+	skipped := r.Skipped()
+	if len(skipped) != 2 {
+		t.Fatalf("expected 2 skipped, got %d", len(skipped))
+	}
+	if skipped[0].ID != rid("r", "b") {
+		t.Errorf("skipped[0]: expected r.b, got %v", skipped[0].ID)
+	}
+	if skipped[1].ID != rid("r", "d") {
+		t.Errorf("skipped[1]: expected r.d, got %v", skipped[1].ID)
+	}
+}
+
+func TestApplyResult_Summary(t *testing.T) {
+	t.Run("mixed_results", func(t *testing.T) {
+		r := &ApplyResult{Results: []ResourceResult{
+			{ID: rid("r", "a"), Status: StatusSuccess, ChangeType: ChangeCreate},
+			{ID: rid("r", "b"), Status: StatusSuccess, ChangeType: ChangeUpdate},
+			{ID: rid("r", "c"), Status: StatusFailed, Error: errors.New("fail"), ChangeType: ChangeDelete},
+			{ID: rid("r", "d"), Status: StatusSkipped, ChangeType: ChangeCreate},
+		}}
+		want := "Apply complete: 2 succeeded, 1 failed, 1 skipped"
+		if got := r.Summary(); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty_result", func(t *testing.T) {
+		r := &ApplyResult{}
+		want := "Apply complete: 0 succeeded, 0 failed, 0 skipped"
+		if got := r.Summary(); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("all_success", func(t *testing.T) {
+		r := &ApplyResult{Results: []ResourceResult{
+			{ID: rid("r", "a"), Status: StatusSuccess, ChangeType: ChangeCreate},
+			{ID: rid("r", "b"), Status: StatusSuccess, ChangeType: ChangeCreate},
+			{ID: rid("r", "c"), Status: StatusSuccess, ChangeType: ChangeCreate},
+		}}
+		want := "Apply complete: 3 succeeded, 0 failed, 0 skipped"
+		if got := r.Summary(); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestApplyResult_FilterEdgeCases(t *testing.T) {
+	t.Run("failed_returns_nil_when_none", func(t *testing.T) {
+		r := &ApplyResult{Results: []ResourceResult{
+			{ID: rid("r", "a"), Status: StatusSuccess, ChangeType: ChangeCreate},
+		}}
+		if got := r.Failed(); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("skipped_returns_nil_when_none", func(t *testing.T) {
+		r := &ApplyResult{Results: []ResourceResult{
+			{ID: rid("r", "a"), Status: StatusSuccess, ChangeType: ChangeCreate},
+		}}
+		if got := r.Skipped(); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+}
+
+func TestResourceResult_PreservesError(t *testing.T) {
+	origErr := errors.New("connection refused")
+	res := ResourceResult{
+		ID:         rid("db", "main"),
+		Status:     StatusFailed,
+		Error:      origErr,
+		ChangeType: ChangeCreate,
+	}
+	if !errors.Is(res.Error, origErr) {
+		t.Error("expected original error to be preserved")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ResultStatus` enum (`StatusSuccess`, `StatusFailed`, `StatusSkipped`) with `String()` method
- Adds `ResourceResult` struct recording per-resource apply outcome (ID, status, error, change type)
- Adds `ApplyResult` aggregate with `HasErrors()`, `Failed()`, `Skipped()`, and `Summary()` query methods
- Tests cover all status variants, filtering, edge cases (empty results, nil returns), and error preservation

## Test plan
- [x] `go build ./...` — clean compilation
- [x] `go test -race ./engine/...` — all tests pass, no data races
- [x] `go test ./...` — full suite passes
- [x] `go vet ./engine/...` — no warnings

Closes #48