### PR TITLE
Implement plan and apply result formatters

### DIFF
--- a/engine/format.go
+++ b/engine/format.go
@@ -1,0 +1,112 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FormatPlan returns a human-readable Terraform-style representation of a plan.
+// No-op changes are omitted. Plain text only — no ANSI color codes.
+func FormatPlan(plan *Plan) string {
+	var blocks []string
+	for _, c := range plan.Changes {
+		switch c.Type {
+		case ChangeCreate:
+			blocks = append(blocks, formatCreate(c))
+		case ChangeUpdate:
+			blocks = append(blocks, formatUpdate(c))
+		case ChangeDelete:
+			blocks = append(blocks, formatDelete(c))
+		}
+	}
+	if len(blocks) == 0 {
+		return "No changes."
+	}
+	return strings.Join(blocks, "\n\n") + "\n"
+}
+
+func formatCreate(c ResourceChange) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "+ %s (create)", c.ID)
+	for _, key := range c.Desired.Body.Keys() {
+		v, _ := c.Desired.Body.Get(key)
+		fmt.Fprintf(&b, "\n    %s: %s", key, v.String())
+	}
+	return b.String()
+}
+
+func formatUpdate(c ResourceChange) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "~ %s (update)", c.ID)
+	for _, d := range c.Diff.Diffs {
+		fmt.Fprintf(&b, "\n    %s: %s", d.Path, formatDiffValue(d))
+	}
+	return b.String()
+}
+
+func formatDelete(c ResourceChange) string {
+	return fmt.Sprintf("- %s (delete)", c.ID)
+}
+
+func formatDiffValue(d ValueDiff) string {
+	switch d.Kind {
+	case DiffModified:
+		return fmt.Sprintf("%s => %s", d.Old.String(), d.New.String())
+	case DiffAdded:
+		return fmt.Sprintf("(added) %s", d.New.String())
+	case DiffRemoved:
+		return fmt.Sprintf("(removed) %s", d.Old.String())
+	default:
+		return ""
+	}
+}
+
+// FormatApplyResult returns a human-readable summary of apply outcomes.
+func FormatApplyResult(result *ApplyResult) string {
+	var b strings.Builder
+	for i, r := range result.Results {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		symbol := applySymbol(r)
+		fmt.Fprintf(&b, "%s %s: %s", symbol, r.ID, applyOutcome(r))
+	}
+	b.WriteByte('\n')
+	b.WriteByte('\n')
+	b.WriteString(result.Summary())
+	return b.String()
+}
+
+func applySymbol(r ResourceResult) string {
+	switch r.Status {
+	case StatusFailed:
+		return "✕"
+	case StatusSkipped:
+		return "↓"
+	default:
+		switch r.ChangeType {
+		case ChangeCreate:
+			return "+"
+		case ChangeUpdate:
+			return "~"
+		case ChangeDelete:
+			return "-"
+		default:
+			return " "
+		}
+	}
+}
+
+func applyOutcome(r ResourceResult) string {
+	switch r.Status {
+	case StatusSuccess:
+		return r.ChangeType.String() + "d"
+	case StatusFailed:
+		return fmt.Sprintf("failed (%s)", r.Error.Error())
+	case StatusSkipped:
+		return "skipped"
+	default:
+		return r.Status.String()
+	}
+}
+

