### PR TITLE
feat(opensearch): provider skeleton with basic auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/MathewBravo/datastorectl
 
 go 1.25.0
+
+require github.com/opensearch-project/opensearch-go/v4 v4.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/opensearch-project/opensearch-go/v4 v4.6.0 h1:Ac8aLtDSmLEyOmv0r1qhQLw3b4vcUhE42NE9k+Z4cRc=
+github.com/opensearch-project/opensearch-go/v4 v4.6.0/go.mod h1:3iZtb4SNt3IzaxavKq0dURh1AmtVgYW71E4XqmYnIiQ=

--- a/providers/opensearch/client.go
+++ b/providers/opensearch/client.go
@@ -1,0 +1,26 @@
+package opensearch
+
+import (
+	"github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+)
+
+// Client is a thin wrapper around the opensearch-go client.
+type Client struct {
+	api *opensearchapi.Client
+}
+
+// NewClient creates an OpenSearch client configured with basic auth.
+func NewClient(endpoint, username, password string) (*Client, error) {
+	api, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses: []string{endpoint},
+			Username:  username,
+			Password:  password,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Client{api: api}, nil
+}

--- a/providers/opensearch/handler.go
+++ b/providers/opensearch/handler.go
@@ -1,0 +1,16 @@
+package opensearch
+
+import (
+	"context"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// resourceHandler is the internal interface each resource type implements.
+// The top-level Provider dispatches to the matching handler by resource type.
+type resourceHandler interface {
+	Discover(ctx context.Context, client *Client) ([]provider.Resource, error)
+	Normalize(ctx context.Context, r provider.Resource) (provider.Resource, error)
+	Validate(ctx context.Context, r provider.Resource) error
+	Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error
+}

--- a/providers/opensearch/provider.go
+++ b/providers/opensearch/provider.go
@@ -1,0 +1,174 @@
+package opensearch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+func init() {
+	provider.Register("opensearch", func() provider.Provider {
+		return &Provider{
+			handlers: map[string]resourceHandler{
+				// Resource handlers will be registered here as they're implemented.
+			},
+		}
+	})
+}
+
+// Provider implements provider.Provider for OpenSearch clusters.
+type Provider struct {
+	client   *Client
+	handlers map[string]resourceHandler
+}
+
+// Configure validates the provider configuration and creates the HTTP client.
+func (p *Provider) Configure(_ context.Context, config *provider.OrderedMap) dcl.Diagnostics {
+	if config == nil {
+		return dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  `opensearch provider requires configuration — set at minimum "endpoint", "auth", "username", and "password"`,
+		}}
+	}
+
+	// endpoint — required, non-empty string.
+	endpointVal, ok := config.Get("endpoint")
+	if !ok || endpointVal.Kind != provider.KindString || endpointVal.Str == "" {
+		return dcl.Diagnostics{{
+			Severity:   dcl.SeverityError,
+			Message:    `"endpoint" is required and must be a non-empty string (the OpenSearch cluster URL, e.g. "https://search.example.com:9200")`,
+			Suggestion: `add endpoint = "https://your-cluster:9200" to the opensearch provider block`,
+		}}
+	}
+	endpoint := endpointVal.Str
+
+	// auth — required, must be "basic".
+	authVal, ok := config.Get("auth")
+	if !ok || authVal.Kind != provider.KindString || authVal.Str == "" {
+		return dcl.Diagnostics{{
+			Severity:   dcl.SeverityError,
+			Message:    `"auth" is required — set it to "basic" to use username/password authentication`,
+			Suggestion: `add auth = "basic" to the opensearch provider block`,
+		}}
+	}
+	auth := authVal.Str
+
+	switch auth {
+	case "basic":
+		// OK — fall through to credential validation below.
+	case "sigv4":
+		return dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  `auth is "sigv4" but sigv4 support is not yet implemented — use "basic" for now`,
+		}}
+	default:
+		return dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  fmt.Sprintf(`auth must be "basic" (sigv4 support is planned but not yet available), got %q`, auth),
+		}}
+	}
+
+	// username — required for basic auth.
+	usernameVal, ok := config.Get("username")
+	if !ok || usernameVal.Kind != provider.KindString || usernameVal.Str == "" {
+		return dcl.Diagnostics{{
+			Severity:   dcl.SeverityError,
+			Message:    `"username" is required when auth is "basic"`,
+			Suggestion: `add username = "admin" to the opensearch provider block`,
+		}}
+	}
+	username := usernameVal.Str
+
+	// password — required for basic auth.
+	passwordVal, ok := config.Get("password")
+	if !ok || passwordVal.Kind != provider.KindString || passwordVal.Str == "" {
+		return dcl.Diagnostics{{
+			Severity:   dcl.SeverityError,
+			Message:    `"password" is required when auth is "basic"`,
+			Suggestion: `add password = secret("opensearch_password") to the opensearch provider block`,
+		}}
+	}
+	password := passwordVal.Str
+
+	client, err := NewClient(endpoint, username, password)
+	if err != nil {
+		return dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  fmt.Sprintf("failed to create opensearch client: %s", err),
+		}}
+	}
+	p.client = client
+	return nil
+}
+
+// Discover iterates all registered handlers and collects discovered resources.
+func (p *Provider) Discover(ctx context.Context) ([]provider.Resource, dcl.Diagnostics) {
+	var all []provider.Resource
+	var diags dcl.Diagnostics
+	for _, h := range p.handlers {
+		resources, err := h.Discover(ctx, p.client)
+		if err != nil {
+			diags.Append(dcl.Diagnostics{{Severity: dcl.SeverityError, Message: err.Error()}})
+			continue
+		}
+		all = append(all, resources...)
+	}
+	return all, diags
+}
+
+// Normalize delegates to the handler registered for the resource type.
+func (p *Provider) Normalize(ctx context.Context, r provider.Resource) (provider.Resource, dcl.Diagnostics) {
+	h, ok := p.handlers[r.ID.Type]
+	if !ok {
+		return r, dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  fmt.Sprintf("resource type %q is not supported by the opensearch provider", r.ID.Type),
+		}}
+	}
+	result, err := h.Normalize(ctx, r)
+	if err != nil {
+		return r, dcl.Diagnostics{{Severity: dcl.SeverityError, Message: err.Error()}}
+	}
+	return result, nil
+}
+
+// Validate delegates to the handler registered for the resource type.
+func (p *Provider) Validate(ctx context.Context, r provider.Resource) dcl.Diagnostics {
+	h, ok := p.handlers[r.ID.Type]
+	if !ok {
+		return dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  fmt.Sprintf("resource type %q is not supported by the opensearch provider", r.ID.Type),
+		}}
+	}
+	if err := h.Validate(ctx, r); err != nil {
+		return dcl.Diagnostics{{Severity: dcl.SeverityError, Message: err.Error()}}
+	}
+	return nil
+}
+
+// Apply delegates to the handler registered for the resource type.
+func (p *Provider) Apply(ctx context.Context, op provider.Operation, r provider.Resource) dcl.Diagnostics {
+	h, ok := p.handlers[r.ID.Type]
+	if !ok {
+		return dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  fmt.Sprintf("resource type %q is not supported by the opensearch provider", r.ID.Type),
+		}}
+	}
+	if err := h.Apply(ctx, p.client, op, r); err != nil {
+		return dcl.Diagnostics{{Severity: dcl.SeverityError, Message: err.Error()}}
+	}
+	return nil
+}
+
+// TypeOrderings declares the default resource type ordering for the opensearch provider.
+func (p *Provider) TypeOrderings() []provider.TypeOrdering {
+	return []provider.TypeOrdering{
+		{Before: "opensearch_role", After: "opensearch_role_mapping"},
+		{Before: "opensearch_internal_user", After: "opensearch_role_mapping"},
+		{Before: "opensearch_component_template", After: "opensearch_composable_index_template"},
+	}
+}

