### PR TITLE
feat: add TypeOrderer optional interface for provider type orderings

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -32,7 +32,7 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 	}
 
 	// 2. Look up, instantiate, and configure providers.
-	providers, _, err := ConfigureProviders(ctx, resourceSet.Resources, configs)
+	providers, orderings, err := ConfigureProviders(ctx, resourceSet.Resources, configs)
 	if err != nil {
 		return nil, fmt.Errorf("configure providers: %w", err)
 	}
@@ -44,7 +44,7 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 	}
 
 	// 4. Build the dependency graph BEFORE resolution (needs KindReference values).
-	graph, err := BuildDependencyGraph(resourceSet.Resources)
+	graph, err := BuildDependencyGraphWithOrdering(resourceSet.Resources, orderings)
 	if err != nil {
 		return nil, fmt.Errorf("build dependency graph: %w", err)
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -32,7 +32,7 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 	}
 
 	// 2. Look up, instantiate, and configure providers.
-	providers, err := ConfigureProviders(ctx, resourceSet.Resources, configs)
+	providers, _, err := ConfigureProviders(ctx, resourceSet.Resources, configs)
 	if err != nil {
 		return nil, fmt.Errorf("configure providers: %w", err)
 	}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -919,3 +919,66 @@ func TestValidateResources(t *testing.T) {
 		}
 	})
 }
