### PR TITLE
feat(opensearch): add opensearch_snapshot_repository resource handler

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,23 @@
 services:
+  opensearch-init:
+    image: opensearchproject/opensearch:2.19.0
+    user: "0"
+    volumes:
+      - opensearch-snapshots:/mnt/snapshots
+    command: ["chown", "-R", "1000:1000", "/mnt/snapshots"]
+
   opensearch:
     image: opensearchproject/opensearch:2.19.0
+    depends_on:
+      opensearch-init:
+        condition: service_completed_successfully
     environment:
       - discovery.type=single-node
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!
       - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+      - path.repo=/usr/share/opensearch/snapshots
+    volumes:
+      - opensearch-snapshots:/usr/share/opensearch/snapshots
     ports:
       - "9200:9200"
       - "9600:9600"
@@ -14,3 +27,6 @@ services:
       timeout: 5s
       retries: 12
       start_period: 30s
+
+volumes:
+  opensearch-snapshots:

--- a/providers/opensearch/provider.go
+++ b/providers/opensearch/provider.go
@@ -19,6 +19,7 @@ func init() {
 				"opensearch_component_template":        &componentTemplateHandler{},
 				"opensearch_composable_index_template": &composableIndexTemplateHandler{},
 				"opensearch_ingest_pipeline":           &ingestPipelineHandler{},
+				"opensearch_snapshot_repository":       &snapshotRepositoryHandler{},
 			},
 		}
 	})

