### PR TITLE
Implement provider resolution and configuration

### DIFF
--- a/engine/providers.go
+++ b/engine/providers.go
@@ -1,0 +1,51 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// ConfigureProviders looks up, instantiates, and configures providers for the
+// given resources. Returns a map keyed by full resource type (e.g.,
+// "opensearch_ism_policy") ready to pass to Execute and NormalizeResources.
+// Each unique provider prefix is instantiated and configured once; multiple
+// resource types sharing a prefix share the same provider instance.
+func ConfigureProviders(ctx context.Context, resources []provider.Resource, configs map[string]*provider.OrderedMap) (map[string]provider.Provider, error) {
+	// Collect unique prefixes and which resource types belong to each.
+	prefixTypes := make(map[string][]string) // prefix → []resourceType
+	for _, r := range resources {
+		prefix, ok := provider.ProviderForResourceType(r.ID.Type)
+		if !ok {
+			return nil, fmt.Errorf("resource type %q has no provider prefix", r.ID.Type)
+		}
+		if _, seen := prefixTypes[prefix]; !seen {
+			prefixTypes[prefix] = nil
+		}
+		prefixTypes[prefix] = append(prefixTypes[prefix], r.ID.Type)
+	}
+
+	// Instantiate and configure each provider, build the return map.
+	out := make(map[string]provider.Provider)
+	for prefix, types := range prefixTypes {
+		factory, ok := provider.Lookup(prefix)
+		if !ok {
+			return nil, fmt.Errorf("no provider registered for prefix %q (from resource type %q)", prefix, types[0])
+		}
+
+		p := factory()
+
+		cfg := configs[prefix] // nil if not present — that's fine
+		diags := p.Configure(ctx, cfg)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("configuring provider %q: %s", prefix, diags.Error())
+		}
+
+		for _, typ := range types {
+			out[typ] = p
+		}
+	}
+
+	return out, nil
+}

--- a/engine/providers_test.go
+++ b/engine/providers_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/MathewBravo/datastorectl/dcl"
@@ -73,6 +74,134 @@ func TestConfigureProviders(t *testing.T) {
 		}
 		if p1 != p2 {
 			t.Error("expected same provider instance for both types")
+		}
+	})
+
+	t.Run("multiple_providers", func(t *testing.T) {
+		var instanceA, instanceB *mockConfigProvider
+		provider.Register("cptest2a", func() provider.Provider {
+			instanceA = &mockConfigProvider{}
+			return instanceA
+		})
+		provider.Register("cptest2b", func() provider.Provider {
+			instanceB = &mockConfigProvider{}
+			return instanceB
+		})
+
+		resources := []provider.Resource{
+			{ID: rid("cptest2a_role", "x"), Body: provider.NewOrderedMap()},
+			{ID: rid("cptest2b_acl", "y"), Body: provider.NewOrderedMap()},
+		}
+
+		result, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !instanceA.configured || !instanceB.configured {
+			t.Error("expected both providers to be configured")
+		}
+		if len(result) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(result))
+		}
+		if result["cptest2a_role"] != instanceA {
+			t.Error("expected cptest2a_role to map to instanceA")
+		}
+		if result["cptest2b_acl"] != instanceB {
+			t.Error("expected cptest2b_acl to map to instanceB")
+		}
+	})
+
+	t.Run("unknown_provider", func(t *testing.T) {
+		resources := []provider.Resource{
+			{ID: rid("cptest3unknown_thing", "a"), Body: provider.NewOrderedMap()},
+		}
+
+		_, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
+
+		if err == nil {
+			t.Fatal("expected error for unknown provider")
+		}
+		if !strings.Contains(err.Error(), "cptest3unknown") {
+			t.Errorf("expected prefix in error, got: %s", err.Error())
+		}
+	})
+
+	t.Run("configure_error", func(t *testing.T) {
+		provider.Register("cptest4", func() provider.Provider {
+			return &mockConfigProvider{
+				configureFn: func(_ context.Context, _ *provider.OrderedMap) dcl.Diagnostics {
+					return dcl.Diagnostics{{Severity: dcl.SeverityError, Message: "bad config"}}
+				},
+			}
+		})
+
+		resources := []provider.Resource{
+			{ID: rid("cptest4_thing", "a"), Body: provider.NewOrderedMap()},
+		}
+
+		_, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
+
+		if err == nil {
+			t.Fatal("expected error for configure failure")
+		}
+		if !strings.Contains(err.Error(), "cptest4") {
+			t.Errorf("expected provider name in error, got: %s", err.Error())
+		}
+		if !strings.Contains(err.Error(), "bad config") {
+			t.Errorf("expected diagnostic message in error, got: %s", err.Error())
+		}
+	})
+
+	t.Run("nil_config", func(t *testing.T) {
+		var instance *mockConfigProvider
+		provider.Register("cptest5", func() provider.Provider {
+			instance = &mockConfigProvider{}
+			return instance
+		})
+
+		resources := []provider.Resource{
+			{ID: rid("cptest5_thing", "a"), Body: provider.NewOrderedMap()},
+		}
+
+		// No config entry for "cptest5" — should pass nil to Configure.
+		result, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !instance.configured {
+			t.Fatal("expected Configure to be called")
+		}
+		if instance.configArg != nil {
+			t.Error("expected nil config when not in map")
+		}
+		if result["cptest5_thing"] == nil {
+			t.Error("expected provider in result map")
+		}
+	})
+
+	t.Run("context_passed_through", func(t *testing.T) {
+		var instance *mockConfigProvider
+		provider.Register("cptest6", func() provider.Provider {
+			instance = &mockConfigProvider{}
+			return instance
+		})
+
+		type ctxKey struct{}
+		ctx := context.WithValue(context.Background(), ctxKey{}, "test-value")
+
+		resources := []provider.Resource{
+			{ID: rid("cptest6_thing", "a"), Body: provider.NewOrderedMap()},
+		}
+
+		_, err := ConfigureProviders(ctx, resources, map[string]*provider.OrderedMap{})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if instance.configCtx.Value(ctxKey{}) != "test-value" {
+			t.Error("expected context to be passed through to Configure")
 		}
 	})
 }

