### PR TITLE
feat(opensearch): add opensearch_role resource handler

### DIFF
--- a/providers/opensearch/client.go
+++ b/providers/opensearch/client.go
@@ -3,6 +3,8 @@ package opensearch
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/opensearch-project/opensearch-go/v4"
@@ -28,6 +30,22 @@ func NewClient(endpoint, username, password string) (*Client, error) {
 		return nil, err
 	}
 	return &Client{api: api}, nil
+}
+
+// do executes an HTTP request through the underlying opensearch-go transport,
+// reads the full response body, and returns it along with the status code.
+func (c *Client) do(req *http.Request) ([]byte, int, error) {
+	resp, err := c.api.Client.Perform(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return body, resp.StatusCode, nil
 }
 
 // NewSigV4Client creates an OpenSearch client that signs requests with AWS SigV4.

--- a/providers/opensearch/provider.go
+++ b/providers/opensearch/provider.go
@@ -12,7 +12,7 @@ func init() {
 	provider.Register("opensearch", func() provider.Provider {
 		return &Provider{
 			handlers: map[string]resourceHandler{
-				// Resource handlers will be registered here as they're implemented.
+				"opensearch_role": &roleHandler{},
 			},
 		}
 	})

--- a/providers/opensearch/role.go
+++ b/providers/opensearch/role.go
@@ -1,0 +1,455 @@
+package opensearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"slices"
+	"sort"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// jsonToValue converts an encoding/json unmarshaled any to a provider.Value.
+// JSON maps are sorted alphabetically by key to produce deterministic OrderedMaps.
+func jsonToValue(v any) provider.Value {
+	switch val := v.(type) {
+	case nil:
+		return provider.NullVal()
+	case string:
+		return provider.StringVal(val)
+	case bool:
+		return provider.BoolVal(val)
+	case float64:
+		if val == math.Trunc(val) && !math.IsInf(val, 0) && !math.IsNaN(val) {
+			return provider.IntVal(int64(val))
+		}
+		return provider.FloatVal(val)
+	case []any:
+		elems := make([]provider.Value, len(val))
+		for i, e := range val {
+			elems[i] = jsonToValue(e)
+		}
+		return provider.ListVal(elems)
+	case map[string]any:
+		keys := make([]string, 0, len(val))
+		for k := range val {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		m := provider.NewOrderedMap()
+		for _, k := range keys {
+			m.Set(k, jsonToValue(val[k]))
+		}
+		return provider.MapVal(m)
+	default:
+		return provider.NullVal()
+	}
+}
+
+// valueToJSON converts a provider.Value back to a Go value suitable for json.Marshal.
+func valueToJSON(v provider.Value) any {
+	switch v.Kind {
+	case provider.KindNull:
+		return nil
+	case provider.KindString:
+		return v.Str
+	case provider.KindInt:
+		return v.Int
+	case provider.KindFloat:
+		return v.Float
+	case provider.KindBool:
+		return v.Bool
+	case provider.KindList:
+		out := make([]any, len(v.List))
+		for i, e := range v.List {
+			out[i] = valueToJSON(e)
+		}
+		return out
+	case provider.KindMap:
+		out := make(map[string]any, v.Map.Len())
+		keys := v.Map.Keys()
+		for _, k := range keys {
+			val, _ := v.Map.Get(k)
+			out[k] = valueToJSON(val)
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// sortStringList returns a sorted copy of a KindList of KindString values.
+func sortStringList(v provider.Value) provider.Value {
+	if v.Kind != provider.KindList || len(v.List) == 0 {
+		return v
+	}
+	sorted := make([]provider.Value, len(v.List))
+	copy(sorted, v.List)
+	slices.SortFunc(sorted, func(a, b provider.Value) int {
+		if a.Str < b.Str {
+			return -1
+		}
+		if a.Str > b.Str {
+			return 1
+		}
+		return 0
+	})
+	return provider.ListVal(sorted)
+}
+
+// roleHandler implements resourceHandler for opensearch_role resources.
+type roleHandler struct{}
+
+// Discover fetches all non-reserved, non-hidden, non-static roles from OpenSearch.
+func (h *roleHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/_plugins/_security/api/roles/", nil)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch_role: discover: %s", err)
+	}
+
+	body, status, err := client.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch_role: discover: %s", err)
+	}
+	if status < 200 || status >= 300 {
+		return nil, fmt.Errorf("opensearch_role: discover failed (%d): %s", status, body)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("opensearch_role: discover: %s", err)
+	}
+
+	var resources []provider.Resource
+	for name, data := range raw {
+		var roleData map[string]any
+		if err := json.Unmarshal(data, &roleData); err != nil {
+			return nil, fmt.Errorf("opensearch_role: discover: failed to decode role %q: %s", name, err)
+		}
+
+		// Filter out reserved, hidden, and static roles.
+		if isTruthy(roleData, "reserved") || isTruthy(roleData, "hidden") || isTruthy(roleData, "static") {
+			continue
+		}
+
+		// Strip metadata keys.
+		delete(roleData, "reserved")
+		delete(roleData, "hidden")
+		delete(roleData, "static")
+
+		// Strip server defaults within index_permissions entries.
+		if ips, ok := roleData["index_permissions"].([]any); ok {
+			for _, entry := range ips {
+				if m, ok := entry.(map[string]any); ok {
+					stripEmptyListField(m, "fls")
+					stripEmptyListField(m, "masked_fields")
+					stripEmptyStringField(m, "dls")
+				}
+			}
+		}
+
+		// Strip top-level empty lists.
+		stripEmptyListField(roleData, "cluster_permissions")
+		stripEmptyListField(roleData, "index_permissions")
+		stripEmptyListField(roleData, "tenant_permissions")
+
+		val := jsonToValue(roleData)
+		resources = append(resources, provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_role", Name: name},
+			Body: val.Map,
+		})
+	}
+	return resources, nil
+}
+
+// Normalize sorts set-typed fields and strips empty server defaults.
+func (h *roleHandler) Normalize(_ context.Context, r provider.Resource) (provider.Resource, error) {
+	body := r.Body.Clone()
+
+	// Sort top-level cluster_permissions.
+	if v, ok := body.Get("cluster_permissions"); ok {
+		body.Set("cluster_permissions", sortStringList(v))
+	}
+
+	// Sort fields within index_permissions entries.
+	if v, ok := body.Get("index_permissions"); ok && v.Kind == provider.KindList {
+		for i, entry := range v.List {
+			if entry.Kind != provider.KindMap {
+				continue
+			}
+			m := entry.Map
+			for _, field := range []string{"index_patterns", "allowed_actions", "fls", "masked_fields"} {
+				if fv, ok := m.Get(field); ok {
+					m.Set(field, sortStringList(fv))
+				}
+			}
+			// Strip empty defaults within entries.
+			stripEmptyValueList(m, "fls")
+			stripEmptyValueList(m, "masked_fields")
+			stripEmptyValueString(m, "dls")
+			v.List[i] = provider.MapVal(m)
+		}
+		body.Set("index_permissions", v)
+	}
+
+	// Sort fields within tenant_permissions entries.
+	if v, ok := body.Get("tenant_permissions"); ok && v.Kind == provider.KindList {
+		for i, entry := range v.List {
+			if entry.Kind != provider.KindMap {
+				continue
+			}
+			m := entry.Map
+			for _, field := range []string{"tenant_patterns", "allowed_actions"} {
+				if fv, ok := m.Get(field); ok {
+					m.Set(field, sortStringList(fv))
+				}
+			}
+			v.List[i] = provider.MapVal(m)
+		}
+		body.Set("tenant_permissions", v)
+	}
+
+	// Strip empty top-level lists.
+	stripEmptyValueList(body, "cluster_permissions")
+	stripEmptyValueList(body, "index_permissions")
+	stripEmptyValueList(body, "tenant_permissions")
+
+	return provider.Resource{ID: r.ID, Body: body, SourceRange: r.SourceRange}, nil
+}
+
+// Validate checks structural correctness of a role resource.
+func (h *roleHandler) Validate(_ context.Context, r provider.Resource) error {
+	allowed := map[string]bool{
+		"cluster_permissions": true,
+		"index_permissions":   true,
+		"tenant_permissions":  true,
+	}
+
+	for _, key := range r.Body.Keys() {
+		if !allowed[key] {
+			return fmt.Errorf("opensearch_role.%s: unknown attribute %q (allowed: cluster_permissions, index_permissions, tenant_permissions)", r.ID.Name, key)
+		}
+	}
+
+	// cluster_permissions
+	if v, ok := r.Body.Get("cluster_permissions"); ok {
+		if v.Kind != provider.KindList {
+			return fmt.Errorf("opensearch_role.%s: cluster_permissions must be a list, got %s", r.ID.Name, v.Kind)
+		}
+		for i, elem := range v.List {
+			if elem.Kind != provider.KindString {
+				return fmt.Errorf("opensearch_role.%s: cluster_permissions[%d] must be a string, got %s", r.ID.Name, i, elem.Kind)
+			}
+		}
+	}
+
+	// index_permissions
+	if v, ok := r.Body.Get("index_permissions"); ok {
+		if v.Kind != provider.KindList {
+			return fmt.Errorf("opensearch_role.%s: index_permissions must be a list, got %s", r.ID.Name, v.Kind)
+		}
+		for i, elem := range v.List {
+			if elem.Kind != provider.KindMap {
+				return fmt.Errorf("opensearch_role.%s: index_permissions[%d] must be a map, got %s", r.ID.Name, i, elem.Kind)
+			}
+			if err := validateIndexPermission(r.ID.Name, i, elem.Map); err != nil {
+				return err
+			}
+		}
+	}
+
+	// tenant_permissions
+	if v, ok := r.Body.Get("tenant_permissions"); ok {
+		if v.Kind != provider.KindList {
+			return fmt.Errorf("opensearch_role.%s: tenant_permissions must be a list, got %s", r.ID.Name, v.Kind)
+		}
+		for i, elem := range v.List {
+			if elem.Kind != provider.KindMap {
+				return fmt.Errorf("opensearch_role.%s: tenant_permissions[%d] must be a map, got %s", r.ID.Name, i, elem.Kind)
+			}
+			if err := validateTenantPermission(r.ID.Name, i, elem.Map); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Apply creates, updates, or deletes a role in OpenSearch.
+func (h *roleHandler) Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error {
+	switch op {
+	case provider.OpCreate, provider.OpUpdate:
+		payload := valueToJSON(provider.MapVal(r.Body))
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("opensearch_role.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+			"/_plugins/_security/api/roles/"+r.ID.Name,
+			bytes.NewReader(data))
+		if err != nil {
+			return fmt.Errorf("opensearch_role.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return fmt.Errorf("opensearch_role.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("opensearch_role.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+		}
+		return nil
+
+	case provider.OpDelete:
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+			"/_plugins/_security/api/roles/"+r.ID.Name, nil)
+		if err != nil {
+			return fmt.Errorf("opensearch_role.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return fmt.Errorf("opensearch_role.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		if status == http.StatusNotFound {
+			return nil // already gone
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("opensearch_role.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("opensearch_role.%s: unsupported operation %s", r.ID.Name, op)
+	}
+}
+
+// --- validation helpers ---
+
+func validateIndexPermission(roleName string, idx int, m *provider.OrderedMap) error {
+	prefix := fmt.Sprintf("opensearch_role.%s: index_permissions[%d]", roleName, idx)
+
+	if err := requireStringList(prefix, m, "index_patterns"); err != nil {
+		return err
+	}
+	if err := requireStringList(prefix, m, "allowed_actions"); err != nil {
+		return err
+	}
+	if err := optionalStringList(prefix, m, "fls"); err != nil {
+		return err
+	}
+	if err := optionalStringList(prefix, m, "masked_fields"); err != nil {
+		return err
+	}
+	if v, ok := m.Get("dls"); ok && v.Kind != provider.KindString {
+		return fmt.Errorf("%s.dls must be a string, got %s", prefix, v.Kind)
+	}
+	return nil
+}
+
+func validateTenantPermission(roleName string, idx int, m *provider.OrderedMap) error {
+	prefix := fmt.Sprintf("opensearch_role.%s: tenant_permissions[%d]", roleName, idx)
+
+	if err := requireStringList(prefix, m, "tenant_patterns"); err != nil {
+		return err
+	}
+	if err := requireStringList(prefix, m, "allowed_actions"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func requireStringList(prefix string, m *provider.OrderedMap, key string) error {
+	v, ok := m.Get(key)
+	if !ok {
+		return fmt.Errorf("%s.%s is required", prefix, key)
+	}
+	if v.Kind != provider.KindList {
+		return fmt.Errorf("%s.%s must be a list, got %s", prefix, key, v.Kind)
+	}
+	for i, elem := range v.List {
+		if elem.Kind != provider.KindString {
+			return fmt.Errorf("%s.%s[%d] must be a string, got %s", prefix, key, i, elem.Kind)
+		}
+	}
+	return nil
+}
+
+func optionalStringList(prefix string, m *provider.OrderedMap, key string) error {
+	v, ok := m.Get(key)
+	if !ok {
+		return nil
+	}
+	if v.Kind != provider.KindList {
+		return fmt.Errorf("%s.%s must be a list, got %s", prefix, key, v.Kind)
+	}
+	for i, elem := range v.List {
+		if elem.Kind != provider.KindString {
+			return fmt.Errorf("%s.%s[%d] must be a string, got %s", prefix, key, i, elem.Kind)
+		}
+	}
+	return nil
+}
+
+// --- JSON/Value stripping helpers ---
+
+// isTruthy checks if a key in a raw JSON map holds a boolean true.
+func isTruthy(m map[string]any, key string) bool {
+	v, ok := m[key]
+	if !ok {
+		return false
+	}
+	b, ok := v.(bool)
+	return ok && b
+}
+
+// stripEmptyListField deletes a key from a raw JSON map if its value is an empty slice.
+func stripEmptyListField(m map[string]any, key string) {
+	v, ok := m[key]
+	if !ok {
+		return
+	}
+	if list, ok := v.([]any); ok && len(list) == 0 {
+		delete(m, key)
+	}
+}
+
+// stripEmptyStringField deletes a key from a raw JSON map if its value is an empty string.
+func stripEmptyStringField(m map[string]any, key string) {
+	v, ok := m[key]
+	if !ok {
+		return
+	}
+	if s, ok := v.(string); ok && s == "" {
+		delete(m, key)
+	}
+}
+
+// stripEmptyValueList deletes a key from an OrderedMap if its value is an empty list.
+func stripEmptyValueList(m *provider.OrderedMap, key string) {
+	v, ok := m.Get(key)
+	if !ok {
+		return
+	}
+	if v.Kind == provider.KindList && len(v.List) == 0 {
+		m.Delete(key)
+	}
+}
+
+// stripEmptyValueString deletes a key from an OrderedMap if its value is an empty string.
+func stripEmptyValueString(m *provider.OrderedMap, key string) {
+	v, ok := m.Get(key)
+	if !ok {
+		return
+	}
+	if v.Kind == provider.KindString && v.Str == "" {
+		m.Delete(key)
+	}
+}

--- a/providers/opensearch/role_test.go
+++ b/providers/opensearch/role_test.go
@@ -1,0 +1,489 @@
+package opensearch
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// --- Unit tests (no cluster needed) ---
+
+func TestNormalize_sorts_permissions(t *testing.T) {
+	h := &roleHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_role", Name: "test"},
+		Body: buildMap(
+			"cluster_permissions", provider.ListVal([]provider.Value{
+				provider.StringVal("cluster_composite_ops"),
+				provider.StringVal("cluster_monitor"),
+				provider.StringVal("cluster_all"),
+			}),
+			"index_permissions", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"index_patterns", provider.ListVal([]provider.Value{
+						provider.StringVal("z-index"),
+						provider.StringVal("a-index"),
+					}),
+					"allowed_actions", provider.ListVal([]provider.Value{
+						provider.StringVal("write"),
+						provider.StringVal("read"),
+					}),
+					"fls", provider.ListVal([]provider.Value{
+						provider.StringVal("field_b"),
+						provider.StringVal("field_a"),
+					}),
+					"masked_fields", provider.ListVal([]provider.Value{
+						provider.StringVal("mask_z"),
+						provider.StringVal("mask_a"),
+					}),
+				)),
+			}),
+			"tenant_permissions", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"tenant_patterns", provider.ListVal([]provider.Value{
+						provider.StringVal("z-tenant"),
+						provider.StringVal("a-tenant"),
+					}),
+					"allowed_actions", provider.ListVal([]provider.Value{
+						provider.StringVal("kibana_all_write"),
+						provider.StringVal("kibana_all_read"),
+					}),
+				)),
+			}),
+		),
+	}
+
+	result, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Normalize failed: %v", err)
+	}
+
+	// cluster_permissions should be sorted
+	assertStringListOrder(t, result.Body, "cluster_permissions",
+		[]string{"cluster_all", "cluster_composite_ops", "cluster_monitor"})
+
+	// index_permissions fields should be sorted
+	ip, _ := result.Body.Get("index_permissions")
+	entry := ip.List[0].Map
+	assertStringListOrder(t, entry, "index_patterns", []string{"a-index", "z-index"})
+	assertStringListOrder(t, entry, "allowed_actions", []string{"read", "write"})
+	assertStringListOrder(t, entry, "fls", []string{"field_a", "field_b"})
+	assertStringListOrder(t, entry, "masked_fields", []string{"mask_a", "mask_z"})
+
+	// tenant_permissions fields should be sorted
+	tp, _ := result.Body.Get("tenant_permissions")
+	tEntry := tp.List[0].Map
+	assertStringListOrder(t, tEntry, "tenant_patterns", []string{"a-tenant", "z-tenant"})
+	assertStringListOrder(t, tEntry, "allowed_actions", []string{"kibana_all_read", "kibana_all_write"})
+}
+
+func TestNormalize_strips_empty_defaults(t *testing.T) {
+	h := &roleHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_role", Name: "test"},
+		Body: buildMap(
+			"cluster_permissions", provider.ListVal(nil),
+			"index_permissions", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"index_patterns", provider.ListVal([]provider.Value{provider.StringVal("my-index")}),
+					"allowed_actions", provider.ListVal([]provider.Value{provider.StringVal("read")}),
+					"fls", provider.ListVal(nil),
+					"masked_fields", provider.ListVal(nil),
+					"dls", provider.StringVal(""),
+				)),
+			}),
+			"tenant_permissions", provider.ListVal(nil),
+		),
+	}
+
+	result, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Normalize failed: %v", err)
+	}
+
+	// Empty top-level lists should be stripped.
+	if _, ok := result.Body.Get("cluster_permissions"); ok {
+		t.Error("expected cluster_permissions to be stripped")
+	}
+	if _, ok := result.Body.Get("tenant_permissions"); ok {
+		t.Error("expected tenant_permissions to be stripped")
+	}
+
+	// The index_permissions entry should have fls, masked_fields, dls stripped.
+	ip, ok := result.Body.Get("index_permissions")
+	if !ok {
+		t.Fatal("expected index_permissions to remain (has one entry)")
+	}
+	entry := ip.List[0].Map
+	if _, ok := entry.Get("fls"); ok {
+		t.Error("expected fls to be stripped from index_permissions entry")
+	}
+	if _, ok := entry.Get("masked_fields"); ok {
+		t.Error("expected masked_fields to be stripped from index_permissions entry")
+	}
+	if _, ok := entry.Get("dls"); ok {
+		t.Error("expected dls to be stripped from index_permissions entry")
+	}
+}
+
+func TestNormalize_idempotent(t *testing.T) {
+	h := &roleHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_role", Name: "test"},
+		Body: buildMap(
+			"cluster_permissions", provider.ListVal([]provider.Value{
+				provider.StringVal("cluster_composite_ops"),
+				provider.StringVal("cluster_monitor"),
+			}),
+			"index_permissions", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"index_patterns", provider.ListVal([]provider.Value{provider.StringVal("b"), provider.StringVal("a")}),
+					"allowed_actions", provider.ListVal([]provider.Value{provider.StringVal("write")}),
+				)),
+			}),
+		),
+	}
+
+	first, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("first Normalize failed: %v", err)
+	}
+	second, err := h.Normalize(context.Background(), first)
+	if err != nil {
+		t.Fatalf("second Normalize failed: %v", err)
+	}
+
+	if !first.Body.Equal(second.Body) {
+		t.Errorf("Normalize is not idempotent:\nfirst:  %s\nsecond: %s",
+			provider.MapVal(first.Body), provider.MapVal(second.Body))
+	}
+}
+
+func TestValidate_valid_role(t *testing.T) {
+	h := &roleHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_role", Name: "good_role"},
+		Body: buildMap(
+			"cluster_permissions", provider.ListVal([]provider.Value{
+				provider.StringVal("cluster_monitor"),
+			}),
+			"index_permissions", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"index_patterns", provider.ListVal([]provider.Value{provider.StringVal("my-index")}),
+					"allowed_actions", provider.ListVal([]provider.Value{provider.StringVal("read")}),
+					"dls", provider.StringVal("{\"match\": {\"field\": \"value\"}}"),
+					"fls", provider.ListVal([]provider.Value{provider.StringVal("field1")}),
+					"masked_fields", provider.ListVal([]provider.Value{provider.StringVal("ssn")}),
+				)),
+			}),
+			"tenant_permissions", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"tenant_patterns", provider.ListVal([]provider.Value{provider.StringVal("my_tenant")}),
+					"allowed_actions", provider.ListVal([]provider.Value{provider.StringVal("kibana_all_write")}),
+				)),
+			}),
+		),
+	}
+
+	if err := h.Validate(context.Background(), r); err != nil {
+		t.Errorf("expected valid role to pass, got: %v", err)
+	}
+}
+
+func TestValidate_cluster_permissions_wrong_type(t *testing.T) {
+	h := &roleHandler{}
+	r := provider.Resource{
+		ID:   provider.ResourceID{Type: "opensearch_role", Name: "bad_role"},
+		Body: buildMap("cluster_permissions", provider.StringVal("not_a_list")),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for non-list cluster_permissions")
+	}
+}
+
+func TestValidate_index_permissions_not_maps(t *testing.T) {
+	h := &roleHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_role", Name: "bad_role"},
+		Body: buildMap(
+			"index_permissions", provider.ListVal([]provider.Value{
+				provider.StringVal("not_a_map"),
+			}),
+		),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for non-map index_permissions entries")
+	}
+}
+
+func TestValidate_unknown_attribute(t *testing.T) {
+	h := &roleHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_role", Name: "bad_role"},
+		Body: buildMap(
+			"bogus", provider.StringVal("unexpected"),
+		),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for unknown attribute")
+	}
+}
+
+func TestJsonToValue_roundtrip(t *testing.T) {
+	original := map[string]any{
+		"cluster_permissions": []any{"cluster_monitor", "cluster_all"},
+		"index_permissions": []any{
+			map[string]any{
+				"index_patterns":  []any{"logs-*", "metrics-*"},
+				"allowed_actions": []any{"read", "search"},
+				"dls":             "",
+			},
+		},
+		"count": float64(42),
+		"flag":  true,
+	}
+
+	val := jsonToValue(original)
+	roundtripped := valueToJSON(val)
+
+	origJSON, _ := json.Marshal(original)
+	rtJSON, _ := json.Marshal(roundtripped)
+
+	// Re-unmarshal both to compare as maps (JSON key ordering can differ in Marshal).
+	var origMap, rtMap map[string]any
+	json.Unmarshal(origJSON, &origMap)
+	json.Unmarshal(rtJSON, &rtMap)
+
+	origNorm, _ := json.Marshal(origMap)
+	rtNorm, _ := json.Marshal(rtMap)
+
+	if string(origNorm) != string(rtNorm) {
+		t.Errorf("roundtrip mismatch:\noriginal:     %s\nroundtripped: %s", origNorm, rtNorm)
+	}
+}
+
+// --- Integration tests ---
+
+func TestRoleHandler_Integration(t *testing.T) {
+	client := newTestClient(t)
+	h := &roleHandler{}
+	roleName := "datastorectl_test_role"
+	cleanupResource(t, client, "opensearch_role", roleName)
+
+	ctx := context.Background()
+
+	t.Run("create", func(t *testing.T) {
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_role", Name: roleName},
+			Body: buildMap(
+				"cluster_permissions", provider.ListVal([]provider.Value{
+					provider.StringVal("cluster_monitor"),
+				}),
+				"index_permissions", provider.ListVal([]provider.Value{
+					provider.MapVal(buildMap(
+						"index_patterns", provider.ListVal([]provider.Value{provider.StringVal("logs-*")}),
+						"allowed_actions", provider.ListVal([]provider.Value{provider.StringVal("read")}),
+					)),
+				}),
+			),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpCreate, r); err != nil {
+			t.Fatalf("Apply OpCreate failed: %v", err)
+		}
+		requireResourceExists(t, client, "opensearch_role", roleName)
+	})
+
+	t.Run("discover_after_create", func(t *testing.T) {
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == roleName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("expected to find role %q in discovered resources", roleName)
+		}
+
+		// Verify body has the expected keys.
+		if _, ok := found.Body.Get("cluster_permissions"); !ok {
+			t.Error("discovered role missing cluster_permissions")
+		}
+		if _, ok := found.Body.Get("index_permissions"); !ok {
+			t.Error("discovered role missing index_permissions")
+		}
+	})
+
+	t.Run("normalize_roundtrip", func(t *testing.T) {
+		// Build the DCL-side resource with keys in alphabetical order
+		// to match jsonToValue's sorted-key output from Discover.
+		dclResource := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_role", Name: roleName},
+			Body: buildMap(
+				"cluster_permissions", provider.ListVal([]provider.Value{
+					provider.StringVal("cluster_monitor"),
+				}),
+				"index_permissions", provider.ListVal([]provider.Value{
+					provider.MapVal(buildMap(
+						"allowed_actions", provider.ListVal([]provider.Value{provider.StringVal("read")}),
+						"index_patterns", provider.ListVal([]provider.Value{provider.StringVal("logs-*")}),
+					)),
+				}),
+			),
+		}
+
+		// Discover and find our role.
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+		var discovered provider.Resource
+		for _, r := range resources {
+			if r.ID.Name == roleName {
+				discovered = r
+				break
+			}
+		}
+
+		normalizedDCL, err := h.Normalize(ctx, dclResource)
+		if err != nil {
+			t.Fatalf("Normalize DCL resource failed: %v", err)
+		}
+		normalizedAPI, err := h.Normalize(ctx, discovered)
+		if err != nil {
+			t.Fatalf("Normalize discovered resource failed: %v", err)
+		}
+
+		if !normalizedDCL.Body.Equal(normalizedAPI.Body) {
+			t.Errorf("normalized bodies do not match:\nDCL: %s\nAPI: %s",
+				provider.MapVal(normalizedDCL.Body), provider.MapVal(normalizedAPI.Body))
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_role", Name: roleName},
+			Body: buildMap(
+				"cluster_permissions", provider.ListVal([]provider.Value{
+					provider.StringVal("cluster_monitor"),
+					provider.StringVal("cluster_composite_ops"),
+				}),
+				"index_permissions", provider.ListVal([]provider.Value{
+					provider.MapVal(buildMap(
+						"index_patterns", provider.ListVal([]provider.Value{provider.StringVal("logs-*")}),
+						"allowed_actions", provider.ListVal([]provider.Value{provider.StringVal("read")}),
+					)),
+				}),
+			),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpUpdate, r); err != nil {
+			t.Fatalf("Apply OpUpdate failed: %v", err)
+		}
+
+		// Re-discover and verify the update.
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover after update failed: %v", err)
+		}
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == roleName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("role %q not found after update", roleName)
+		}
+
+		cp, ok := found.Body.Get("cluster_permissions")
+		if !ok {
+			t.Fatal("cluster_permissions missing after update")
+		}
+		if len(cp.List) != 2 {
+			t.Errorf("expected 2 cluster_permissions after update, got %d", len(cp.List))
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_role", Name: roleName},
+			Body: provider.NewOrderedMap(),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpDelete, r); err != nil {
+			t.Fatalf("Apply OpDelete failed: %v", err)
+		}
+		requireResourceNotExists(t, client, "opensearch_role", roleName)
+	})
+
+	t.Run("discover_excludes_reserved", func(t *testing.T) {
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+
+		builtins := map[string]bool{
+			"all_access":   true,
+			"kibana_user":  true,
+		}
+
+		for _, r := range resources {
+			if builtins[r.ID.Name] {
+				t.Errorf("discovered built-in reserved role %q — should have been filtered", r.ID.Name)
+			}
+			if v, ok := r.Body.Get("reserved"); ok {
+				t.Errorf("role %q has 'reserved' key in body: %s", r.ID.Name, v)
+			}
+		}
+	})
+}
+
+// --- test helpers ---
+
+// buildMap constructs an *OrderedMap from alternating key, value pairs.
+func buildMap(kvs ...any) *provider.OrderedMap {
+	m := provider.NewOrderedMap()
+	for i := 0; i < len(kvs); i += 2 {
+		m.Set(kvs[i].(string), kvs[i+1].(provider.Value))
+	}
+	return m
+}
+
+// assertStringListOrder asserts a key in an OrderedMap holds a list of strings in the expected order.
+func assertStringListOrder(t *testing.T, m *provider.OrderedMap, key string, expected []string) {
+	t.Helper()
+	v, ok := m.Get(key)
+	if !ok {
+		t.Errorf("expected key %q to exist", key)
+		return
+	}
+	if v.Kind != provider.KindList {
+		t.Errorf("expected %q to be a list, got %s", key, v.Kind)
+		return
+	}
+	if len(v.List) != len(expected) {
+		t.Errorf("%q: expected %d elements, got %d", key, len(expected), len(v.List))
+		return
+	}
+	for i, want := range expected {
+		if v.List[i].Str != want {
+			t.Errorf("%q[%d]: expected %q, got %q", key, i, want, v.List[i].Str)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds the first resource handler (`opensearch_role`) for the opensearch provider, implementing the full Discover -> Normalize -> Validate -> Apply lifecycle
- Adds `Client.do()` shared HTTP helper and `jsonToValue`/`valueToJSON` conversion helpers that future handlers (#93+) will reuse
- Includes unit tests (Normalize, Validate, JSON roundtrip) and Docker-based integration tests (CRUD lifecycle, reserved-role filtering)

Closes #92

## Test plan

- [x] `go vet ./...` passes
- [x] Unit tests pass: `go test ./providers/opensearch/... -run 'TestNormalize|TestValidate|TestJson'`
- [x] Integration tests pass against Docker cluster: `go test ./providers/opensearch/... -run TestRoleHandler`
- [x] Full suite passes: `go test ./... -count=1`
- [x] Verify integration tests skip cleanly without Docker: `go test ./providers/opensearch/... -v -run TestRoleHandler` (no cluster)