### PR TITLE
feat(opensearch): add opensearch_cluster_settings resource handler

### DIFF
--- a/providers/opensearch/cluster_settings.go
+++ b/providers/opensearch/cluster_settings.go
@@ -1,0 +1,146 @@
+package opensearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// clusterSettingsHandler implements resourceHandler for opensearch_cluster_settings resources.
+// This is a singleton resource — one per cluster with canonical name "cluster".
+type clusterSettingsHandler struct{}
+
+// clusterSettingsSingletonName is the canonical resource name for the cluster settings singleton.
+const clusterSettingsSingletonName = "cluster"
+
+// Discover fetches persistent cluster settings from OpenSearch.
+// Returns at most one resource. Returns an empty list if no persistent settings are configured.
+func (h *clusterSettingsHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/_cluster/settings?flat_settings=true", nil)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch_cluster_settings: discover: %s", err)
+	}
+
+	body, status, err := client.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch_cluster_settings: discover: %s", err)
+	}
+	if status < 200 || status >= 300 {
+		return nil, fmt.Errorf("opensearch_cluster_settings: discover failed (%d): %s", status, body)
+	}
+
+	var resp struct {
+		Persistent map[string]any `json:"persistent"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("opensearch_cluster_settings: discover: %s", err)
+	}
+
+	// No persistent settings configured — nothing to discover.
+	if len(resp.Persistent) == 0 {
+		return nil, nil
+	}
+
+	val := jsonToValue(resp.Persistent)
+	return []provider.Resource{{
+		ID:   provider.ResourceID{Type: "opensearch_cluster_settings", Name: clusterSettingsSingletonName},
+		Body: val.Map,
+	}}, nil
+}
+
+// Normalize is minimal — flat settings are already in canonical form.
+func (h *clusterSettingsHandler) Normalize(_ context.Context, r provider.Resource) (provider.Resource, error) {
+	body := r.Body.Clone()
+	return provider.Resource{ID: r.ID, Body: body, SourceRange: r.SourceRange}, nil
+}
+
+// Validate checks structural correctness of a cluster settings resource.
+func (h *clusterSettingsHandler) Validate(_ context.Context, r provider.Resource) error {
+	prefix := fmt.Sprintf("opensearch_cluster_settings.%s", r.ID.Name)
+
+	// All values must be strings (flat settings are string key-value pairs).
+	for _, key := range r.Body.Keys() {
+		v, _ := r.Body.Get(key)
+		if v.Kind != provider.KindString {
+			return fmt.Errorf("%s: setting %q must be a string, got %s", prefix, key, v.Kind)
+		}
+	}
+
+	// TODO: Reject more than one opensearch_cluster_settings block.
+	// The handler interface validates one resource at a time, so this check
+	// would need to happen at the engine level.
+
+	return nil
+}
+
+// Apply creates, updates, or deletes (resets) cluster settings.
+// Create and Update send a partial PUT with only the user-declared keys.
+// Delete resets each managed key to its default by PUTting null values.
+func (h *clusterSettingsHandler) Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error {
+	switch op {
+	case provider.OpCreate, provider.OpUpdate:
+		settings := make(map[string]any)
+		for _, key := range r.Body.Keys() {
+			v, _ := r.Body.Get(key)
+			settings[key] = valueToJSON(v)
+		}
+
+		envelope := map[string]any{"persistent": settings}
+		data, err := json.Marshal(envelope)
+		if err != nil {
+			return fmt.Errorf("opensearch_cluster_settings.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+			"/_cluster/settings", bytes.NewReader(data))
+		if err != nil {
+			return fmt.Errorf("opensearch_cluster_settings.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return fmt.Errorf("opensearch_cluster_settings.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("opensearch_cluster_settings.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+		}
+		return nil
+
+	case provider.OpDelete:
+		// Reset each managed key to default by sending null.
+		settings := make(map[string]any)
+		for _, key := range r.Body.Keys() {
+			settings[key] = nil
+		}
+
+		envelope := map[string]any{"persistent": settings}
+		data, err := json.Marshal(envelope)
+		if err != nil {
+			return fmt.Errorf("opensearch_cluster_settings.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+			"/_cluster/settings", bytes.NewReader(data))
+		if err != nil {
+			return fmt.Errorf("opensearch_cluster_settings.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		body, status, err := client.do(req)
+		if err != nil {
+			return fmt.Errorf("opensearch_cluster_settings.%s: %s failed: %s", r.ID.Name, op, err)
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("opensearch_cluster_settings.%s: %s failed (%d): %s", r.ID.Name, op, status, body)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("opensearch_cluster_settings.%s: unsupported operation %s", r.ID.Name, op)
+	}
+}

--- a/providers/opensearch/cluster_settings_test.go
+++ b/providers/opensearch/cluster_settings_test.go
@@ -1,0 +1,194 @@
+package opensearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// --- Unit tests (no cluster needed) ---
+
+func TestClusterSettingsNormalize_idempotent(t *testing.T) {
+	h := &clusterSettingsHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_cluster_settings", Name: "cluster"},
+		Body: buildMap(
+			"action.auto_create_index", provider.StringVal("true"),
+			"cluster.routing.allocation.enable", provider.StringVal("all"),
+		),
+	}
+
+	first, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("first Normalize failed: %v", err)
+	}
+	second, err := h.Normalize(context.Background(), first)
+	if err != nil {
+		t.Fatalf("second Normalize failed: %v", err)
+	}
+
+	if !first.Body.Equal(second.Body) {
+		t.Errorf("Normalize is not idempotent:\nfirst:  %s\nsecond: %s",
+			provider.MapVal(first.Body), provider.MapVal(second.Body))
+	}
+}
+
+func TestClusterSettingsValidate_valid_settings(t *testing.T) {
+	h := &clusterSettingsHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_cluster_settings", Name: "cluster"},
+		Body: buildMap(
+			"action.auto_create_index", provider.StringVal("true"),
+		),
+	}
+
+	if err := h.Validate(context.Background(), r); err != nil {
+		t.Errorf("expected valid settings to pass, got: %v", err)
+	}
+}
+
+func TestClusterSettingsValidate_non_string_value(t *testing.T) {
+	h := &clusterSettingsHandler{}
+	r := provider.Resource{
+		ID: provider.ResourceID{Type: "opensearch_cluster_settings", Name: "cluster"},
+		Body: buildMap(
+			"action.auto_create_index", provider.IntVal(1),
+		),
+	}
+
+	err := h.Validate(context.Background(), r)
+	if err == nil {
+		t.Fatal("expected error for non-string setting value")
+	}
+}
+
+// --- Integration tests ---
+
+func TestClusterSettingsHandler_Integration(t *testing.T) {
+	client := newTestClient(t)
+	h := &clusterSettingsHandler{}
+	ctx := context.Background()
+
+	// The setting we'll manage for testing.
+	testKey := "action.auto_create_index"
+
+	// Cleanup: reset the test setting after the test.
+	t.Cleanup(func() {
+		settings := map[string]any{"persistent": map[string]any{testKey: nil}}
+		data, _ := json.Marshal(settings)
+		req, _ := http.NewRequest(http.MethodPut, "/_cluster/settings", bytes.NewReader(data))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.api.Client.Perform(req)
+		if err != nil {
+			t.Logf("cleanup: PUT /_cluster/settings failed: %v", err)
+			return
+		}
+		resp.Body.Close()
+	})
+
+	t.Run("create", func(t *testing.T) {
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_cluster_settings", Name: clusterSettingsSingletonName},
+			Body: buildMap(
+				testKey, provider.StringVal("false"),
+			),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpCreate, r); err != nil {
+			t.Fatalf("Apply OpCreate failed: %v", err)
+		}
+	})
+
+	t.Run("discover_after_create", func(t *testing.T) {
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover failed: %v", err)
+		}
+
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == clusterSettingsSingletonName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatal("expected to find cluster settings in discovered resources")
+		}
+
+		v, ok := found.Body.Get(testKey)
+		if !ok {
+			t.Fatalf("discovered settings missing %q", testKey)
+		}
+		if v.Str != "false" {
+			t.Errorf("expected %q to be \"false\", got %q", testKey, v.Str)
+		}
+	})
+
+	t.Run("update", func(t *testing.T) {
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_cluster_settings", Name: clusterSettingsSingletonName},
+			Body: buildMap(
+				testKey, provider.StringVal("true"),
+			),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpUpdate, r); err != nil {
+			t.Fatalf("Apply OpUpdate failed: %v", err)
+		}
+
+		// Verify via Discover.
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover after update failed: %v", err)
+		}
+		var found *provider.Resource
+		for i := range resources {
+			if resources[i].ID.Name == clusterSettingsSingletonName {
+				found = &resources[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Fatal("cluster settings not found after update")
+		}
+
+		v, _ := found.Body.Get(testKey)
+		if v.Str != "true" {
+			t.Errorf("expected %q to be \"true\" after update, got %q", testKey, v.Str)
+		}
+	})
+
+	t.Run("delete_resets_to_default", func(t *testing.T) {
+		r := provider.Resource{
+			ID: provider.ResourceID{Type: "opensearch_cluster_settings", Name: clusterSettingsSingletonName},
+			Body: buildMap(
+				testKey, provider.StringVal("true"),
+			),
+		}
+
+		if err := h.Apply(ctx, client, provider.OpDelete, r); err != nil {
+			t.Fatalf("Apply OpDelete failed: %v", err)
+		}
+
+		// After delete, the key should no longer appear in persistent settings.
+		resources, err := h.Discover(ctx, client)
+		if err != nil {
+			t.Fatalf("Discover after delete failed: %v", err)
+		}
+
+		// Either no resource discovered (no persistent settings left),
+		// or the test key is absent from the body.
+		for _, res := range resources {
+			if res.ID.Name == clusterSettingsSingletonName {
+				if _, ok := res.Body.Get(testKey); ok {
+					t.Errorf("expected %q to be reset after delete, but it still appears in persistent settings", testKey)
+				}
+			}
+		}
+	})
+}

--- a/providers/opensearch/provider.go
+++ b/providers/opensearch/provider.go
@@ -12,10 +12,11 @@ func init() {
 	provider.Register("opensearch", func() provider.Provider {
 		return &Provider{
 			handlers: map[string]resourceHandler{
-				"opensearch_role":          &roleHandler{},
-				"opensearch_internal_user": &internalUserHandler{},
-				"opensearch_role_mapping":  &roleMappingHandler{},
-				"opensearch_ism_policy":    &ismPolicyHandler{},
+				"opensearch_role":              &roleHandler{},
+				"opensearch_internal_user":     &internalUserHandler{},
+				"opensearch_role_mapping":      &roleMappingHandler{},
+				"opensearch_ism_policy":        &ismPolicyHandler{},
+				"opensearch_cluster_settings":  &clusterSettingsHandler{},
 				"opensearch_component_template":        &componentTemplateHandler{},
 				"opensearch_composable_index_template": &composableIndexTemplateHandler{},
 				"opensearch_ingest_pipeline":           &ingestPipelineHandler{},


### PR DESCRIPTION
## Summary

- Implements `clusterSettingsHandler` for the `opensearch_cluster_settings` resource type
- Singleton resource with canonical name `"cluster"` — one per cluster
- `Discover` uses `flat_settings=true` for dot-notation keys and returns at most one resource
- `Apply` sends partial PUT for create/update (only user-declared keys) and null-value PUT for delete (resets to OpenSearch defaults — no HTTP DELETE)
- Registered handler in `provider.go`

## Test plan

- [x] `go vet ./...` — clean
- [x] `TestClusterSettingsNormalize_idempotent` — passes
- [x] `TestClusterSettingsValidate_valid_settings` — passes
- [x] `TestClusterSettingsValidate_non_string_value` — passes
- [x] `TestClusterSettingsHandler_Integration/create` — passes
- [x] `TestClusterSettingsHandler_Integration/discover_after_create` — passes
- [x] `TestClusterSettingsHandler_Integration/update` — passes
- [x] `TestClusterSettingsHandler_Integration/delete_resets_to_default` — passes

Closes #99