--- a/engine/format_test.go
+++ b/engine/format_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -29,6 +30,164 @@ func TestFormatPlan(t *testing.T) {
 		}
 		if !strings.Contains(got, "    count: 3") {
 			t.Errorf("expected count attr, got:\n%s", got)
+		}
+	})
+
+	t.Run("format_update", func(t *testing.T) {
+		plan := &Plan{
+			Changes: []ResourceChange{
+				{
+					ID:   rid("svc", "a"),
+					Type: ChangeUpdate,
+					Diff: ResourceDiff{
+						ID: rid("svc", "a"),
+						Diffs: []ValueDiff{
+							{Kind: DiffModified, Path: "timeout", Old: provider.StringVal("7d"), New: provider.StringVal("14d")},
+							{Kind: DiffAdded, Path: "retries", New: provider.IntVal(3)},
+							{Kind: DiffRemoved, Path: "legacy", Old: provider.StringVal("old")},
+						},
+					},
+				},
+			},
+		}
+
+		got := FormatPlan(plan)
+
+		if !strings.Contains(got, "~ svc.a (update)") {
+			t.Errorf("expected update header, got:\n%s", got)
+		}
+		if !strings.Contains(got, `    timeout: "7d" => "14d"`) {
+			t.Errorf("expected modified diff, got:\n%s", got)
+		}
+		if !strings.Contains(got, "    retries: (added) 3") {
+			t.Errorf("expected added diff, got:\n%s", got)
+		}
+		if !strings.Contains(got, `    legacy: (removed) "old"`) {
+			t.Errorf("expected removed diff, got:\n%s", got)
+		}
+	})
+
+	t.Run("format_delete", func(t *testing.T) {
+		plan := &Plan{
+			Changes: []ResourceChange{
+				{ID: rid("svc", "a"), Type: ChangeDelete},
+			},
+		}
+
+		got := FormatPlan(plan)
+
+		if !strings.Contains(got, "- svc.a (delete)") {
+			t.Errorf("expected delete header, got:\n%s", got)
+		}
+		// Should not contain indented attributes.
+		lines := strings.Split(got, "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(line, "    ") {
+				t.Errorf("delete should not have body attrs, found: %s", line)
+			}
+		}
+	})
+
+	t.Run("format_no_changes", func(t *testing.T) {
+		plan := &Plan{
+			Changes: []ResourceChange{
+				{ID: rid("svc", "a"), Type: ChangeNoOp},
+			},
+		}
+
+		got := FormatPlan(plan)
+
+		if got != "No changes." {
+			t.Errorf("expected 'No changes.', got: %s", got)
+		}
+	})
+
+	t.Run("format_mixed", func(t *testing.T) {
+		created := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+		created.Body.Set("key", provider.StringVal("val"))
+
+		plan := &Plan{
+			Changes: []ResourceChange{
+				{ID: rid("svc", "a"), Type: ChangeCreate, Desired: created},
+				{
+					ID:   rid("svc", "b"),
+					Type: ChangeUpdate,
+					Diff: ResourceDiff{
+						ID:    rid("svc", "b"),
+						Diffs: []ValueDiff{{Kind: DiffModified, Path: "x", Old: provider.IntVal(1), New: provider.IntVal(2)}},
+					},
+				},
+				{ID: rid("svc", "c"), Type: ChangeDelete},
+				{ID: rid("svc", "d"), Type: ChangeNoOp},
+			},
+		}
+
+		got := FormatPlan(plan)
+
+		if !strings.Contains(got, "+ svc.a (create)") {
+			t.Errorf("expected create block, got:\n%s", got)
+		}
+		if !strings.Contains(got, "~ svc.b (update)") {
+			t.Errorf("expected update block, got:\n%s", got)
+		}
+		if !strings.Contains(got, "- svc.c (delete)") {
+			t.Errorf("expected delete block, got:\n%s", got)
+		}
+		// No-op should not appear.
+		if strings.Contains(got, "svc.d") {
+			t.Errorf("no-op should not appear in output, got:\n%s", got)
+		}
+	})
+}
+
+func TestFormatApplyResult(t *testing.T) {
+	t.Run("format_apply_success", func(t *testing.T) {
+		result := &ApplyResult{
+			Results: []ResourceResult{
+				{ID: rid("svc", "a"), Status: StatusSuccess, ChangeType: ChangeCreate},
+				{ID: rid("svc", "b"), Status: StatusSuccess, ChangeType: ChangeUpdate},
+				{ID: rid("svc", "c"), Status: StatusSuccess, ChangeType: ChangeDelete},
+			},
+		}
+
+		got := FormatApplyResult(result)
+
+		if !strings.Contains(got, "+ svc.a: created") {
+			t.Errorf("expected created line, got:\n%s", got)
+		}
+		if !strings.Contains(got, "~ svc.b: updated") {
+			t.Errorf("expected updated line, got:\n%s", got)
+		}
+		if !strings.Contains(got, "- svc.c: deleted") {
+			t.Errorf("expected deleted line, got:\n%s", got)
+		}
+		if !strings.Contains(got, "Apply complete: 3 succeeded, 0 failed, 0 skipped") {
+			t.Errorf("expected summary line, got:\n%s", got)
+		}
+	})
+
+	t.Run("format_apply_mixed", func(t *testing.T) {
+		result := &ApplyResult{
+			Results: []ResourceResult{
+				{ID: rid("svc", "a"), Status: StatusSuccess, ChangeType: ChangeCreate},
+				{ID: rid("svc", "b"), Status: StatusFailed, ChangeType: ChangeUpdate, Error: fmt.Errorf("connection refused")},
+				{ID: rid("svc", "c"), Status: StatusSkipped, ChangeType: ChangeCreate},
+			},
+		}
+
+		got := FormatApplyResult(result)
+
+		if !strings.Contains(got, "+ svc.a: created") {
+			t.Errorf("expected created line, got:\n%s", got)
+		}
+		if !strings.Contains(got, "✕ svc.b: failed (connection refused)") {
+			t.Errorf("expected failed line with error, got:\n%s", got)
+		}
+		if !strings.Contains(got, "↓ svc.c: skipped") {
+			t.Errorf("expected skipped line, got:\n%s", got)
+		}
+		if !strings.Contains(got, "Apply complete: 1 succeeded, 1 failed, 1 skipped") {
+			t.Errorf("expected summary line, got:\n%s", got)
 		}
 	})
 }

