### PR TITLE
test(opensearch): add Docker-based integration test infrastructure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  opensearch:
+    image: opensearchproject/opensearch:2.19.0
+    environment:
+      - discovery.type=single-node
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
+      - "9600:9600"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sk https://localhost:9200 -u admin:myStrongPassword123! || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s

--- a/providers/opensearch/testhelpers_test.go
+++ b/providers/opensearch/testhelpers_test.go
@@ -1,0 +1,127 @@
+package opensearch
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+)
+
+// resourceAPIPaths maps resource types to their OpenSearch REST API path prefixes.
+var resourceAPIPaths = map[string]string{
+	"opensearch_role":                      "/_plugins/_security/api/roles/",
+	"opensearch_role_mapping":              "/_plugins/_security/api/rolesmapping/",
+	"opensearch_internal_user":             "/_plugins/_security/api/internalusers/",
+	"opensearch_component_template":        "/_component_template/",
+	"opensearch_composable_index_template": "/_index_template/",
+}
+
+// restPath returns the full REST path for a resource type and name.
+// Panics on unknown resource types — test setup bugs should be loud.
+func restPath(resourceType, name string) string {
+	prefix, ok := resourceAPIPaths[resourceType]
+	if !ok {
+		panic(fmt.Sprintf("unknown resource type in test helper: %q", resourceType))
+	}
+	return prefix + name
+}
+
+// newTestClient creates a *Client connected to the integration-test cluster.
+// Skips the test when no cluster is available.
+func newTestClient(t *testing.T) *Client {
+	t.Helper()
+	skipIfNoCluster(t)
+
+	apiClient, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses: []string{testEndpoint},
+			Username:  testUsername,
+			Password:  testPassword,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to create test OpenSearch client: %v", err)
+	}
+
+	return &Client{api: apiClient}
+}
+
+// cleanupResource registers a t.Cleanup that deletes the named resource.
+// A 404 is silently ignored (resource may not have been created).
+func cleanupResource(t *testing.T, client *Client, resourceType, name string) {
+	t.Helper()
+	t.Cleanup(func() {
+		path := restPath(resourceType, name)
+		req, err := http.NewRequest(http.MethodDelete, path, nil)
+		if err != nil {
+			t.Logf("cleanup: failed to build DELETE request for %s/%s: %v", resourceType, name, err)
+			return
+		}
+
+		resp, err := client.api.Client.Perform(req)
+		if err != nil {
+			t.Logf("cleanup: DELETE %s failed: %v", path, err)
+			return
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound && resp.StatusCode >= 400 {
+			t.Logf("cleanup: DELETE %s returned %d", path, resp.StatusCode)
+		}
+	})
+}
+
+// requireResourceExists asserts the resource exists in the cluster.
+func requireResourceExists(t *testing.T, client *Client, resourceType, name string) {
+	t.Helper()
+
+	path := restPath(resourceType, name)
+	req, err := http.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		t.Fatalf("requireResourceExists: failed to build GET request: %v", err)
+	}
+
+	resp, err := client.api.Client.Perform(req)
+	if err != nil {
+		t.Fatalf("requireResourceExists: GET %s failed: %v", path, err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		t.Fatalf("requireResourceExists: %s/%s does not exist (404)", resourceType, name)
+	}
+	if resp.StatusCode >= 400 {
+		t.Fatalf("requireResourceExists: GET %s returned %d", path, resp.StatusCode)
+	}
+}
+
+// requireResourceNotExists asserts the resource does not exist in the cluster.
+func requireResourceNotExists(t *testing.T, client *Client, resourceType, name string) {
+	t.Helper()
+
+	path := restPath(resourceType, name)
+	req, err := http.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		t.Fatalf("requireResourceNotExists: failed to build GET request: %v", err)
+	}
+
+	resp, err := client.api.Client.Perform(req)
+	if err != nil {
+		t.Fatalf("requireResourceNotExists: GET %s failed: %v", path, err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return // expected
+	}
+	if resp.StatusCode < 400 {
+		t.Fatalf("requireResourceNotExists: %s/%s unexpectedly exists (status %d)", resourceType, name, resp.StatusCode)
+	}
+	t.Fatalf("requireResourceNotExists: GET %s returned unexpected status %d", path, resp.StatusCode)
+}

--- a/providers/opensearch/testmain_test.go
+++ b/providers/opensearch/testmain_test.go
@@ -1,0 +1,70 @@
+package opensearch
+
+import (
+	"crypto/tls"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+const (
+	defaultTestEndpoint = "https://localhost:9200"
+	testUsername         = "admin"
+	testPassword         = "myStrongPassword123!"
+)
+
+// testEndpoint holds the resolved OpenSearch endpoint.
+// Empty means no cluster is available — integration tests will be skipped.
+var testEndpoint string
+
+func TestMain(m *testing.M) {
+	endpoint := os.Getenv("DATASTORECTL_TEST_ENDPOINT")
+	if endpoint == "" {
+		endpoint = defaultTestEndpoint
+	}
+
+	if clusterReachable(endpoint) {
+		testEndpoint = endpoint
+	} else {
+		// Log once so CI output shows why integration tests were skipped.
+		// Use Stderr so it appears even without -v.
+		os.Stderr.WriteString("opensearch: cluster not reachable at " + endpoint +
+			" — skipping integration tests (set DATASTORECTL_TEST_ENDPOINT or run docker compose up)\n")
+	}
+
+	os.Exit(m.Run())
+}
+
+// clusterReachable sends a HEAD request to the endpoint and returns true if
+// the cluster responds. Uses raw net/http so a bug in opensearch-go cannot
+// break the skip logic.
+func clusterReachable(endpoint string) bool {
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodHead, endpoint, nil)
+	if err != nil {
+		return false
+	}
+	req.SetBasicAuth(testUsername, testPassword)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode < 500
+}
+
+// skipIfNoCluster skips t when no OpenSearch cluster is available.
+func skipIfNoCluster(t *testing.T) {
+	t.Helper()
+	if testEndpoint == "" {
+		t.Skip("no OpenSearch cluster available; set DATASTORECTL_TEST_ENDPOINT or run docker compose up")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `docker-compose.yml` with a single-node OpenSearch 2.19.0 cluster (security plugin enabled, basic auth)
- Adds `testmain_test.go` with `TestMain` that probes for a running cluster and `skipIfNoCluster` helper — existing unit tests always run regardless of Docker state
- Adds `testhelpers_test.go` with `newTestClient`, `cleanupResource`, `requireResourceExists`, and `requireResourceNotExists` for future resource handler integration tests

Closes #91

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes without Docker (unit tests run, integration skipped)
- [ ] `docker compose up -d --wait` then `go test ./providers/opensearch/... -v` connects to cluster
- [ ] `DATASTORECTL_TEST_ENDPOINT=https://other:9200 go test ./providers/opensearch/... -v` respects env override