### PR TITLE
feat(opensearch): add opensearch_role_mapping resource handler

### DIFF
--- a/providers/opensearch/provider.go
+++ b/providers/opensearch/provider.go
@@ -14,6 +14,7 @@ func init() {
 			handlers: map[string]resourceHandler{
 				"opensearch_role":          &roleHandler{},
 				"opensearch_internal_user": &internalUserHandler{},
+				"opensearch_role_mapping":  &roleMappingHandler{},
 			},
 		}
 	})

--- a/providers/opensearch/role_mapping.go
+++ b/providers/opensearch/role_mapping.go
@@ -1,0 +1,196 @@
+package opensearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// roleMappingHandler implements resourceHandler for opensearch_role_mapping resources.
+type roleMappingHandler struct{}
+
+// Discover fetches all non-reserved, non-hidden, non-static role mappings from OpenSearch.
+func (h *roleMappingHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/_plugins/_security/api/rolesmapping/", nil)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch_role_mapping: discover: %s", err)
+	}
+
+	body, status, err := client.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch_role_mapping: discover: %s", err)
+	}
+	if status < 200 || status >= 300 {
+		return nil, fmt.Errorf("opensearch_role_mapping: discover failed (%d): %s", status, body)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("opensearch_role_mapping: discover: %s", err)
+	}
+
+	var resources []provider.Resource
+	for name, data := range raw {
+		var mappingData map[string]any
+		if err := json.Unmarshal(data, &mappingData); err != nil {
+			return nil, fmt.Errorf("opensearch_role_mapping: discover: failed to decode mapping %q: %s", name, err)
+		}
+
+		// Filter out reserved, hidden, and static mappings.
+		if isTruthy(mappingData, "reserved") || isTruthy(mappingData, "hidden") || isTruthy(mappingData, "static") {
+			continue
+		}
+
+		// Strip metadata keys.
+		delete(mappingData, "reserved")
+		delete(mappingData, "hidden")
+		delete(mappingData, "static")
+
+		// Strip empty defaults.
+		stripEmptyListField(mappingData, "backend_roles")
+		stripEmptyListField(mappingData, "hosts")
+		stripEmptyListField(mappingData, "users")
+		stripEmptyListField(mappingData, "and_backend_roles")
+		stripEmptyStringField(mappingData, "description")
+
+		val := jsonToValue(mappingData)
+		resources = append(resources, provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_role_mapping", Name: name},
+			Body: val.Map,
+		})
+	}
+	return resources, nil
+}
+
+// Normalize sorts set-typed fields and strips empty server defaults.
+func (h *roleMappingHandler) Normalize(_ context.Context, r provider.Resource) (provider.Resource, error) {
+	body := r.Body.Clone()
+
+	// Sort list fields.
+	if v, ok := body.Get("backend_roles"); ok {
+		body.Set("backend_roles", sortStringList(v))
+	}
+	if v, ok := body.Get("hosts"); ok {
+		body.Set("hosts", sortStringList(v))
+	}
+	if v, ok := body.Get("users"); ok {
+		body.Set("users", sortStringList(v))
+	}
+	if v, ok := body.Get("and_backend_roles"); ok {
+		body.Set("and_backend_roles", sortStringList(v))
+	}
+
+	// Strip empty defaults.
+	stripEmptyValueList(body, "backend_roles")
+	stripEmptyValueList(body, "hosts")
+	stripEmptyValueList(body, "users")
+	stripEmptyValueList(body, "and_backend_roles")
+	stripEmptyValueString(body, "description")
+
+	return provider.Resource{ID: r.ID, Body: body, SourceRange: r.SourceRange}, nil
+}
+
+// Validate checks structural correctness of a role mapping resource.
+func (h *roleMappingHandler) Validate(_ context.Context, r provider.Resource) error {
+	allowed := map[string]bool{
+		"backend_roles":     true,
+		"hosts":             true,
+		"users":             true,
+		"and_backend_roles": true,
+		"description":       true,
+	}
+
+	prefix := fmt.Sprintf("opensearch_role_mapping.%s", r.ID.Name)
+
+	for _, key := range r.Body.Keys() {
+		if !allowed[key] {
+			return fmt.Errorf("%s: unknown attribute %q (allowed: backend_roles, hosts, users, and_backend_roles, description)", prefix, key)
+		}
+	}
+
+	// backend_roles — optional list of strings.
+	if err := optionalStringList(prefix, r.Body, "backend_roles"); err != nil {
+		return err
+	}
+
+	// hosts — optional list of strings.
+	if err := optionalStringList(prefix, r.Body, "hosts"); err != nil {
+		return err
+	}
+
+	// users — optional list of strings.
+	if err := optionalStringList(prefix, r.Body, "users"); err != nil {
+		return err
+	}
+
+	// and_backend_roles — optional list of strings.
+	if err := optionalStringList(prefix, r.Body, "and_backend_roles"); err != nil {
+		return err
+	}
+
+	// description — optional string.
+	if v, ok := r.Body.Get("description"); ok && v.Kind != provider.KindString {
+		return fmt.Errorf("%s: description must be a string, got %s", prefix, v.Kind)
+	}
+
+	// TODO: Consider warning when all three of backend_roles, users, hosts are absent/empty.
+	// The handler interface returns error, not dcl.Diagnostics, so we cannot
+	// emit a warning today.
+
+	return nil
+}
+
+// Apply creates, updates, or deletes a role mapping in OpenSearch.
+func (h *roleMappingHandler) Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error {
+	switch op {
+	case provider.OpCreate, provider.OpUpdate:
+		payload := valueToJSON(provider.MapVal(r.Body))
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("opensearch_role_mapping.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+			"/_plugins/_security/api/rolesmapping/"+r.ID.Name,
+			bytes.NewReader(data))
+		if err != nil {
+			return fmt.Errorf("opensearch_role_mapping.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return fmt.Errorf("opensearch_role_mapping.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("opensearch_role_mapping.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+		}
+		return nil
+
+	case provider.OpDelete:
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+			"/_plugins/_security/api/rolesmapping/"+r.ID.Name, nil)
+		if err != nil {
+			return fmt.Errorf("opensearch_role_mapping.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return fmt.Errorf("opensearch_role_mapping.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		if status == http.StatusNotFound {
+			return nil // already gone
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("opensearch_role_mapping.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("opensearch_role_mapping.%s: unsupported operation %s", r.ID.Name, op)
+	}
+}

--- a/providers/opensearch/role_mapping_test.go
+++ b/providers/opensearch/role_mapping_test.go
@@ -1,0 +1,357 @@
+package opensearch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// --- Unit tests (no cluster needed) ---
+
+func TestRoleMappingNormalize_sorts_lists(t *testing.T) {
+	h := &roleMappingHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_role_mapping", Name: "test"},
+		Body: buildMap(
+			"backend_roles", provider.ListVal([]provider.Value{
+				provider.StringVal("arn:aws:iam::222222222:role/beta"),
+				provider.StringVal("arn:aws:iam::111111111:role/alpha"),
+			}),
+			"hosts", provider.ListVal([]provider.Value{
+				provider.StringVal("host-z"),
+				provider.StringVal("host-a"),
+			}),
+			"users", provider.ListVal([]provider.Value{
+				provider.StringVal("user_b"),
+				provider.StringVal("user_a"),
+			}),
+		),
+	}
+
+	result, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Normalize failed: %v", err)
+	}
+
+	assertStringListOrder(t, result.Body, "backend_roles", []string{
+		"arn:aws:iam::111111111:role/alpha",
+		"arn:aws:iam::222222222:role/beta",
+	})
+	assertStringListOrder(t, result.Body, "hosts", []string{"host-a", "host-z"})
+	assertStringListOrder(t, result.Body, "users", []string{"user_a", "user_b"})
+}
+
+func TestRoleMappingNormalize_strips_empty_defaults(t *testing.T) {
+	h := &roleMappingHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_role_mapping", Name: "test"},
+		Body: buildMap(
+			"backend_roles", provider.ListVal(nil),
+			"hosts", provider.ListVal(nil),
+			"users", provider.ListVal(nil),
+			"and_backend_roles", provider.ListVal(nil),
+			"description", provider.StringVal(""),
+		),
+	}
+
+	result, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Normalize failed: %v", err)
+	}
+
+	for _, key := range []string{"backend_roles", "hosts", "users", "and_backend_roles", "description"} {
+		if _, ok := result.Body.Get(key); ok {
+			t.Errorf("expected %s to be stripped", key)
+		}
+	}
+}
+
+func TestRoleMappingNormalize_idempotent(t *testing.T) {
+	h := &roleMappingHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_role_mapping", Name: "test"},
+		Body: buildMap(
+			"backend_roles", provider.ListVal([]provider.Value{
+				provider.StringVal("role_b"),
+				provider.StringVal("role_a"),
+			}),
+			"description", provider.StringVal("a test mapping"),
+		),
+	}
+
+	first, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("first Normalize failed: %v", err)
+	}
+	second, err := h.Normalize(context.Background(), first)
+	if err != nil {
+		t.Fatalf("second Normalize failed: %v", err)
+	}
+
+	if !first.Body.Equal(second.Body) {
+		t.Errorf("Normalize is not idempotent:\nfirst:  %s\nsecond: %s",
+			provider.MapVal(first.Body), provider.MapVal(second.Body))
+	}
+}
+
+func TestRoleMappingValidate_valid_mapping(t *testing.T) {
+	h := &roleMappingHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_role_mapping", Name: "good_mapping"},
+		Body: buildMap(
+			"backend_roles", provider.ListVal([]provider.Value{
+				provider.StringVal("arn:aws:iam::123456789:role/test"),
+			}),
+			"hosts", provider.ListVal([]provider.Value{
+				provider.StringVal("*.example.com"),
+			}),
+			"users", provider.ListVal([]provider.Value{
+				provider.StringVal("admin"),
+			}),
+			"and_backend_roles", provider.ListVal([]provider.Value{
+				provider.StringVal("extra_role"),
+			}),
+			"description", provider.StringVal("a test mapping"),
+		),
+	}
+
+	if err := h.Validate(context.Background(), r); err != nil {
+		t.Errorf("expected valid mapping to pass, got: %v", err)
+	}
+}
+
+func TestRoleMappingValidate_unknown_attribute(t *testing.T) {
+	h := &roleMappingHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_role_mapping", Name: "bad_mapping"},
+		Body: buildMap(
+			"bogus", provider.StringVal("unexpected"),
+		),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for unknown attribute")
+	}
+}
+
+func TestRoleMappingValidate_backend_roles_wrong_type(t *testing.T) {
+	h := &roleMappingHandler{}
+	r := provider.Resource{
+		ID:   provider.ResourceID{Type: "opensearch_role_mapping", Name: "bad_mapping"},
+		Body: buildMap("backend_roles", provider.StringVal("not_a_list")),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for non-list backend_roles")
+	}
+}
+
+func TestRoleMappingValidate_description_wrong_type(t *testing.T) {
+	h := &roleMappingHandler{}
+	r := provider.Resource{
+		ID:   provider.ResourceID{Type: "opensearch_role_mapping", Name: "bad_mapping"},
+		Body: buildMap("description", provider.IntVal(42)),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for non-string description")
+	}
+}
+
+// --- Integration tests ---
+
+func TestRoleMappingHandler_Integration(t *testing.T) {
+	client := newTestClient(t)
+	rh := &roleHandler{}
+	mh := &roleMappingHandler{}
+	roleName := "datastorectl_test_mapping_role"
+	mappingName := roleName // mapping named after the role
+	cleanupResource(t, client, "opensearch_role_mapping", mappingName)
+	cleanupResource(t, client, "opensearch_role", roleName)
+
+	ctx := context.Background()
+
+	t.Run("create_prerequisite_role", func(t *testing.T) {
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_role", Name: roleName},
+			Body: buildMap(
+				"cluster_permissions", provider.ListVal([]provider.Value{
+					provider.StringVal("cluster_monitor"),
+				}),
+			),
+		}
+
+		if err := rh.Apply(ctx, client, provider.OpCreate, r); err != nil {
+			t.Fatalf("Apply OpCreate for prerequisite role failed: %v", err)
+		}
+		requireResourceExists(t, client, "opensearch_role", roleName)
+	})
+
+	t.Run("create", func(t *testing.T) {
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_role_mapping", Name: mappingName},
+			Body: buildMap(
+				"backend_roles", provider.ListVal([]provider.Value{
+					provider.StringVal("arn:aws:iam::123456789:role/test"),
+				}),
+				"description", provider.StringVal("test mapping"),
+			),
+		}
+
+		if err := mh.Apply(ctx, client, provider.OpCreate, r); err != nil {
+			t.Fatalf("Apply OpCreate failed: %v", err)
+		}
+		requireResourceExists(t, client, "opensearch_role_mapping", mappingName)
+	})
+
+	t.Run("discover_after_create", func(t *testing.T) {
+		resources, err := mh.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == mappingName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("expected to find mapping %q in discovered resources", mappingName)
+		}
+
+		// Verify expected fields present.
+		if _, ok := found.Body.Get("backend_roles"); !ok {
+			t.Error("discovered mapping missing backend_roles")
+		}
+		if _, ok := found.Body.Get("description"); !ok {
+			t.Error("discovered mapping missing description")
+		}
+
+		// Verify metadata is stripped.
+		for _, key := range []string{"reserved", "hidden", "static"} {
+			if _, ok := found.Body.Get(key); ok {
+				t.Errorf("discovered mapping should not have %q", key)
+			}
+		}
+	})
+
+	t.Run("normalize_roundtrip", func(t *testing.T) {
+		// DCL resource with keys in alphabetical order to match jsonToValue output.
+		dclResource := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_role_mapping", Name: mappingName},
+			Body: buildMap(
+				"backend_roles", provider.ListVal([]provider.Value{
+					provider.StringVal("arn:aws:iam::123456789:role/test"),
+				}),
+				"description", provider.StringVal("test mapping"),
+			),
+		}
+
+		// Discover and find our mapping.
+		resources, err := mh.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+		var discovered provider.Resource
+		for _, r := range resources {
+			if r.ID.Name == mappingName {
+				discovered = r
+				break
+			}
+		}
+
+		normalizedDCL, err := mh.Normalize(ctx, dclResource)
+		if err != nil {
+			t.Fatalf("Normalize DCL resource failed: %v", err)
+		}
+		normalizedAPI, err := mh.Normalize(ctx, discovered)
+		if err != nil {
+			t.Fatalf("Normalize discovered resource failed: %v", err)
+		}
+
+		if !normalizedDCL.Body.Equal(normalizedAPI.Body) {
+			t.Errorf("normalized bodies do not match:\nDCL: %s\nAPI: %s",
+				provider.MapVal(normalizedDCL.Body), provider.MapVal(normalizedAPI.Body))
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_role_mapping", Name: mappingName},
+			Body: buildMap(
+				"backend_roles", provider.ListVal([]provider.Value{
+					provider.StringVal("arn:aws:iam::123456789:role/test"),
+				}),
+				"users", provider.ListVal([]provider.Value{
+					provider.StringVal("test_user"),
+				}),
+				"description", provider.StringVal("test mapping"),
+			),
+		}
+
+		if err := mh.Apply(ctx, client, provider.OpUpdate, r); err != nil {
+			t.Fatalf("Apply OpUpdate failed: %v", err)
+		}
+
+		// Re-discover and verify the update.
+		resources, err := mh.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover after update failed: %v", err)
+		}
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == mappingName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("mapping %q not found after update", mappingName)
+		}
+
+		users, ok := found.Body.Get("users")
+		if !ok {
+			t.Fatal("users missing after update")
+		}
+		if len(users.List) != 1 {
+			t.Errorf("expected 1 user after update, got %d", len(users.List))
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_role_mapping", Name: mappingName},
+			Body: provider.NewOrderedMap(),
+		}
+
+		if err := mh.Apply(ctx, client, provider.OpDelete, r); err != nil {
+			t.Fatalf("Apply OpDelete failed: %v", err)
+		}
+		requireResourceNotExists(t, client, "opensearch_role_mapping", mappingName)
+	})
+
+	t.Run("discover_excludes_reserved", func(t *testing.T) {
+		resources, err := mh.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+
+		for _, r := range resources {
+			if v, ok := r.Body.Get("reserved"); ok {
+				t.Errorf("mapping %q has 'reserved' key in body: %s", r.ID.Name, v)
+			}
+			if v, ok := r.Body.Get("hidden"); ok {
+				t.Errorf("mapping %q has 'hidden' key in body: %s", r.ID.Name, v)
+			}
+			if v, ok := r.Body.Get("static"); ok {
+				t.Errorf("mapping %q has 'static' key in body: %s", r.ID.Name, v)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `roleMappingHandler` implementing `resourceHandler` for `opensearch_role_mapping` resources — discover, normalize, validate, and apply operations
- Registers handler in `provider.go` init (type orderings already declared)
- Adds 7 unit tests (normalize sorting/stripping/idempotency, validate valid/unknown/wrong-type) and 7 integration subtests (create prerequisite role, create/discover/normalize-roundtrip/update/delete mapping, discover excludes reserved metadata)

Closes #94

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./providers/opensearch/... -v -run TestRoleMapping` — all 7 unit + 7 integration tests pass
- [x] `go test ./providers/opensearch/... -v -count=1` — all existing tests unbroken (36 total)
- [x] `go test ./... -count=1` — full suite green