--- a/providers/opensearch/provider_test.go
+++ b/providers/opensearch/provider_test.go
@@ -1,0 +1,173 @@
+package opensearch
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// helper builds an *OrderedMap from key-value string pairs.
+func configMap(kvs ...string) *provider.OrderedMap {
+	m := provider.NewOrderedMap()
+	for i := 0; i < len(kvs); i += 2 {
+		m.Set(kvs[i], provider.StringVal(kvs[i+1]))
+	}
+	return m
+}
+
+// ─── Configure validation ───────────────────────────────────────────
+
+func TestConfigure(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    *provider.OrderedMap
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:      "nil_config",
+			config:    nil,
+			wantErr:   true,
+			errSubstr: "requires configuration",
+		},
+		{
+			name:      "missing_endpoint",
+			config:    configMap("auth", "basic", "username", "admin", "password", "secret"),
+			wantErr:   true,
+			errSubstr: "endpoint",
+		},
+		{
+			name:      "empty_endpoint",
+			config:    configMap("endpoint", "", "auth", "basic", "username", "admin", "password", "secret"),
+			wantErr:   true,
+			errSubstr: "endpoint",
+		},
+		{
+			name:      "missing_auth",
+			config:    configMap("endpoint", "https://localhost:9200"),
+			wantErr:   true,
+			errSubstr: "auth",
+		},
+		{
+			name:      "invalid_auth",
+			config:    configMap("endpoint", "https://localhost:9200", "auth", "oauth"),
+			wantErr:   true,
+			errSubstr: `"basic"`,
+		},
+		{
+			name:      "sigv4_not_implemented",
+			config:    configMap("endpoint", "https://localhost:9200", "auth", "sigv4"),
+			wantErr:   true,
+			errSubstr: "not yet implemented",
+		},
+		{
+			name:      "basic_missing_username",
+			config:    configMap("endpoint", "https://localhost:9200", "auth", "basic", "password", "secret"),
+			wantErr:   true,
+			errSubstr: "username",
+		},
+		{
+			name:      "basic_missing_password",
+			config:    configMap("endpoint", "https://localhost:9200", "auth", "basic", "username", "admin"),
+			wantErr:   true,
+			errSubstr: "password",
+		},
+		{
+			name:    "basic_auth_success",
+			config:  configMap("endpoint", "https://localhost:9200", "auth", "basic", "username", "admin", "password", "secret"),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Provider{handlers: map[string]resourceHandler{}}
+			diags := p.Configure(context.Background(), tt.config)
+			if tt.wantErr {
+				if !diags.HasErrors() {
+					t.Fatal("expected error diagnostic, got none")
+				}
+				msg := diags.Error()
+				if !strings.Contains(msg, tt.errSubstr) {
+					t.Errorf("expected error to contain %q, got:\n%s", tt.errSubstr, msg)
+				}
+			} else {
+				if diags.HasErrors() {
+					t.Fatalf("unexpected error: %s", diags.Error())
+				}
+				if p.client == nil {
+					t.Fatal("expected client to be set after successful Configure")
+				}
+			}
+		})
+	}
+}
+
+// ─── TypeOrderer ────────────────────────────────────────────────────
+
+func TestTypeOrderer_implements_interface(t *testing.T) {
+	var p provider.Provider = &Provider{}
+	if _, ok := p.(provider.TypeOrderer); !ok {
+		t.Fatal("Provider does not implement provider.TypeOrderer")
+	}
+}
+
+func TestTypeOrderer_returns_orderings(t *testing.T) {
+	p := &Provider{}
+	orderings := p.TypeOrderings()
+
+	if got := len(orderings); got != 3 {
+		t.Fatalf("expected 3 orderings, got %d", got)
+	}
+
+	want := []provider.TypeOrdering{
+		{Before: "opensearch_role", After: "opensearch_role_mapping"},
+		{Before: "opensearch_internal_user", After: "opensearch_role_mapping"},
+		{Before: "opensearch_component_template", After: "opensearch_composable_index_template"},
+	}
+	for i, w := range want {
+		if orderings[i] != w {
+			t.Errorf("ordering[%d] = %+v, want %+v", i, orderings[i], w)
+		}
+	}
+}
+
+// ─── Dispatch routing ───────────────────────────────────────────────
+
+func TestNormalize_unknown_type(t *testing.T) {
+	p := &Provider{handlers: map[string]resourceHandler{}}
+	r := provider.Resource{ID: provider.ResourceID{Type: "opensearch_nonexistent", Name: "x"}}
+	_, diags := p.Normalize(context.Background(), r)
+	if !diags.HasErrors() {
+		t.Fatal("expected error for unknown resource type")
+	}
+	if msg := diags.Error(); !strings.Contains(msg, "not supported") {
+		t.Errorf("expected 'not supported' in error, got: %s", msg)
+	}
+}
+
+func TestValidate_unknown_type(t *testing.T) {
+	p := &Provider{handlers: map[string]resourceHandler{}}
+	r := provider.Resource{ID: provider.ResourceID{Type: "opensearch_nonexistent", Name: "x"}}
+	diags := p.Validate(context.Background(), r)
+	if !diags.HasErrors() {
+		t.Fatal("expected error for unknown resource type")
+	}
+	if msg := diags.Error(); !strings.Contains(msg, "not supported") {
+		t.Errorf("expected 'not supported' in error, got: %s", msg)
+	}
+}
+
+func TestApply_unknown_type(t *testing.T) {
+	p := &Provider{handlers: map[string]resourceHandler{}}
+	r := provider.Resource{ID: provider.ResourceID{Type: "opensearch_nonexistent", Name: "x"}}
+	diags := p.Apply(context.Background(), provider.OpCreate, r)
+	if !diags.HasErrors() {
+		t.Fatal("expected error for unknown resource type")
+	}
+	if msg := diags.Error(); !strings.Contains(msg, "not supported") {
+		t.Errorf("expected 'not supported' in error, got: %s", msg)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `providers/opensearch/` package — the first concrete provider implementation for datastorectl
- `Client` wraps `opensearch-go/v4` with basic auth (endpoint + username + password)
- `Provider` implements full `provider.Provider` interface with `Configure` validation, handler-based dispatch, and `TypeOrderer` support
- `resourceHandler` internal interface establishes the pattern future resource handlers (roles, ISM policies, templates) will follow
- 14 tests covering Configure validation (9 cases), TypeOrderer assertions, and dispatch routing errors

Closes #89

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes — all existing tests unaffected
- [x] 9 Configure sub-tests verify every validation path (nil config, missing/empty endpoint, missing/invalid auth, sigv4 not-yet-implemented, missing username/password, success)
- [x] TypeOrderer interface assertion + 3-ordering verification
- [x] Dispatch returns actionable errors for unknown resource types