### PR TITLE
feat(opensearch): add opensearch_component_template resource handler

### DIFF
--- a/providers/opensearch/component_template.go
+++ b/providers/opensearch/component_template.go
@@ -1,0 +1,142 @@
+package opensearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// componentTemplateHandler implements resourceHandler for opensearch_component_template resources.
+type componentTemplateHandler struct{}
+
+// Discover fetches all non-system component templates from OpenSearch.
+func (h *componentTemplateHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/_component_template", nil)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch_component_template: discover: %s", err)
+	}
+
+	body, status, err := client.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch_component_template: discover: %s", err)
+	}
+	if status < 200 || status >= 300 {
+		return nil, fmt.Errorf("opensearch_component_template: discover failed (%d): %s", status, body)
+	}
+
+	var resp componentTemplateListResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("opensearch_component_template: discover: %s", err)
+	}
+
+	var resources []provider.Resource
+	for _, entry := range resp.ComponentTemplates {
+		// Filter system templates (dot-prefixed names are OpenSearch internal).
+		if strings.HasPrefix(entry.Name, ".") {
+			continue
+		}
+
+		templateData := entry.ComponentTemplate
+
+		// Strip version — treated as metadata, not desired state.
+		delete(templateData, "version")
+
+		val := jsonToValue(templateData)
+		resources = append(resources, provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_component_template", Name: entry.Name},
+			Body: val.Map,
+		})
+	}
+	return resources, nil
+}
+
+// componentTemplateListResponse is the envelope returned by GET /_component_template.
+type componentTemplateListResponse struct {
+	ComponentTemplates []struct {
+		Name              string         `json:"name"`
+		ComponentTemplate map[string]any `json:"component_template"`
+	} `json:"component_templates"`
+}
+
+// Normalize strips the version field. Map keys are already sorted deterministically
+// by jsonToValue during Discover.
+func (h *componentTemplateHandler) Normalize(_ context.Context, r provider.Resource) (provider.Resource, error) {
+	body := r.Body.Clone()
+
+	// Strip version — not part of desired state.
+	body.Delete("version")
+
+	return provider.Resource{ID: r.ID, Body: body, SourceRange: r.SourceRange}, nil
+}
+
+// Validate checks structural correctness of a component template resource.
+func (h *componentTemplateHandler) Validate(_ context.Context, r provider.Resource) error {
+	prefix := fmt.Sprintf("opensearch_component_template.%s", r.ID.Name)
+
+	// template — required map.
+	tmpl, ok := r.Body.Get("template")
+	if !ok {
+		return fmt.Errorf("%s: \"template\" is required — a component template must define a template block with settings, mappings, or aliases", prefix)
+	}
+	if tmpl.Kind != provider.KindMap {
+		return fmt.Errorf("%s: template must be a map, got %s", prefix, tmpl.Kind)
+	}
+
+	return nil
+}
+
+// Apply creates, updates, or deletes a component template in OpenSearch.
+func (h *componentTemplateHandler) Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error {
+	switch op {
+	case provider.OpCreate, provider.OpUpdate:
+		payload := valueToJSON(provider.MapVal(r.Body))
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("opensearch_component_template.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+			"/_component_template/"+r.ID.Name,
+			bytes.NewReader(data))
+		if err != nil {
+			return fmt.Errorf("opensearch_component_template.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return fmt.Errorf("opensearch_component_template.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("opensearch_component_template.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+		}
+		return nil
+
+	case provider.OpDelete:
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+			"/_component_template/"+r.ID.Name, nil)
+		if err != nil {
+			return fmt.Errorf("opensearch_component_template.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return fmt.Errorf("opensearch_component_template.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		if status == http.StatusNotFound {
+			return nil // already gone
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("opensearch_component_template.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("opensearch_component_template.%s: unsupported operation %s", r.ID.Name, op)
+	}
+}

--- a/providers/opensearch/component_template_test.go
+++ b/providers/opensearch/component_template_test.go
@@ -1,0 +1,287 @@
+package opensearch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// --- Unit tests (no cluster needed) ---
+
+func TestComponentTemplateNormalize_strips_version(t *testing.T) {
+	h := &componentTemplateHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_component_template", Name: "test"},
+		Body: buildMap(
+			"template", provider.MapVal(buildMap(
+				"settings", provider.MapVal(buildMap(
+					"index", provider.MapVal(buildMap(
+						"number_of_shards", provider.StringVal("1"),
+					)),
+				)),
+			)),
+			"version", provider.IntVal(1),
+		),
+	}
+
+	result, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Normalize failed: %v", err)
+	}
+
+	if _, ok := result.Body.Get("version"); ok {
+		t.Error("expected version to be stripped")
+	}
+	if _, ok := result.Body.Get("template"); !ok {
+		t.Error("expected template to be preserved")
+	}
+}
+
+func TestComponentTemplateNormalize_idempotent(t *testing.T) {
+	h := &componentTemplateHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_component_template", Name: "test"},
+		Body: buildMap(
+			"template", provider.MapVal(buildMap(
+				"mappings", provider.MapVal(buildMap(
+					"properties", provider.MapVal(buildMap(
+						"timestamp", provider.MapVal(buildMap(
+							"type", provider.StringVal("date"),
+						)),
+					)),
+				)),
+			)),
+		),
+	}
+
+	first, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("first Normalize failed: %v", err)
+	}
+	second, err := h.Normalize(context.Background(), first)
+	if err != nil {
+		t.Fatalf("second Normalize failed: %v", err)
+	}
+
+	if !first.Body.Equal(second.Body) {
+		t.Errorf("Normalize is not idempotent:\nfirst:  %s\nsecond: %s",
+			provider.MapVal(first.Body), provider.MapVal(second.Body))
+	}
+}
+
+func TestComponentTemplateValidate_valid_template(t *testing.T) {
+	h := &componentTemplateHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_component_template", Name: "good_template"},
+		Body: buildMap(
+			"template", provider.MapVal(buildMap(
+				"settings", provider.MapVal(buildMap(
+					"index", provider.MapVal(buildMap(
+						"number_of_shards", provider.StringVal("1"),
+					)),
+				)),
+			)),
+		),
+	}
+
+	if err := h.Validate(context.Background(), r); err != nil {
+		t.Errorf("expected valid template to pass, got: %v", err)
+	}
+}
+
+func TestComponentTemplateValidate_missing_template(t *testing.T) {
+	h := &componentTemplateHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_component_template", Name: "bad_template"},
+		Body: buildMap(
+			"version", provider.IntVal(1),
+		),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for missing template")
+	}
+}
+
+func TestComponentTemplateValidate_template_wrong_type(t *testing.T) {
+	h := &componentTemplateHandler{}
+	r := provider.Resource{
+		ID:   provider.ResourceID{Type: "opensearch_component_template", Name: "bad_template"},
+		Body: buildMap("template", provider.StringVal("not_a_map")),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for non-map template")
+	}
+}
+
+// --- Integration tests ---
+
+func TestComponentTemplateHandler_Integration(t *testing.T) {
+	client := newTestClient(t)
+	h := &componentTemplateHandler{}
+	templateName := "datastorectl_test_component"
+	cleanupResource(t, client, "opensearch_component_template", templateName)
+
+	ctx := context.Background()
+
+	t.Run("create", func(t *testing.T) {
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_component_template", Name: templateName},
+			Body: buildMap(
+				"template", provider.MapVal(buildMap(
+					"settings", provider.MapVal(buildMap(
+						"index", provider.MapVal(buildMap(
+							"number_of_shards", provider.StringVal("2"),
+						)),
+					)),
+				)),
+			),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpCreate, r); err != nil {
+			t.Fatalf("Apply OpCreate failed: %v", err)
+		}
+		requireResourceExists(t, client, "opensearch_component_template", templateName)
+	})
+
+	t.Run("discover_after_create", func(t *testing.T) {
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == templateName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("expected to find template %q in discovered resources", templateName)
+		}
+
+		// Verify template block present.
+		if _, ok := found.Body.Get("template"); !ok {
+			t.Error("discovered template missing template block")
+		}
+
+		// Verify version is stripped.
+		if _, ok := found.Body.Get("version"); ok {
+			t.Error("discovered template should not have version")
+		}
+	})
+
+	t.Run("normalize_roundtrip", func(t *testing.T) {
+		// Discover and find our template.
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+		var discovered provider.Resource
+		for _, r := range resources {
+			if r.ID.Name == templateName {
+				discovered = r
+				break
+			}
+		}
+
+		normalizedAPI, err := h.Normalize(ctx, discovered)
+		if err != nil {
+			t.Fatalf("Normalize discovered resource failed: %v", err)
+		}
+
+		// Build DCL resource matching normalized discovered body.
+		dclResource := provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_component_template", Name: templateName},
+			Body: normalizedAPI.Body.Clone(),
+		}
+
+		normalizedDCL, err := h.Normalize(ctx, dclResource)
+		if err != nil {
+			t.Fatalf("Normalize DCL resource failed: %v", err)
+		}
+
+		if !normalizedDCL.Body.Equal(normalizedAPI.Body) {
+			t.Errorf("normalized bodies do not match:\nDCL: %s\nAPI: %s",
+				provider.MapVal(normalizedDCL.Body), provider.MapVal(normalizedAPI.Body))
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		// Add mappings to the template.
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_component_template", Name: templateName},
+			Body: buildMap(
+				"template", provider.MapVal(buildMap(
+					"mappings", provider.MapVal(buildMap(
+						"properties", provider.MapVal(buildMap(
+							"timestamp", provider.MapVal(buildMap(
+								"type", provider.StringVal("date"),
+							)),
+						)),
+					)),
+					"settings", provider.MapVal(buildMap(
+						"index", provider.MapVal(buildMap(
+							"number_of_shards", provider.StringVal("2"),
+						)),
+					)),
+				)),
+			),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpUpdate, r); err != nil {
+			t.Fatalf("Apply OpUpdate failed: %v", err)
+		}
+
+		// Re-discover and verify the update.
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover after update failed: %v", err)
+		}
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == templateName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("template %q not found after update", templateName)
+		}
+
+		tmpl, _ := found.Body.Get("template")
+		if _, ok := tmpl.Map.Get("mappings"); !ok {
+			t.Error("mappings missing after update")
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_component_template", Name: templateName},
+			Body: provider.NewOrderedMap(),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpDelete, r); err != nil {
+			t.Fatalf("Apply OpDelete failed: %v", err)
+		}
+		requireResourceNotExists(t, client, "opensearch_component_template", templateName)
+	})
+
+	t.Run("discover_excludes_system", func(t *testing.T) {
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+
+		for _, r := range resources {
+			if len(r.ID.Name) > 0 && r.ID.Name[0] == '.' {
+				t.Errorf("discovered system template %q — dot-prefixed templates should be filtered", r.ID.Name)
+			}
+		}
+	})
+}

--- a/providers/opensearch/provider.go
+++ b/providers/opensearch/provider.go
@@ -16,6 +16,7 @@ func init() {
 				"opensearch_internal_user": &internalUserHandler{},
 				"opensearch_role_mapping":  &roleMappingHandler{},
 				"opensearch_ism_policy":    &ismPolicyHandler{},
+				"opensearch_component_template": &componentTemplateHandler{},
 			},
 		}
 	})


### PR DESCRIPTION
## Summary

- Adds `componentTemplateHandler` implementing `resourceHandler` for `opensearch_component_template` resources
- Filters dot-prefixed system templates (OpenSearch internal) during discovery
- Strips server-injected `version` field in both Discover and Normalize
- Validates required `template` block is present and is a map
- Registers handler in `provider.go` (TypeOrdering for component → composable already declared)

Closes #96

## Test plan

- [x] `go vet ./...` passes
- [x] 5 unit tests: normalize version-stripping/idempotency, validate valid/missing-template/wrong-type
- [x] 6 integration subtests: create → discover → normalize-roundtrip → update (add mappings) → delete → discover-excludes-system
- [x] `go test ./... -count=1` full suite green