--- a/engine/providers_test.go
+++ b/engine/providers_test.go
@@ -1,0 +1,78 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// mockConfigProvider implements provider.Provider with a configurable Configure func.
+type mockConfigProvider struct {
+	configureFn func(ctx context.Context, config *provider.OrderedMap) dcl.Diagnostics
+	configured  bool
+	configArg   *provider.OrderedMap
+	configCtx   context.Context
+}
+
+func (m *mockConfigProvider) Configure(ctx context.Context, config *provider.OrderedMap) dcl.Diagnostics {
+	m.configured = true
+	m.configArg = config
+	m.configCtx = ctx
+	if m.configureFn != nil {
+		return m.configureFn(ctx, config)
+	}
+	return nil
+}
+func (m *mockConfigProvider) Discover(context.Context) ([]provider.Resource, dcl.Diagnostics) {
+	return nil, nil
+}
+func (m *mockConfigProvider) Normalize(_ context.Context, r provider.Resource) (provider.Resource, dcl.Diagnostics) {
+	return r, nil
+}
+func (m *mockConfigProvider) Validate(context.Context, provider.Resource) dcl.Diagnostics { return nil }
+func (m *mockConfigProvider) Apply(context.Context, provider.Operation, provider.Resource) dcl.Diagnostics {
+	return nil
+}
+
+func TestConfigureProviders(t *testing.T) {
+	t.Run("all_succeed", func(t *testing.T) {
+		var instance *mockConfigProvider
+		provider.Register("cptest1", func() provider.Provider {
+			instance = &mockConfigProvider{}
+			return instance
+		})
+
+		resources := []provider.Resource{
+			{ID: rid("cptest1_role", "a"), Body: provider.NewOrderedMap()},
+			{ID: rid("cptest1_policy", "b"), Body: provider.NewOrderedMap()},
+		}
+
+		cfg := provider.NewOrderedMap()
+		cfg.Set("host", provider.StringVal("localhost"))
+		configs := map[string]*provider.OrderedMap{"cptest1": cfg}
+
+		result, err := ConfigureProviders(context.Background(), resources, configs)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !instance.configured {
+			t.Fatal("expected Configure to be called")
+		}
+		if instance.configArg != cfg {
+			t.Error("expected config to be passed through")
+		}
+
+		// Both resource types should map to the same provider instance.
+		p1, ok1 := result["cptest1_role"]
+		p2, ok2 := result["cptest1_policy"]
+		if !ok1 || !ok2 {
+			t.Fatal("expected both resource types in map")
+		}
+		if p1 != p2 {
+			t.Error("expected same provider instance for both types")
+		}
+	})
+}


### PR DESCRIPTION
Closes #54

## Summary
- Add `ConfigureProviders` that looks up providers from the global registry, instantiates via factory, calls `Configure()`, and returns a map keyed by full resource type
- Multiple resource types sharing a prefix share one provider instance
- Fails fast on unknown providers, bad resource type prefixes, or configuration errors

## Test Plan
- [x] `all_succeed` — 2 resources same prefix, configured once, both types in map, same instance
- [x] `multiple_providers` — 2 different prefixes, both configured, correct map entries
- [x] `unknown_provider` — unregistered prefix returns error
- [x] `configure_error` — Configure returns error diagnostics, returns error
- [x] `nil_config` — missing config key passes nil to Configure, succeeds
- [x] `context_passed_through` — ctx forwarded to Configure
- [x] `go test -race` — no data races
- [x] `go vet` — clean