--- a/providers/opensearch/snapshot_repository.go
+++ b/providers/opensearch/snapshot_repository.go
@@ -1,0 +1,128 @@
+package opensearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// snapshotRepositoryHandler implements resourceHandler for opensearch_snapshot_repository resources.
+type snapshotRepositoryHandler struct{}
+
+// Discover fetches all snapshot repositories from OpenSearch.
+func (h *snapshotRepositoryHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/_snapshot/_all", nil)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch_snapshot_repository: discover: %s", err)
+	}
+
+	body, status, err := client.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch_snapshot_repository: discover: %s", err)
+	}
+	if status < 200 || status >= 300 {
+		return nil, fmt.Errorf("opensearch_snapshot_repository: discover failed (%d): %s", status, body)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("opensearch_snapshot_repository: discover: %s", err)
+	}
+
+	var resources []provider.Resource
+	for name, data := range raw {
+		var repoData map[string]any
+		if err := json.Unmarshal(data, &repoData); err != nil {
+			return nil, fmt.Errorf("opensearch_snapshot_repository: discover: failed to decode repository %q: %s", name, err)
+		}
+
+		val := jsonToValue(repoData)
+		resources = append(resources, provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_snapshot_repository", Name: name},
+			Body: val.Map,
+		})
+	}
+	return resources, nil
+}
+
+// Normalize is a no-op — settings keys are already sorted by jsonToValue during Discover.
+func (h *snapshotRepositoryHandler) Normalize(_ context.Context, r provider.Resource) (provider.Resource, error) {
+	body := r.Body.Clone()
+	return provider.Resource{ID: r.ID, Body: body, SourceRange: r.SourceRange}, nil
+}
+
+// Validate checks structural correctness of a snapshot repository resource.
+func (h *snapshotRepositoryHandler) Validate(_ context.Context, r provider.Resource) error {
+	prefix := fmt.Sprintf("opensearch_snapshot_repository.%s", r.ID.Name)
+
+	// type — required string.
+	typeVal, ok := r.Body.Get("type")
+	if !ok {
+		return fmt.Errorf("%s: \"type\" is required — specify the repository type (e.g. \"fs\", \"s3\")", prefix)
+	}
+	if typeVal.Kind != provider.KindString {
+		return fmt.Errorf("%s: type must be a string, got %s", prefix, typeVal.Kind)
+	}
+
+	// settings — optional map.
+	if v, ok := r.Body.Get("settings"); ok && v.Kind != provider.KindMap {
+		return fmt.Errorf("%s: settings must be a map, got %s", prefix, v.Kind)
+	}
+
+	return nil
+}
+
+// Apply creates, updates, or deletes a snapshot repository in OpenSearch.
+func (h *snapshotRepositoryHandler) Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error {
+	switch op {
+	case provider.OpCreate, provider.OpUpdate:
+		payload := valueToJSON(provider.MapVal(r.Body))
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("opensearch_snapshot_repository.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+			"/_snapshot/"+r.ID.Name,
+			bytes.NewReader(data))
+		if err != nil {
+			return fmt.Errorf("opensearch_snapshot_repository.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return fmt.Errorf("opensearch_snapshot_repository.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("opensearch_snapshot_repository.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+		}
+		return nil
+
+	case provider.OpDelete:
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+			"/_snapshot/"+r.ID.Name, nil)
+		if err != nil {
+			return fmt.Errorf("opensearch_snapshot_repository.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return fmt.Errorf("opensearch_snapshot_repository.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		if status == http.StatusNotFound {
+			return nil // already gone
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("opensearch_snapshot_repository.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("opensearch_snapshot_repository.%s: unsupported operation %s", r.ID.Name, op)
+	}
+}

--- a/providers/opensearch/snapshot_repository_test.go
+++ b/providers/opensearch/snapshot_repository_test.go
@@ -1,0 +1,241 @@
+package opensearch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// --- Unit tests (no cluster needed) ---
+
+func TestSnapshotRepositoryNormalize_idempotent(t *testing.T) {
+	h := &snapshotRepositoryHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_snapshot_repository", Name: "test"},
+		Body: buildMap(
+			"settings", provider.MapVal(buildMap(
+				"location", provider.StringVal("/mnt/snapshots"),
+			)),
+			"type", provider.StringVal("fs"),
+		),
+	}
+
+	first, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("first Normalize failed: %v", err)
+	}
+	second, err := h.Normalize(context.Background(), first)
+	if err != nil {
+		t.Fatalf("second Normalize failed: %v", err)
+	}
+
+	if !first.Body.Equal(second.Body) {
+		t.Errorf("Normalize is not idempotent:\nfirst:  %s\nsecond: %s",
+			provider.MapVal(first.Body), provider.MapVal(second.Body))
+	}
+}
+
+func TestSnapshotRepositoryValidate_valid_repo(t *testing.T) {
+	h := &snapshotRepositoryHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_snapshot_repository", Name: "good"},
+		Body: buildMap(
+			"settings", provider.MapVal(buildMap(
+				"location", provider.StringVal("/mnt/snapshots"),
+			)),
+			"type", provider.StringVal("fs"),
+		),
+	}
+
+	if err := h.Validate(context.Background(), r); err != nil {
+		t.Errorf("expected valid repo to pass, got: %v", err)
+	}
+}
+
+func TestSnapshotRepositoryValidate_missing_type(t *testing.T) {
+	h := &snapshotRepositoryHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_snapshot_repository", Name: "bad"},
+		Body: buildMap(
+			"settings", provider.MapVal(buildMap(
+				"location", provider.StringVal("/mnt/snapshots"),
+			)),
+		),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for missing type")
+	}
+}
+
+func TestSnapshotRepositoryValidate_type_wrong_type(t *testing.T) {
+	h := &snapshotRepositoryHandler{}
+	r := provider.Resource{
+		ID:   provider.ResourceID{Type: "opensearch_snapshot_repository", Name: "bad"},
+		Body: buildMap("type", provider.IntVal(42)),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for non-string type")
+	}
+}
+
+func TestSnapshotRepositoryValidate_settings_wrong_type(t *testing.T) {
+	h := &snapshotRepositoryHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_snapshot_repository", Name: "bad"},
+		Body: buildMap(
+			"type", provider.StringVal("fs"),
+			"settings", provider.StringVal("not_a_map"),
+		),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for non-map settings")
+	}
+}
+
+// --- Integration tests ---
+
+func TestSnapshotRepositoryHandler_Integration(t *testing.T) {
+	client := newTestClient(t)
+	h := &snapshotRepositoryHandler{}
+	repoName := "datastorectl_test_repo"
+	cleanupResource(t, client, "opensearch_snapshot_repository", repoName)
+
+	ctx := context.Background()
+
+	t.Run("create", func(t *testing.T) {
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_snapshot_repository", Name: repoName},
+			Body: buildMap(
+				"settings", provider.MapVal(buildMap(
+					"location", provider.StringVal("/usr/share/opensearch/snapshots"),
+				)),
+				"type", provider.StringVal("fs"),
+			),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpCreate, r); err != nil {
+			t.Fatalf("Apply OpCreate failed: %v", err)
+		}
+		requireResourceExists(t, client, "opensearch_snapshot_repository", repoName)
+	})
+
+	t.Run("discover_after_create", func(t *testing.T) {
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == repoName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("expected to find repository %q in discovered resources", repoName)
+		}
+
+		if _, ok := found.Body.Get("type"); !ok {
+			t.Error("discovered repo missing type")
+		}
+		if _, ok := found.Body.Get("settings"); !ok {
+			t.Error("discovered repo missing settings")
+		}
+	})
+
+	t.Run("normalize_roundtrip", func(t *testing.T) {
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+		var discovered provider.Resource
+		for _, r := range resources {
+			if r.ID.Name == repoName {
+				discovered = r
+				break
+			}
+		}
+
+		normalizedAPI, err := h.Normalize(ctx, discovered)
+		if err != nil {
+			t.Fatalf("Normalize discovered resource failed: %v", err)
+		}
+
+		dclResource := provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_snapshot_repository", Name: repoName},
+			Body: normalizedAPI.Body.Clone(),
+		}
+
+		normalizedDCL, err := h.Normalize(ctx, dclResource)
+		if err != nil {
+			t.Fatalf("Normalize DCL resource failed: %v", err)
+		}
+
+		if !normalizedDCL.Body.Equal(normalizedAPI.Body) {
+			t.Errorf("normalized bodies do not match:\nDCL: %s\nAPI: %s",
+				provider.MapVal(normalizedDCL.Body), provider.MapVal(normalizedAPI.Body))
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		// Change compress setting.
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_snapshot_repository", Name: repoName},
+			Body: buildMap(
+				"settings", provider.MapVal(buildMap(
+					"compress", provider.StringVal("true"),
+					"location", provider.StringVal("/usr/share/opensearch/snapshots"),
+				)),
+				"type", provider.StringVal("fs"),
+			),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpUpdate, r); err != nil {
+			t.Fatalf("Apply OpUpdate failed: %v", err)
+		}
+
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover after update failed: %v", err)
+		}
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == repoName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatalf("repository %q not found after update", repoName)
+		}
+
+		settings, _ := found.Body.Get("settings")
+		compress, ok := settings.Map.Get("compress")
+		if !ok {
+			t.Fatal("compress setting missing after update")
+		}
+		if compress.Str != "true" {
+			t.Errorf("expected compress to be \"true\", got %q", compress.Str)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "opensearch_snapshot_repository", Name: repoName},
+			Body: provider.NewOrderedMap(),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpDelete, r); err != nil {
+			t.Fatalf("Apply OpDelete failed: %v", err)
+		}
+		requireResourceNotExists(t, client, "opensearch_snapshot_repository", repoName)
+	})
+}