+
+type mockOrderingProvider struct {
+	mockEngineProvider
+	orderings []provider.TypeOrdering
+}
+
+func (m *mockOrderingProvider) TypeOrderings() []provider.TypeOrdering {
+	return m.orderings
+}
+
+func TestEnginePlan_TypeOrderings(t *testing.T) {
+	t.Run("provider_orderings_create_graph_edges", func(t *testing.T) {
+		mock := &mockOrderingProvider{
+			orderings: []provider.TypeOrdering{
+				{Before: "engord1_role", After: "engord1_mapping"},
+			},
+		}
+		provider.Register("engord1", func() provider.Provider { return mock })
+
+		file := makeFile(
+			provider.ResourceID{Type: "engord1_role", Name: "admin"},
+			provider.ResourceID{Type: "engord1_mapping", Name: "m1"},
+		)
+
+		e := &Engine{SecretResolver: stubSecretResolver{}}
+		_, graph, err := e.Plan(context.Background(), file, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		deps := graph.DependsOn(rid("engord1_mapping", "m1"))
+		found := false
+		for _, d := range deps {
+			if d == rid("engord1_role", "admin") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected graph edge engord1_mapping.m1 → engord1_role.admin, got deps: %v", deps)
+		}
+	})
+
+	t.Run("no_orderings_no_extra_edges", func(t *testing.T) {
+		mock := &mockEngineProvider{}
+		provider.Register("engord2", func() provider.Provider { return mock })
+
+		file := makeFile(
+			provider.ResourceID{Type: "engord2_role", Name: "admin"},
+			provider.ResourceID{Type: "engord2_mapping", Name: "m1"},
+		)
+
+		e := &Engine{SecretResolver: stubSecretResolver{}}
+		_, graph, err := e.Plan(context.Background(), file, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		deps := graph.DependsOn(rid("engord2_mapping", "m1"))
+		if len(deps) != 0 {
+			t.Errorf("expected no edges between unrelated types, got deps: %v", deps)
+		}
+	})
+}

--- a/engine/graph_build.go
+++ b/engine/graph_build.go
@@ -8,13 +8,6 @@ import (
 	"github.com/MathewBravo/datastorectl/provider"
 )
 
-// TypeOrdering declares that resources of type Before should be
-// processed before resources of type After.
-type TypeOrdering struct {
-	Before string
-	After  string
-}
-
 // BuildDependencyGraph builds a dependency graph from cross-resource
 // references. Returns an error if any reference targets a resource
 // not in the input slice.
@@ -27,7 +20,7 @@ func BuildDependencyGraph(resources []provider.Resource) (*Graph, error) {
 // Returns an error if any reference targets a resource not in the
 // input slice. Orderings mentioning types with no matching resources
 // are silently ignored.
-func BuildDependencyGraphWithOrdering(resources []provider.Resource, orderings []TypeOrdering) (*Graph, error) {
+func BuildDependencyGraphWithOrdering(resources []provider.Resource, orderings []provider.TypeOrdering) (*Graph, error) {
 	g := NewGraph()
 
 	// Pass 1: register nodes, build indexes.

--- a/engine/graph_build_test.go
+++ b/engine/graph_build_test.go
@@ -163,7 +163,7 @@ func TestBuildDependencyGraphWithOrdering(t *testing.T) {
 	t.Run("single_ordering", func(t *testing.T) {
 		idx := makeResource("index", "hot")
 		ism := makeResource("ism_policy", "delete")
-		orderings := []TypeOrdering{{Before: "index", After: "ism_policy"}}
+		orderings := []provider.TypeOrdering{{Before: "index", After: "ism_policy"}}
 		g, err := BuildDependencyGraphWithOrdering([]provider.Resource{idx, ism}, orderings)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -176,7 +176,7 @@ func TestBuildDependencyGraphWithOrdering(t *testing.T) {
 
 	t.Run("ordering_no_matching_types", func(t *testing.T) {
 		db := makeResource("db", "main")
-		orderings := []TypeOrdering{{Before: "foo", After: "bar"}}
+		orderings := []provider.TypeOrdering{{Before: "foo", After: "bar"}}
 		g, err := BuildDependencyGraphWithOrdering([]provider.Resource{db}, orderings)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -191,7 +191,7 @@ func TestBuildDependencyGraphWithOrdering(t *testing.T) {
 
 	t.Run("ordering_one_side_empty", func(t *testing.T) {
 		idx := makeResource("index", "hot")
-		orderings := []TypeOrdering{{Before: "index", After: "ism_policy"}}
+		orderings := []provider.TypeOrdering{{Before: "index", After: "ism_policy"}}
 		g, err := BuildDependencyGraphWithOrdering([]provider.Resource{idx}, orderings)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -205,7 +205,7 @@ func TestBuildDependencyGraphWithOrdering(t *testing.T) {
 		db := makeResource("db", "main")
 		cache := makeResource("cache", "redis")
 		app := makeResource("app", "web", rid("db", "main"))
-		orderings := []TypeOrdering{{Before: "db", After: "cache"}}
+		orderings := []provider.TypeOrdering{{Before: "db", After: "cache"}}
 		g, err := BuildDependencyGraphWithOrdering([]provider.Resource{db, cache, app}, orderings)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -226,7 +226,7 @@ func TestBuildDependencyGraphWithOrdering(t *testing.T) {
 		a := makeResource("a", "svc")
 		b := makeResource("b", "svc")
 		c := makeResource("c", "svc")
-		orderings := []TypeOrdering{
+		orderings := []provider.TypeOrdering{
 			{Before: "a", After: "b"},
 			{Before: "b", After: "c"},
 		}
@@ -249,7 +249,7 @@ func TestBuildDependencyGraphWithOrdering(t *testing.T) {
 		idx2 := makeResource("index", "cold")
 		ism1 := makeResource("ism_policy", "delete")
 		ism2 := makeResource("ism_policy", "archive")
-		orderings := []TypeOrdering{{Before: "index", After: "ism_policy"}}
+		orderings := []provider.TypeOrdering{{Before: "index", After: "ism_policy"}}
 		g, err := BuildDependencyGraphWithOrdering(
 			[]provider.Resource{idx1, idx2, ism1, ism2}, orderings,
 		)

--- a/engine/providers.go
+++ b/engine/providers.go
@@ -12,13 +12,13 @@ import (
 // "opensearch_ism_policy") ready to pass to Execute and NormalizeResources.
 // Each unique provider prefix is instantiated and configured once; multiple
 // resource types sharing a prefix share the same provider instance.
-func ConfigureProviders(ctx context.Context, resources []provider.Resource, configs map[string]*provider.OrderedMap) (map[string]provider.Provider, error) {
+func ConfigureProviders(ctx context.Context, resources []provider.Resource, configs map[string]*provider.OrderedMap) (map[string]provider.Provider, []provider.TypeOrdering, error) {
 	// Collect unique prefixes and which resource types belong to each.
 	prefixTypes := make(map[string][]string) // prefix → []resourceType
 	for _, r := range resources {
 		prefix, ok := provider.ProviderForResourceType(r.ID.Type)
 		if !ok {
-			return nil, fmt.Errorf("resource type %q has no provider prefix", r.ID.Type)
+			return nil, nil, fmt.Errorf("resource type %q has no provider prefix", r.ID.Type)
 		}
 		if _, seen := prefixTypes[prefix]; !seen {
 			prefixTypes[prefix] = nil
@@ -28,10 +28,11 @@ func ConfigureProviders(ctx context.Context, resources []provider.Resource, conf
 
 	// Instantiate and configure each provider, build the return map.
 	out := make(map[string]provider.Provider)
+	var orderings []provider.TypeOrdering
 	for prefix, types := range prefixTypes {
 		factory, ok := provider.Lookup(prefix)
 		if !ok {
-			return nil, fmt.Errorf("no provider registered for prefix %q (from resource type %q)", prefix, types[0])
+			return nil, nil, fmt.Errorf("no provider registered for prefix %q (from resource type %q)", prefix, types[0])
 		}
 
 		p := factory()
@@ -39,7 +40,11 @@ func ConfigureProviders(ctx context.Context, resources []provider.Resource, conf
 		cfg := configs[prefix] // nil if not present — that's fine
 		diags := p.Configure(ctx, cfg)
 		if diags.HasErrors() {
-			return nil, fmt.Errorf("configuring provider %q: %s", prefix, diags.Error())
+			return nil, nil, fmt.Errorf("configuring provider %q: %s", prefix, diags.Error())
+		}
+
+		if to, ok := p.(provider.TypeOrderer); ok {
+			orderings = append(orderings, to.TypeOrderings()...)
 		}
 
 		for _, typ := range types {
@@ -47,5 +52,5 @@ func ConfigureProviders(ctx context.Context, resources []provider.Resource, conf
 		}
 	}
 
-	return out, nil
+	return out, orderings, nil
 }

--- a/engine/providers_test.go
+++ b/engine/providers_test.go
@@ -54,7 +54,7 @@ func TestConfigureProviders(t *testing.T) {
 		cfg.Set("host", provider.StringVal("localhost"))
 		configs := map[string]*provider.OrderedMap{"cptest1": cfg}
 
-		result, err := ConfigureProviders(context.Background(), resources, configs)
+		result, _, err := ConfigureProviders(context.Background(), resources, configs)
 
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -93,7 +93,7 @@ func TestConfigureProviders(t *testing.T) {
 			{ID: rid("cptest2b_acl", "y"), Body: provider.NewOrderedMap()},
 		}
 
-		result, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
+		result, _, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
 
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -117,7 +117,7 @@ func TestConfigureProviders(t *testing.T) {
 			{ID: rid("cptest3unknown_thing", "a"), Body: provider.NewOrderedMap()},
 		}
 
-		_, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
+		_, _, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
 
 		if err == nil {
 			t.Fatal("expected error for unknown provider")
@@ -140,7 +140,7 @@ func TestConfigureProviders(t *testing.T) {
 			{ID: rid("cptest4_thing", "a"), Body: provider.NewOrderedMap()},
 		}
 
-		_, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
+		_, _, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
 
 		if err == nil {
 			t.Fatal("expected error for configure failure")
@@ -165,7 +165,7 @@ func TestConfigureProviders(t *testing.T) {
 		}
 
 		// No config entry for "cptest5" — should pass nil to Configure.
-		result, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
+		result, _, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
 
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -195,7 +195,7 @@ func TestConfigureProviders(t *testing.T) {
 			{ID: rid("cptest6_thing", "a"), Body: provider.NewOrderedMap()},
 		}
 
-		_, err := ConfigureProviders(ctx, resources, map[string]*provider.OrderedMap{})
+		_, _, err := ConfigureProviders(ctx, resources, map[string]*provider.OrderedMap{})
 
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -204,4 +204,56 @@ func TestConfigureProviders(t *testing.T) {
 			t.Error("expected context to be passed through to Configure")
 		}
 	})
+
+	t.Run("collects_type_orderings", func(t *testing.T) {
+		provider.Register("cptest7", func() provider.Provider {
+			return &mockTypeOrdererProvider{
+				orderings: []provider.TypeOrdering{
+					{Before: "cptest7_role", After: "cptest7_mapping"},
+				},
+			}
+		})
+
+		resources := []provider.Resource{
+			{ID: rid("cptest7_role", "a"), Body: provider.NewOrderedMap()},
+		}
+
+		_, orderings, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(orderings) != 1 {
+			t.Fatalf("expected 1 ordering, got %d", len(orderings))
+		}
+		if orderings[0].Before != "cptest7_role" || orderings[0].After != "cptest7_mapping" {
+			t.Errorf("unexpected ordering: %+v", orderings[0])
+		}
+	})
+
+	t.Run("no_orderings_when_not_type_orderer", func(t *testing.T) {
+		provider.Register("cptest8", func() provider.Provider {
+			return &mockConfigProvider{}
+		})
+
+		resources := []provider.Resource{
+			{ID: rid("cptest8_thing", "a"), Body: provider.NewOrderedMap()},
+		}
+
+		_, orderings, err := ConfigureProviders(context.Background(), resources, map[string]*provider.OrderedMap{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(orderings) != 0 {
+			t.Errorf("expected 0 orderings for non-TypeOrderer provider, got %d", len(orderings))
+		}
+	})
+}
+
+type mockTypeOrdererProvider struct {
+	mockConfigProvider
+	orderings []provider.TypeOrdering
+}
+
+func (m *mockTypeOrdererProvider) TypeOrderings() []provider.TypeOrdering {
+	return m.orderings
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -39,3 +39,17 @@ type Provider interface {
 	Validate(ctx context.Context, r Resource) dcl.Diagnostics
 	Apply(ctx context.Context, op Operation, r Resource) dcl.Diagnostics
 }
+
+// TypeOrdering declares that resources of type Before should be
+// processed before resources of type After.
+type TypeOrdering struct {
+	Before string
+	After  string
+}
+
+// TypeOrderer is an optional interface a Provider may implement to
+// declare default type-level orderings. The engine collects these
+// during provider configuration and feeds them into the dependency graph.
+type TypeOrderer interface {
+	TypeOrderings() []TypeOrdering
+}

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -27,6 +27,31 @@ func TestOperationString(t *testing.T) {
 	}
 }
 
+type stubTypeOrderer struct{ stubProvider }
+
+func (stubTypeOrderer) TypeOrderings() []TypeOrdering {
+	return []TypeOrdering{{Before: "role", After: "role_mapping"}}
+}
+
+var _ TypeOrderer = stubTypeOrderer{}
+
+func TestTypeOrdererOptional(t *testing.T) {
+	var p Provider = stubTypeOrderer{}
+	to, ok := p.(TypeOrderer)
+	if !ok {
+		t.Fatal("expected stubTypeOrderer to satisfy TypeOrderer")
+	}
+	orderings := to.TypeOrderings()
+	if len(orderings) != 1 || orderings[0].Before != "role" {
+		t.Errorf("unexpected orderings: %v", orderings)
+	}
+
+	var plain Provider = stubProvider{}
+	if _, ok := plain.(TypeOrderer); ok {
+		t.Error("stubProvider should not satisfy TypeOrderer")
+	}
+}
+
 func TestOperationConstants(t *testing.T) {
 	tests := []struct {
 		op   Operation


### PR DESCRIPTION
## Summary

- Adds `TypeOrdering` struct and `TypeOrderer` optional interface to `provider/` so providers can declare default type-level orderings (e.g., roles before role mappings) without expanding the core `Provider` interface
- Migrates `engine/graph_build.go` to use `provider.TypeOrdering` instead of a local duplicate struct
- Extends `ConfigureProviders` to collect orderings from providers that implement `TypeOrderer` (3-value return)
- Wires collected orderings through `Engine.plan()` into `BuildDependencyGraphWithOrdering` so provider-declared orderings produce graph edges

Closes #88

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./provider/...` — new `TestTypeOrdererOptional` verifies interface satisfaction and type-assertion
- [x] `go test ./engine/...` — all existing tests pass, plus:
  - `TestConfigureProviders/collects_type_orderings` and `no_orderings_when_not_type_orderer`
  - `TestEnginePlan_TypeOrderings/provider_orderings_create_graph_edges` and `no_orderings_no_extra_edges`