--- a/engine/format_test.go
+++ b/engine/format_test.go
@@ -1,0 +1,34 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+func TestFormatPlan(t *testing.T) {
+	t.Run("format_create", func(t *testing.T) {
+		res := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+		res.Body.Set("name", provider.StringVal("hello"))
+		res.Body.Set("count", provider.IntVal(3))
+
+		plan := &Plan{
+			Changes: []ResourceChange{
+				{ID: rid("svc", "a"), Type: ChangeCreate, Desired: res},
+			},
+		}
+
+		got := FormatPlan(plan)
+
+		if !strings.Contains(got, "+ svc.a (create)") {
+			t.Errorf("expected create header, got:\n%s", got)
+		}
+		if !strings.Contains(got, `    name: "hello"`) {
+			t.Errorf("expected name attr, got:\n%s", got)
+		}
+		if !strings.Contains(got, "    count: 3") {
+			t.Errorf("expected count attr, got:\n%s", got)
+		}
+	})
+}


### PR DESCRIPTION
Closes #53

## Summary
- Add `FormatPlan` for human-readable Terraform-style plan output with `+`/`~`/`-` prefixes
- Add `FormatApplyResult` for post-apply summary with per-resource status and error details
- Plain text only — no ANSI colors (deferred to future `output` package)
- Creates show all body attributes, updates show attr-level diffs (`=>`, `(added)`, `(removed)`), deletes show header only

## Test Plan
- [x] `format_create` — single create with body attributes
- [x] `format_update` — modified/added/removed diffs with correct formatting
- [x] `format_delete` — header only, no body attrs
- [x] `format_no_changes` — returns "No changes."
- [x] `format_mixed` — create + update + delete + no-op, no-op omitted
- [x] `format_apply_success` — correct symbols per change type, summary line
- [x] `format_apply_mixed` — success + failure + skip, error shown in parens
- [x] `go test -race` — no data races
- [x] `go vet` — clean