### PR TITLE
Implement dependency-aware skip tracker

### DIFF
--- a/engine/skip.go
+++ b/engine/skip.go
@@ -1,0 +1,47 @@
+package engine
+
+import "github.com/MathewBravo/datastorectl/provider"
+
+// SkipTracker determines whether a resource should be skipped because one of
+// its transitive dependencies has failed. It wraps an immutable Graph and a
+// set of failed resource IDs.
+type SkipTracker struct {
+	graph  *Graph
+	failed map[provider.ResourceID]struct{}
+}
+
+// NewSkipTracker returns a SkipTracker backed by the given dependency graph.
+// The graph is shared, not copied — it must not be mutated after construction.
+func NewSkipTracker(g *Graph) *SkipTracker {
+	return &SkipTracker{graph: g, failed: make(map[provider.ResourceID]struct{})}
+}
+
+// MarkFailed records id as a failed resource. Idempotent.
+func (s *SkipTracker) MarkFailed(id provider.ResourceID) {
+	s.failed[id] = struct{}{}
+}
+
+// ShouldSkip reports whether id has any transitive dependency that has been
+// marked as failed. A resource that is itself failed but has no failed
+// dependencies returns false — the caller distinguishes failed vs skipped.
+func (s *SkipTracker) ShouldSkip(id provider.ResourceID) bool {
+	queue := s.graph.DependsOn(id)
+	visited := make(map[provider.ResourceID]struct{}, len(queue))
+	for _, dep := range queue {
+		visited[dep] = struct{}{}
+	}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if _, failed := s.failed[current]; failed {
+			return true
+		}
+		for _, dep := range s.graph.DependsOn(current) {
+			if _, seen := visited[dep]; !seen {
+				visited[dep] = struct{}{}
+				queue = append(queue, dep)
+			}
+		}
+	}
+	return false
+}