--- a/providers/opensearch/testhelpers_test.go
+++ b/providers/opensearch/testhelpers_test.go
@@ -19,6 +19,7 @@ var resourceAPIPaths = map[string]string{
 	"opensearch_component_template":        "/_component_template/",
 	"opensearch_composable_index_template": "/_index_template/",
 	"opensearch_ingest_pipeline":           "/_ingest/pipeline/",
+	"opensearch_snapshot_repository":        "/_snapshot/",
 }
 
 // restPath returns the full REST path for a resource type and name.


### PR DESCRIPTION
## Summary

- Adds `snapshotRepositoryHandler` implementing the full `resourceHandler` interface (Discover, Normalize, Validate, Apply)
- Uses `GET /_snapshot/_all` for discovery and `PUT /_snapshot/{name}` for create/update, `DELETE /_snapshot/{name}` for delete
- Registers `opensearch_snapshot_repository` in the provider handlers map
- Fixes `docker-compose.yml` to configure `path.repo` and an init container that grants write permissions on the snapshots volume, enabling `fs` repository integration tests

## Test plan

- [ ] `go vet ./...` passes cleanly
- [ ] Unit tests pass: Normalize idempotency, Validate (valid, missing type, wrong type, non-map settings)
- [ ] Integration tests pass: create, discover_after_create, normalize_roundtrip, update, delete

Closes #100