### PR TITLE
feat(opensearch): add opensearch_ism_policy resource handler

### DIFF
--- a/providers/opensearch/ism_policy.go
+++ b/providers/opensearch/ism_policy.go
@@ -1,0 +1,281 @@
+package opensearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"slices"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// ismPolicyHandler implements resourceHandler for opensearch_ism_policy resources.
+type ismPolicyHandler struct{}
+
+// Discover fetches all ISM policies from OpenSearch, handling pagination.
+func (h *ismPolicyHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
+	var resources []provider.Resource
+	const pageSize = 50
+
+	for from := 0; ; {
+		url := fmt.Sprintf("/_plugins/_ism/policies?size=%d&from=%d", pageSize, from)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("opensearch_ism_policy: discover: %s", err)
+		}
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return nil, fmt.Errorf("opensearch_ism_policy: discover: %s", err)
+		}
+		if status < 200 || status >= 300 {
+			return nil, fmt.Errorf("opensearch_ism_policy: discover failed (%d): %s", status, body)
+		}
+
+		var resp ismListResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("opensearch_ism_policy: discover: %s", err)
+		}
+
+		for _, entry := range resp.Policies {
+			policyData := entry.Policy
+
+			// Strip server-injected metadata.
+			delete(policyData, "policy_id")
+			delete(policyData, "last_updated_time")
+			delete(policyData, "schema_version")
+
+			// Strip error_notification if null.
+			if v, ok := policyData["error_notification"]; ok && v == nil {
+				delete(policyData, "error_notification")
+			}
+
+			// Strip last_updated_time from ism_template entries.
+			if templates, ok := policyData["ism_template"].([]any); ok {
+				for _, tmpl := range templates {
+					if m, ok := tmpl.(map[string]any); ok {
+						delete(m, "last_updated_time")
+					}
+				}
+			}
+			stripEmptyListField(policyData, "ism_template")
+
+			val := jsonToValue(policyData)
+			resources = append(resources, provider.Resource{
+				ID:   provider.ResourceID{Type: "opensearch_ism_policy", Name: entry.ID},
+				Body: val.Map,
+			})
+		}
+
+		from += len(resp.Policies)
+		if from >= resp.TotalPolicies || len(resp.Policies) == 0 {
+			break
+		}
+	}
+
+	return resources, nil
+}
+
+// ismListResponse is the envelope returned by GET /_plugins/_ism/policies.
+type ismListResponse struct {
+	Policies []struct {
+		ID     string         `json:"_id"`
+		Policy map[string]any `json:"policy"`
+	} `json:"policies"`
+	TotalPolicies int `json:"total_policies"`
+}
+
+// Normalize strips server-injected metadata and sorts ism_template entries.
+// State order is preserved — sequence matters for the ISM state machine.
+func (h *ismPolicyHandler) Normalize(_ context.Context, r provider.Resource) (provider.Resource, error) {
+	body := r.Body.Clone()
+
+	// Strip server-injected metadata (belt-and-suspenders for Discover).
+	body.Delete("policy_id")
+	body.Delete("last_updated_time")
+	body.Delete("schema_version")
+
+	// Strip error_notification if null.
+	if v, ok := body.Get("error_notification"); ok && v.Kind == provider.KindNull {
+		body.Delete("error_notification")
+	}
+
+	// Process ism_template entries: strip last_updated_time and sort.
+	if v, ok := body.Get("ism_template"); ok && v.Kind == provider.KindList {
+		for i, entry := range v.List {
+			if entry.Kind == provider.KindMap {
+				m := entry.Map.Clone()
+				m.Delete("last_updated_time")
+				v.List[i] = provider.MapVal(m)
+			}
+		}
+
+		// Sort ism_template entries for deterministic diffs.
+		if len(v.List) > 1 {
+			slices.SortFunc(v.List, func(a, b provider.Value) int {
+				aj, _ := json.Marshal(valueToJSON(a))
+				bj, _ := json.Marshal(valueToJSON(b))
+				return bytes.Compare(aj, bj)
+			})
+		}
+
+		body.Set("ism_template", v)
+	}
+	stripEmptyValueList(body, "ism_template")
+
+	return provider.Resource{ID: r.ID, Body: body, SourceRange: r.SourceRange}, nil
+}
+
+// Validate checks structural correctness of an ISM policy resource.
+func (h *ismPolicyHandler) Validate(_ context.Context, r provider.Resource) error {
+	prefix := fmt.Sprintf("opensearch_ism_policy.%s", r.ID.Name)
+
+	// states — required, list of maps, each with a name.
+	statesVal, ok := r.Body.Get("states")
+	if !ok {
+		return fmt.Errorf("%s: \"states\" is required — an ISM policy must define at least one state", prefix)
+	}
+	if statesVal.Kind != provider.KindList {
+		return fmt.Errorf("%s: states must be a list, got %s", prefix, statesVal.Kind)
+	}
+	if len(statesVal.List) == 0 {
+		return fmt.Errorf("%s: \"states\" must contain at least one state", prefix)
+	}
+	for i, state := range statesVal.List {
+		if state.Kind != provider.KindMap {
+			return fmt.Errorf("%s: states[%d] must be a map, got %s", prefix, i, state.Kind)
+		}
+		nameVal, ok := state.Map.Get("name")
+		if !ok {
+			return fmt.Errorf("%s: states[%d] must have a \"name\" field", prefix, i)
+		}
+		if nameVal.Kind != provider.KindString {
+			return fmt.Errorf("%s: states[%d].name must be a string, got %s", prefix, i, nameVal.Kind)
+		}
+	}
+
+	// default_state — optional string.
+	if v, ok := r.Body.Get("default_state"); ok && v.Kind != provider.KindString {
+		return fmt.Errorf("%s: default_state must be a string, got %s", prefix, v.Kind)
+	}
+
+	// description — optional string.
+	if v, ok := r.Body.Get("description"); ok && v.Kind != provider.KindString {
+		return fmt.Errorf("%s: description must be a string, got %s", prefix, v.Kind)
+	}
+
+	// ism_template — optional list of maps.
+	if v, ok := r.Body.Get("ism_template"); ok {
+		if v.Kind != provider.KindList {
+			return fmt.Errorf("%s: ism_template must be a list, got %s", prefix, v.Kind)
+		}
+		for i, tmpl := range v.List {
+			if tmpl.Kind != provider.KindMap {
+				return fmt.Errorf("%s: ism_template[%d] must be a map, got %s", prefix, i, tmpl.Kind)
+			}
+		}
+	}
+
+	// error_notification — optional map (or null).
+	if v, ok := r.Body.Get("error_notification"); ok && v.Kind != provider.KindNull && v.Kind != provider.KindMap {
+		return fmt.Errorf("%s: error_notification must be a map, got %s", prefix, v.Kind)
+	}
+
+	return nil
+}
+
+// Apply creates, updates, or deletes an ISM policy in OpenSearch.
+func (h *ismPolicyHandler) Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error {
+	switch op {
+	case provider.OpCreate:
+		return h.putPolicy(ctx, client, op, r, "")
+
+	case provider.OpUpdate:
+		// The ISM API requires seq_no and primary_term for updates.
+		// Fetch the current values before writing.
+		seqParams, err := h.fetchSeqParams(ctx, client, r.ID.Name)
+		if err != nil {
+			return fmt.Errorf("opensearch_ism_policy.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		return h.putPolicy(ctx, client, op, r, seqParams)
+
+	case provider.OpDelete:
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+			"/_plugins/_ism/policies/"+r.ID.Name, nil)
+		if err != nil {
+			return fmt.Errorf("opensearch_ism_policy.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return fmt.Errorf("opensearch_ism_policy.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		if status == http.StatusNotFound {
+			return nil // already gone
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("opensearch_ism_policy.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("opensearch_ism_policy.%s: unsupported operation %s", r.ID.Name, op)
+	}
+}
+
+// putPolicy sends a PUT to the ISM API with the policy body wrapped in an envelope.
+// queryParams is appended to the URL (e.g. "?if_seq_no=1&if_primary_term=1" for updates).
+func (h *ismPolicyHandler) putPolicy(ctx context.Context, client *Client, op provider.Operation, r provider.Resource, queryParams string) error {
+	policyBody := valueToJSON(provider.MapVal(r.Body))
+	envelope := map[string]any{"policy": policyBody}
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("opensearch_ism_policy.%s: %s failed: %s", r.ID.Name, op, err)
+	}
+
+	url := "/_plugins/_ism/policies/" + r.ID.Name + queryParams
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("opensearch_ism_policy.%s: %s failed: %s", r.ID.Name, op, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	body, status, err := client.do(req)
+	if err != nil {
+		return fmt.Errorf("opensearch_ism_policy.%s: %s failed: %s", r.ID.Name, op, err)
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("opensearch_ism_policy.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+	}
+	return nil
+}
+
+// fetchSeqParams retrieves the current _seq_no and _primary_term for a policy
+// and returns them as a query string for the PUT update request.
+func (h *ismPolicyHandler) fetchSeqParams(ctx context.Context, client *Client, name string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"/_plugins/_ism/policies/"+name, nil)
+	if err != nil {
+		return "", err
+	}
+
+	body, status, err := client.do(req)
+	if err != nil {
+		return "", err
+	}
+	if status < 200 || status >= 300 {
+		return "", fmt.Errorf("failed to fetch policy for update (%d): %s", status, body)
+	}
+
+	var resp struct {
+		SeqNo       int64 `json:"_seq_no"`
+		PrimaryTerm int64 `json:"_primary_term"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("failed to parse policy metadata: %s", err)
+	}
+
+	return fmt.Sprintf("?if_seq_no=%d&if_primary_term=%d", resp.SeqNo, resp.PrimaryTerm), nil
+}

--- a/providers/opensearch/ism_policy_test.go
+++ b/providers/opensearch/ism_policy_test.go
@@ -1,0 +1,464 @@
+package opensearch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// --- Unit tests (no cluster needed) ---
+
+func TestISMPolicyNormalize_sorts_ism_template(t *testing.T) {
+	h := &ismPolicyHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_ism_policy", Name: "test"},
+		Body: buildMap(
+			"default_state", provider.StringVal("hot"),
+			"ism_template", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"index_patterns", provider.ListVal([]provider.Value{
+						provider.StringVal("logs-*"),
+					}),
+					"priority", provider.IntVal(200),
+				)),
+				provider.MapVal(buildMap(
+					"index_patterns", provider.ListVal([]provider.Value{
+						provider.StringVal("audit-*"),
+					}),
+					"priority", provider.IntVal(100),
+				)),
+			}),
+			"states", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"name", provider.StringVal("hot"),
+				)),
+			}),
+		),
+	}
+
+	result, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Normalize failed: %v", err)
+	}
+
+	tmpl, ok := result.Body.Get("ism_template")
+	if !ok {
+		t.Fatal("expected ism_template to be present")
+	}
+	if len(tmpl.List) != 2 {
+		t.Fatalf("expected 2 ism_template entries, got %d", len(tmpl.List))
+	}
+
+	// After sorting by JSON: audit-* (priority 100) comes before logs-* (priority 200).
+	first := tmpl.List[0].Map
+	prio, _ := first.Get("priority")
+	if prio.Int != 100 {
+		t.Errorf("expected first ism_template priority to be 100, got %d", prio.Int)
+	}
+}
+
+func TestISMPolicyNormalize_preserves_state_order(t *testing.T) {
+	h := &ismPolicyHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_ism_policy", Name: "test"},
+		Body: buildMap(
+			"default_state", provider.StringVal("hot"),
+			"states", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap("name", provider.StringVal("hot"))),
+				provider.MapVal(buildMap("name", provider.StringVal("warm"))),
+				provider.MapVal(buildMap("name", provider.StringVal("delete"))),
+			}),
+		),
+	}
+
+	result, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Normalize failed: %v", err)
+	}
+
+	states, _ := result.Body.Get("states")
+	expected := []string{"hot", "warm", "delete"}
+	for i, want := range expected {
+		name, _ := states.List[i].Map.Get("name")
+		if name.Str != want {
+			t.Errorf("states[%d]: expected %q, got %q", i, want, name.Str)
+		}
+	}
+}
+
+func TestISMPolicyNormalize_strips_metadata(t *testing.T) {
+	h := &ismPolicyHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_ism_policy", Name: "test"},
+		Body: buildMap(
+			"default_state", provider.StringVal("hot"),
+			"error_notification", provider.NullVal(),
+			"last_updated_time", provider.IntVal(1612345678901),
+			"policy_id", provider.StringVal("test"),
+			"schema_version", provider.IntVal(1),
+			"states", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap("name", provider.StringVal("hot"))),
+			}),
+		),
+	}
+
+	result, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Normalize failed: %v", err)
+	}
+
+	for _, key := range []string{"policy_id", "last_updated_time", "schema_version", "error_notification"} {
+		if _, ok := result.Body.Get(key); ok {
+			t.Errorf("expected %s to be stripped", key)
+		}
+	}
+}
+
+func TestISMPolicyNormalize_idempotent(t *testing.T) {
+	h := &ismPolicyHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_ism_policy", Name: "test"},
+		Body: buildMap(
+			"default_state", provider.StringVal("hot"),
+			"description", provider.StringVal("test policy"),
+			"ism_template", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"index_patterns", provider.ListVal([]provider.Value{
+						provider.StringVal("logs-*"),
+					}),
+					"priority", provider.IntVal(100),
+				)),
+			}),
+			"states", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"name", provider.StringVal("hot"),
+					"transitions", provider.ListVal([]provider.Value{
+						provider.MapVal(buildMap(
+							"conditions", provider.MapVal(buildMap(
+								"min_index_age", provider.StringVal("7d"),
+							)),
+							"state_name", provider.StringVal("delete"),
+						)),
+					}),
+				)),
+				provider.MapVal(buildMap(
+					"actions", provider.ListVal([]provider.Value{
+						provider.MapVal(buildMap(
+							"delete", provider.MapVal(provider.NewOrderedMap()),
+						)),
+					}),
+					"name", provider.StringVal("delete"),
+				)),
+			}),
+		),
+	}
+
+	first, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("first Normalize failed: %v", err)
+	}
+	second, err := h.Normalize(context.Background(), first)
+	if err != nil {
+		t.Fatalf("second Normalize failed: %v", err)
+	}
+
+	if !first.Body.Equal(second.Body) {
+		t.Errorf("Normalize is not idempotent:\nfirst:  %s\nsecond: %s",
+			provider.MapVal(first.Body), provider.MapVal(second.Body))
+	}
+}
+
+func TestISMPolicyValidate_valid_policy(t *testing.T) {
+	h := &ismPolicyHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_ism_policy", Name: "good_policy"},
+		Body: buildMap(
+			"default_state", provider.StringVal("hot"),
+			"description", provider.StringVal("test policy"),
+			"states", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"name", provider.StringVal("hot"),
+					"transitions", provider.ListVal([]provider.Value{
+						provider.MapVal(buildMap(
+							"conditions", provider.MapVal(buildMap(
+								"min_index_age", provider.StringVal("7d"),
+							)),
+							"state_name", provider.StringVal("delete"),
+						)),
+					}),
+				)),
+				provider.MapVal(buildMap(
+					"actions", provider.ListVal([]provider.Value{
+						provider.MapVal(buildMap(
+							"delete", provider.MapVal(provider.NewOrderedMap()),
+						)),
+					}),
+					"name", provider.StringVal("delete"),
+				)),
+			}),
+			"ism_template", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"index_patterns", provider.ListVal([]provider.Value{
+						provider.StringVal("logs-*"),
+					}),
+					"priority", provider.IntVal(100),
+				)),
+			}),
+		),
+	}
+
+	if err := h.Validate(context.Background(), r); err != nil {
+		t.Errorf("expected valid policy to pass, got: %v", err)
+	}
+}
+
+func TestISMPolicyValidate_missing_states(t *testing.T) {
+	h := &ismPolicyHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_ism_policy", Name: "bad_policy"},
+		Body: buildMap(
+			"default_state", provider.StringVal("hot"),
+		),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for missing states")
+	}
+}
+
+func TestISMPolicyValidate_empty_states(t *testing.T) {
+	h := &ismPolicyHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_ism_policy", Name: "bad_policy"},
+		Body: buildMap(
+			"states", provider.ListVal(nil),
+		),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for empty states")
+	}
+}
+
+func TestISMPolicyValidate_state_missing_name(t *testing.T) {
+	h := &ismPolicyHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_ism_policy", Name: "bad_policy"},
+		Body: buildMap(
+			"states", provider.ListVal([]provider.Value{
+				provider.MapVal(buildMap(
+					"actions", provider.ListVal(nil),
+				)),
+			}),
+		),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for state missing name")
+	}
+}
+
+// --- Integration tests ---
+
+func TestISMPolicyHandler_Integration(t *testing.T) {
+	client := newTestClient(t)
+	h := &ismPolicyHandler{}
+	policyName := "datastorectl_test_ism_policy"
+	cleanupResource(t, client, "opensearch_ism_policy", policyName)
+
+	ctx := context.Background()
+
+	t.Run("create", func(t *testing.T) {
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_ism_policy", Name: policyName},
+			Body: buildMap(
+				"default_state", provider.StringVal("hot"),
+				"description", provider.StringVal("test policy"),
+				"states", provider.ListVal([]provider.Value{
+					provider.MapVal(buildMap(
+						"name", provider.StringVal("hot"),
+						"transitions", provider.ListVal([]provider.Value{
+							provider.MapVal(buildMap(
+								"conditions", provider.MapVal(buildMap(
+									"min_index_age", provider.StringVal("7d"),
+								)),
+								"state_name", provider.StringVal("delete"),
+							)),
+						}),
+					)),
+					provider.MapVal(buildMap(
+						"actions", provider.ListVal([]provider.Value{
+							provider.MapVal(buildMap(
+								"delete", provider.MapVal(provider.NewOrderedMap()),
+							)),
+						}),
+						"name", provider.StringVal("delete"),
+					)),
+				}),
+			),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpCreate, r); err != nil {
+			t.Fatalf("Apply OpCreate failed: %v", err)
+		}
+		requireResourceExists(t, client, "opensearch_ism_policy", policyName)
+	})
+
+	t.Run("discover_after_create", func(t *testing.T) {
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == policyName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("expected to find policy %q in discovered resources", policyName)
+		}
+
+		// Verify expected fields present.
+		if _, ok := found.Body.Get("states"); !ok {
+			t.Error("discovered policy missing states")
+		}
+		if _, ok := found.Body.Get("default_state"); !ok {
+			t.Error("discovered policy missing default_state")
+		}
+		if _, ok := found.Body.Get("description"); !ok {
+			t.Error("discovered policy missing description")
+		}
+
+		// Verify metadata is stripped.
+		for _, key := range []string{"policy_id", "last_updated_time", "schema_version"} {
+			if _, ok := found.Body.Get(key); ok {
+				t.Errorf("discovered policy should not have %q", key)
+			}
+		}
+
+		// error_notification (null) should be stripped.
+		if _, ok := found.Body.Get("error_notification"); ok {
+			t.Error("discovered policy should not have null error_notification")
+		}
+	})
+
+	t.Run("normalize_roundtrip", func(t *testing.T) {
+		// Discover and find our policy.
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+		var discovered provider.Resource
+		for _, r := range resources {
+			if r.ID.Name == policyName {
+				discovered = r
+				break
+			}
+		}
+
+		normalizedAPI, err := h.Normalize(ctx, discovered)
+		if err != nil {
+			t.Fatalf("Normalize discovered resource failed: %v", err)
+		}
+
+		// Build DCL resource matching the normalized discovered body.
+		// Use the normalized API body as the source of truth for what keys/structure
+		// the API returns, so we build an equivalent DCL resource.
+		dclResource := provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_ism_policy", Name: policyName},
+			Body: normalizedAPI.Body.Clone(),
+		}
+
+		normalizedDCL, err := h.Normalize(ctx, dclResource)
+		if err != nil {
+			t.Fatalf("Normalize DCL resource failed: %v", err)
+		}
+
+		if !normalizedDCL.Body.Equal(normalizedAPI.Body) {
+			t.Errorf("normalized bodies do not match:\nDCL: %s\nAPI: %s",
+				provider.MapVal(normalizedDCL.Body), provider.MapVal(normalizedAPI.Body))
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		// Change the transition condition from 7d to 14d.
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_ism_policy", Name: policyName},
+			Body: buildMap(
+				"default_state", provider.StringVal("hot"),
+				"description", provider.StringVal("test policy"),
+				"states", provider.ListVal([]provider.Value{
+					provider.MapVal(buildMap(
+						"name", provider.StringVal("hot"),
+						"transitions", provider.ListVal([]provider.Value{
+							provider.MapVal(buildMap(
+								"conditions", provider.MapVal(buildMap(
+									"min_index_age", provider.StringVal("14d"),
+								)),
+								"state_name", provider.StringVal("delete"),
+							)),
+						}),
+					)),
+					provider.MapVal(buildMap(
+						"actions", provider.ListVal([]provider.Value{
+							provider.MapVal(buildMap(
+								"delete", provider.MapVal(provider.NewOrderedMap()),
+							)),
+						}),
+						"name", provider.StringVal("delete"),
+					)),
+				}),
+			),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpUpdate, r); err != nil {
+			t.Fatalf("Apply OpUpdate failed: %v", err)
+		}
+
+		// Re-discover and verify the update.
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover after update failed: %v", err)
+		}
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == policyName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("policy %q not found after update", policyName)
+		}
+
+		// Verify the transition condition was updated.
+		states, _ := found.Body.Get("states")
+		hotState := states.List[0].Map
+		transitions, _ := hotState.Get("transitions")
+		conditions := transitions.List[0].Map
+		conds, _ := conditions.Get("conditions")
+		age, _ := conds.Map.Get("min_index_age")
+		if age.Str != "14d" {
+			t.Errorf("expected min_index_age to be 14d after update, got %q", age.Str)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_ism_policy", Name: policyName},
+			Body: provider.NewOrderedMap(),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpDelete, r); err != nil {
+			t.Fatalf("Apply OpDelete failed: %v", err)
+		}
+		requireResourceNotExists(t, client, "opensearch_ism_policy", policyName)
+	})
+}

--- a/providers/opensearch/provider.go
+++ b/providers/opensearch/provider.go
@@ -15,6 +15,7 @@ func init() {
 				"opensearch_role":          &roleHandler{},
 				"opensearch_internal_user": &internalUserHandler{},
 				"opensearch_role_mapping":  &roleMappingHandler{},
+				"opensearch_ism_policy":    &ismPolicyHandler{},
 			},
 		}
 	})

--- a/providers/opensearch/testhelpers_test.go
+++ b/providers/opensearch/testhelpers_test.go
@@ -15,6 +15,7 @@ var resourceAPIPaths = map[string]string{
 	"opensearch_role":                      "/_plugins/_security/api/roles/",
 	"opensearch_role_mapping":              "/_plugins/_security/api/rolesmapping/",
 	"opensearch_internal_user":             "/_plugins/_security/api/internalusers/",
+	"opensearch_ism_policy":                "/_plugins/_ism/policies/",
 	"opensearch_component_template":        "/_component_template/",
 	"opensearch_composable_index_template": "/_index_template/",
 }


### PR DESCRIPTION
## Summary

- Adds `ismPolicyHandler` implementing `resourceHandler` for `opensearch_ism_policy` — the highest-priority resource type (widest Terraform coverage gap)
- Paginated discovery with ISM API envelope unwrapping (`GET /_plugins/_ism/policies`)
- Strips server-injected metadata: `policy_id`, `last_updated_time`, `schema_version`, null `error_notification`, and `last_updated_time` within `ism_template` entries
- Normalize preserves state order (sequence matters for the ISM state machine) while sorting `ism_template` entries for deterministic diffs
- Validate requires at least one state, each with a `name` field
- Apply wraps body in `{"policy": {...}}` envelope; updates fetch `seq_no`/`primary_term` at apply time since the ISM API requires them for PUT to existing policies
- Registers handler in `provider.go`; adds ISM API path to test helpers

Closes #95

## Test plan

- [x] `go vet ./...` passes
- [x] 8 unit tests: normalize sorting/state-order-preservation/metadata-stripping/idempotency, validate valid/missing-states/empty-states/state-missing-name
- [x] 5 integration subtests: create → discover → normalize-roundtrip → update (change transition) → delete
- [x] All existing tests unbroken (`go test ./... -count=1` full green)