--- a/engine/skip_test.go
+++ b/engine/skip_test.go
@@ -1,0 +1,171 @@
+package engine
+
+import "testing"
+
+func TestShouldSkip(t *testing.T) {
+	t.Run("no_failures", func(t *testing.T) {
+		// A → B → C, no marks
+		g := NewGraph()
+		a, b, c := rid("x", "a"), rid("x", "b"), rid("x", "c")
+		g.AddEdge(a, b)
+		g.AddEdge(b, c)
+
+		st := NewSkipTracker(g)
+		if st.ShouldSkip(a) {
+			t.Fatal("expected ShouldSkip(A) = false with no failures")
+		}
+	})
+
+	t.Run("direct_dependency_failed", func(t *testing.T) {
+		// A → B, mark B
+		g := NewGraph()
+		a, b := rid("x", "a"), rid("x", "b")
+		g.AddEdge(a, b)
+
+		st := NewSkipTracker(g)
+		st.MarkFailed(b)
+		if !st.ShouldSkip(a) {
+			t.Fatal("expected ShouldSkip(A) = true when direct dep B failed")
+		}
+	})
+
+	t.Run("transitive_dependency_failed", func(t *testing.T) {
+		// A → B → C, mark C
+		g := NewGraph()
+		a, b, c := rid("x", "a"), rid("x", "b"), rid("x", "c")
+		g.AddEdge(a, b)
+		g.AddEdge(b, c)
+
+		st := NewSkipTracker(g)
+		st.MarkFailed(c)
+		if !st.ShouldSkip(a) {
+			t.Fatal("expected ShouldSkip(A) = true when transitive dep C failed")
+		}
+		if !st.ShouldSkip(b) {
+			t.Fatal("expected ShouldSkip(B) = true when direct dep C failed")
+		}
+	})
+
+	t.Run("independent_resource_unaffected", func(t *testing.T) {
+		// A → B, C isolated, mark B
+		g := NewGraph()
+		a, b, c := rid("x", "a"), rid("x", "b"), rid("x", "c")
+		g.AddEdge(a, b)
+		g.AddNode(c)
+
+		st := NewSkipTracker(g)
+		st.MarkFailed(b)
+		if st.ShouldSkip(c) {
+			t.Fatal("expected ShouldSkip(C) = false for independent resource")
+		}
+	})
+
+	t.Run("failed_resource_not_skipped", func(t *testing.T) {
+		// A → B, mark B — B itself is failed, not skipped
+		g := NewGraph()
+		a, b := rid("x", "a"), rid("x", "b")
+		g.AddEdge(a, b)
+
+		st := NewSkipTracker(g)
+		st.MarkFailed(b)
+		if st.ShouldSkip(b) {
+			t.Fatal("expected ShouldSkip(B) = false for the failed resource itself")
+		}
+	})
+
+	t.Run("diamond_all_paths_fail", func(t *testing.T) {
+		// D → B, D → C, B → A, C → A, mark A
+		g := NewGraph()
+		a, b, c, d := rid("x", "a"), rid("x", "b"), rid("x", "c"), rid("x", "d")
+		g.AddEdge(d, b)
+		g.AddEdge(d, c)
+		g.AddEdge(b, a)
+		g.AddEdge(c, a)
+
+		st := NewSkipTracker(g)
+		st.MarkFailed(a)
+		if !st.ShouldSkip(d) {
+			t.Fatal("expected ShouldSkip(D) = true in diamond with A failed")
+		}
+	})
+
+	t.Run("diamond_partial_failure", func(t *testing.T) {
+		// D → B, D → C, mark B
+		g := NewGraph()
+		b, c, d := rid("x", "b"), rid("x", "c"), rid("x", "d")
+		g.AddEdge(d, b)
+		g.AddEdge(d, c)
+
+		st := NewSkipTracker(g)
+		st.MarkFailed(b)
+		if !st.ShouldSkip(d) {
+			t.Fatal("expected ShouldSkip(D) = true when one diamond branch failed")
+		}
+	})
+
+	t.Run("multiple_failures", func(t *testing.T) {
+		// A → B, A → C, mark B and C
+		g := NewGraph()
+		a, b, c := rid("x", "a"), rid("x", "b"), rid("x", "c")
+		g.AddEdge(a, b)
+		g.AddEdge(a, c)
+
+		st := NewSkipTracker(g)
+		st.MarkFailed(b)
+		st.MarkFailed(c)
+		if !st.ShouldSkip(a) {
+			t.Fatal("expected ShouldSkip(A) = true with multiple failed deps")
+		}
+	})
+
+	t.Run("mark_failed_idempotent", func(t *testing.T) {
+		// A → B, mark B twice — no panic, still skipped
+		g := NewGraph()
+		a, b := rid("x", "a"), rid("x", "b")
+		g.AddEdge(a, b)
+
+		st := NewSkipTracker(g)
+		st.MarkFailed(b)
+		st.MarkFailed(b)
+		if !st.ShouldSkip(a) {
+			t.Fatal("expected ShouldSkip(A) = true after idempotent MarkFailed")
+		}
+	})
+
+	t.Run("no_dependencies", func(t *testing.T) {
+		// A isolated, no marks
+		g := NewGraph()
+		a := rid("x", "a")
+		g.AddNode(a)
+
+		st := NewSkipTracker(g)
+		if st.ShouldSkip(a) {
+			t.Fatal("expected ShouldSkip(A) = false for isolated node")
+		}
+	})
+
+	t.Run("long_chain", func(t *testing.T) {
+		// A → B → C → D → E, mark E
+		g := NewGraph()
+		a, b, c, d, e := rid("x", "a"), rid("x", "b"), rid("x", "c"), rid("x", "d"), rid("x", "e")
+		g.AddEdge(a, b)
+		g.AddEdge(b, c)
+		g.AddEdge(c, d)
+		g.AddEdge(d, e)
+
+		st := NewSkipTracker(g)
+		st.MarkFailed(e)
+		if !st.ShouldSkip(a) {
+			t.Fatal("expected ShouldSkip(A) = true in long chain")
+		}
+		if !st.ShouldSkip(b) {
+			t.Fatal("expected ShouldSkip(B) = true in long chain")
+		}
+		if !st.ShouldSkip(c) {
+			t.Fatal("expected ShouldSkip(C) = true in long chain")
+		}
+		if !st.ShouldSkip(d) {
+			t.Fatal("expected ShouldSkip(D) = true in long chain")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `SkipTracker` struct in `engine/skip.go` that wraps the dependency graph and a failed-resource set
- `ShouldSkip(id)` performs BFS over transitive dependencies, returning `true` if any prerequisite has failed (early terminates on first hit)
- Key semantic: a failed resource is "failed", not "skipped" — `ShouldSkip(X)` where X itself failed returns `false`
- 11 subtests covering: no failures, direct/transitive deps, independent resources, diamond graphs, long chains, idempotent marking

Closes #50

## Test plan

- [x] `go build ./...` — clean compilation
- [x] `go test -race ./engine/... -v` — all 11 subtests pass, no data races
- [x] `go test ./...` — full suite passes
- [x] `go vet ./engine/...` — no warnings