### PR TITLE
feat(config): add context block extraction and parsing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,167 @@
+// Package config extracts and validates connection contexts from parsed DCL files.
+// Contexts define how to connect to a provider (endpoint, auth, credentials).
+// This package bridges DCL AST blocks and the provider.OrderedMap configs
+// that engine.ConfigureProviders expects.
+package config
+
+import (
+	"fmt"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// Context is a validated, structured representation of a DCL context block.
+type Context struct {
+	Name     string              // block label (e.g., "prod-opensearch")
+	Provider string              // value of the "provider" attribute
+	Attrs    *provider.OrderedMap // remaining attributes (endpoint, auth, etc.)
+}
+
+// SplitFile separates context blocks from resource blocks in a parsed DCL file.
+// Context blocks have Type == "context". Everything else is treated as a resource block.
+func SplitFile(file *dcl.File) (contexts []dcl.Block, resources []dcl.Block) {
+	for _, block := range file.Blocks {
+		if block.Type == "context" {
+			contexts = append(contexts, block)
+		} else {
+			resources = append(resources, block)
+		}
+	}
+	return contexts, resources
+}
+
+// ParseContexts validates and converts raw context blocks into structured Contexts.
+//
+// Each context block must have:
+//   - A label (the context name)
+//   - A "provider" attribute that is a string or identifier
+//
+// The provider attribute is extracted and stored separately; it does not appear in Attrs.
+// Duplicate context names produce an error.
+func ParseContexts(blocks []dcl.Block) ([]Context, error) {
+	seen := map[string]struct{}{}
+	contexts := make([]Context, 0, len(blocks))
+
+	for _, block := range blocks {
+		if block.Label == "" {
+			return nil, fmt.Errorf("context block is missing a name — use: context \"my-name\" { ... }")
+		}
+
+		if _, dup := seen[block.Label]; dup {
+			return nil, fmt.Errorf("duplicate context name %q — each context must have a unique name", block.Label)
+		}
+		seen[block.Label] = struct{}{}
+
+		providerName, attrs, err := extractContextAttrs(block)
+		if err != nil {
+			return nil, fmt.Errorf("context %q: %s", block.Label, err)
+		}
+
+		contexts = append(contexts, Context{
+			Name:     block.Label,
+			Provider: providerName,
+			Attrs:    attrs,
+		})
+	}
+
+	return contexts, nil
+}
+
+// extractContextAttrs pulls the "provider" attribute out of a context block
+// and converts the remaining attributes into a provider.OrderedMap.
+func extractContextAttrs(block dcl.Block) (string, *provider.OrderedMap, error) {
+	var providerName string
+	attrs := provider.NewOrderedMap()
+
+	for _, attr := range block.Attributes {
+		if attr.Key == "provider" {
+			name, err := identifierString(attr.Value)
+			if err != nil {
+				return "", nil, fmt.Errorf("\"provider\" must be a name (e.g. opensearch), got %T", attr.Value)
+			}
+			providerName = name
+			continue
+		}
+
+		v, err := exprToValue(attr.Value)
+		if err != nil {
+			return "", nil, fmt.Errorf("attribute %q: %s", attr.Key, err)
+		}
+		attrs.Set(attr.Key, v)
+	}
+
+	if providerName == "" {
+		return "", nil, fmt.Errorf("\"provider\" attribute is required — specify which provider this context configures (e.g. provider = opensearch)")
+	}
+
+	return providerName, attrs, nil
+}
+
+// identifierString extracts a string from an Identifier or LiteralString expression.
+func identifierString(expr dcl.Expression) (string, error) {
+	switch e := expr.(type) {
+	case *dcl.Identifier:
+		return e.Name, nil
+	case *dcl.LiteralString:
+		return e.Value, nil
+	default:
+		return "", fmt.Errorf("expected identifier or string, got %T", expr)
+	}
+}
+
+// exprToValue converts a DCL AST expression into a provider.Value.
+// Same logic as engine/convert.go's exprToValue — duplicated here to avoid
+// an import cycle (engine will import config in a later ticket).
+func exprToValue(expr dcl.Expression) (provider.Value, error) {
+	if expr == nil {
+		return provider.Value{}, fmt.Errorf("cannot convert nil expression")
+	}
+
+	switch e := expr.(type) {
+	case *dcl.LiteralString:
+		return provider.StringVal(e.Value), nil
+	case *dcl.LiteralInt:
+		return provider.IntVal(e.Value), nil
+	case *dcl.LiteralFloat:
+		return provider.FloatVal(e.Value), nil
+	case *dcl.LiteralBool:
+		return provider.BoolVal(e.Value), nil
+	case *dcl.Identifier:
+		return provider.StringVal(e.Name), nil
+	case *dcl.Reference:
+		return provider.RefVal(e.Parts), nil
+	case *dcl.FunctionCall:
+		args := make([]provider.Value, len(e.Args))
+		for i, arg := range e.Args {
+			v, err := exprToValue(arg)
+			if err != nil {
+				return provider.Value{}, fmt.Errorf("function %q arg %d: %w", e.Name, i, err)
+			}
+			args[i] = v
+		}
+		return provider.FuncCallVal(e.Name, args), nil
+	case *dcl.ListExpr:
+		elems := make([]provider.Value, len(e.Elements))
+		for i, elem := range e.Elements {
+			v, err := exprToValue(elem)
+			if err != nil {
+				return provider.Value{}, fmt.Errorf("list element %d: %w", i, err)
+			}
+			elems[i] = v
+		}
+		return provider.ListVal(elems), nil
+	case *dcl.MapExpr:
+		m := provider.NewOrderedMap()
+		for i, val := range e.Values {
+			v, err := exprToValue(val)
+			if err != nil {
+				return provider.Value{}, fmt.Errorf("map key %q: %w", e.Keys[i], err)
+			}
+			m.Set(e.Keys[i], v)
+		}
+		return provider.MapVal(m), nil
+	default:
+		return provider.Value{}, fmt.Errorf("unsupported expression type %T", expr)
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,289 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// --- SplitFile tests ---
+
+func TestSplitFile_separates_contexts_and_resources(t *testing.T) {
+	file := &dcl.File{
+		Blocks: []dcl.Block{
+			{Type: "context", Label: "prod"},
+			{Type: "opensearch_role", Label: "reader"},
+			{Type: "context", Label: "staging"},
+			{Type: "opensearch_ism_policy", Label: "lifecycle"},
+		},
+	}
+
+	contexts, resources := SplitFile(file)
+
+	if len(contexts) != 2 {
+		t.Fatalf("expected 2 context blocks, got %d", len(contexts))
+	}
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resource blocks, got %d", len(resources))
+	}
+
+	if contexts[0].Label != "prod" || contexts[1].Label != "staging" {
+		t.Errorf("context labels: got %q and %q", contexts[0].Label, contexts[1].Label)
+	}
+	if resources[0].Type != "opensearch_role" || resources[1].Type != "opensearch_ism_policy" {
+		t.Errorf("resource types: got %q and %q", resources[0].Type, resources[1].Type)
+	}
+}
+
+func TestSplitFile_no_contexts(t *testing.T) {
+	file := &dcl.File{
+		Blocks: []dcl.Block{
+			{Type: "opensearch_role", Label: "reader"},
+		},
+	}
+
+	contexts, resources := SplitFile(file)
+
+	if len(contexts) != 0 {
+		t.Errorf("expected 0 contexts, got %d", len(contexts))
+	}
+	if len(resources) != 1 {
+		t.Errorf("expected 1 resource, got %d", len(resources))
+	}
+}
+
+func TestSplitFile_no_resources(t *testing.T) {
+	file := &dcl.File{
+		Blocks: []dcl.Block{
+			{Type: "context", Label: "prod"},
+			{Type: "context", Label: "staging"},
+		},
+	}
+
+	contexts, resources := SplitFile(file)
+
+	if len(contexts) != 2 {
+		t.Errorf("expected 2 contexts, got %d", len(contexts))
+	}
+	if len(resources) != 0 {
+		t.Errorf("expected 0 resources, got %d", len(resources))
+	}
+}
+
+// --- ParseContexts tests ---
+
+func TestParseContexts_valid(t *testing.T) {
+	blocks := []dcl.Block{
+		{
+			Type:  "context",
+			Label: "prod-opensearch",
+			Attributes: []dcl.Attribute{
+				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
+				{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://search.example.com:9200"}},
+				{Key: "auth", Value: &dcl.LiteralString{Value: "basic"}},
+				{Key: "username", Value: &dcl.LiteralString{Value: "admin"}},
+			},
+		},
+	}
+
+	contexts, err := ParseContexts(blocks)
+	if err != nil {
+		t.Fatalf("ParseContexts failed: %v", err)
+	}
+
+	if len(contexts) != 1 {
+		t.Fatalf("expected 1 context, got %d", len(contexts))
+	}
+
+	ctx := contexts[0]
+	if ctx.Name != "prod-opensearch" {
+		t.Errorf("expected name %q, got %q", "prod-opensearch", ctx.Name)
+	}
+	if ctx.Provider != "opensearch" {
+		t.Errorf("expected provider %q, got %q", "opensearch", ctx.Provider)
+	}
+
+	// Verify provider is NOT in attrs.
+	if _, ok := ctx.Attrs.Get("provider"); ok {
+		t.Error("provider should not appear in Attrs")
+	}
+
+	// Verify other attrs are present.
+	endpoint, ok := ctx.Attrs.Get("endpoint")
+	if !ok || endpoint.Str != "https://search.example.com:9200" {
+		t.Errorf("expected endpoint, got %v", endpoint)
+	}
+	auth, ok := ctx.Attrs.Get("auth")
+	if !ok || auth.Str != "basic" {
+		t.Errorf("expected auth=basic, got %v", auth)
+	}
+	username, ok := ctx.Attrs.Get("username")
+	if !ok || username.Str != "admin" {
+		t.Errorf("expected username=admin, got %v", username)
+	}
+}
+
+func TestParseContexts_multiple(t *testing.T) {
+	blocks := []dcl.Block{
+		{
+			Type:  "context",
+			Label: "prod-os",
+			Attributes: []dcl.Attribute{
+				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
+				{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://prod:9200"}},
+			},
+		},
+		{
+			Type:  "context",
+			Label: "staging-os",
+			Attributes: []dcl.Attribute{
+				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
+				{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://staging:9200"}},
+			},
+		},
+	}
+
+	contexts, err := ParseContexts(blocks)
+	if err != nil {
+		t.Fatalf("ParseContexts failed: %v", err)
+	}
+	if len(contexts) != 2 {
+		t.Fatalf("expected 2 contexts, got %d", len(contexts))
+	}
+	if contexts[0].Name != "prod-os" || contexts[1].Name != "staging-os" {
+		t.Errorf("got names %q and %q", contexts[0].Name, contexts[1].Name)
+	}
+}
+
+func TestParseContexts_missing_label(t *testing.T) {
+	blocks := []dcl.Block{
+		{
+			Type:  "context",
+			Label: "",
+			Attributes: []dcl.Attribute{
+				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
+			},
+		},
+	}
+
+	_, err := ParseContexts(blocks)
+	if err == nil {
+		t.Fatal("expected error for missing label")
+	}
+}
+
+func TestParseContexts_missing_provider(t *testing.T) {
+	blocks := []dcl.Block{
+		{
+			Type:  "context",
+			Label: "prod",
+			Attributes: []dcl.Attribute{
+				{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://prod:9200"}},
+			},
+		},
+	}
+
+	_, err := ParseContexts(blocks)
+	if err == nil {
+		t.Fatal("expected error for missing provider")
+	}
+}
+
+func TestParseContexts_duplicate_name(t *testing.T) {
+	blocks := []dcl.Block{
+		{
+			Type:  "context",
+			Label: "prod",
+			Attributes: []dcl.Attribute{
+				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
+			},
+		},
+		{
+			Type:  "context",
+			Label: "prod",
+			Attributes: []dcl.Attribute{
+				{Key: "provider", Value: &dcl.Identifier{Name: "redis"}},
+			},
+		},
+	}
+
+	_, err := ParseContexts(blocks)
+	if err == nil {
+		t.Fatal("expected error for duplicate context name")
+	}
+}
+
+func TestParseContexts_provider_not_string(t *testing.T) {
+	blocks := []dcl.Block{
+		{
+			Type:  "context",
+			Label: "prod",
+			Attributes: []dcl.Attribute{
+				{Key: "provider", Value: &dcl.LiteralInt{Value: 42}},
+			},
+		},
+	}
+
+	_, err := ParseContexts(blocks)
+	if err == nil {
+		t.Fatal("expected error for non-string provider")
+	}
+}
+
+func TestParseContexts_provider_as_string_literal(t *testing.T) {
+	blocks := []dcl.Block{
+		{
+			Type:  "context",
+			Label: "prod",
+			Attributes: []dcl.Attribute{
+				{Key: "provider", Value: &dcl.LiteralString{Value: "opensearch"}},
+				{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://prod:9200"}},
+			},
+		},
+	}
+
+	contexts, err := ParseContexts(blocks)
+	if err != nil {
+		t.Fatalf("ParseContexts failed: %v", err)
+	}
+	if contexts[0].Provider != "opensearch" {
+		t.Errorf("expected provider %q, got %q", "opensearch", contexts[0].Provider)
+	}
+}
+
+func TestParseContexts_converts_secret_calls(t *testing.T) {
+	blocks := []dcl.Block{
+		{
+			Type:  "context",
+			Label: "prod",
+			Attributes: []dcl.Attribute{
+				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
+				{Key: "password", Value: &dcl.FunctionCall{
+					Name: "secret",
+					Args: []dcl.Expression{
+						&dcl.LiteralString{Value: "env"},
+						&dcl.LiteralString{Value: "OS_PASSWORD"},
+					},
+				}},
+			},
+		},
+	}
+
+	contexts, err := ParseContexts(blocks)
+	if err != nil {
+		t.Fatalf("ParseContexts failed: %v", err)
+	}
+
+	pw, ok := contexts[0].Attrs.Get("password")
+	if !ok {
+		t.Fatal("expected password attr")
+	}
+	// Should be preserved as a FuncCallVal for later resolution.
+	if pw.Kind != provider.KindFunctionCall {
+		t.Errorf("expected KindFunctionCall, got %s", pw.Kind)
+	}
+	if pw.FuncName != "secret" {
+		t.Errorf("expected function name %q, got %q", "secret", pw.FuncName)
+	}
+}


### PR DESCRIPTION
## Summary

- New `config/` package — first ticket in the config module
- `SplitFile()` separates context blocks (`Type == "context"`) from resource blocks in a parsed DCL file
- `Context` type holds the structured result: Name, Provider, and Attrs (`*provider.OrderedMap`)
- `ParseContexts()` validates context blocks: label required, `provider` attribute required and must be a string/identifier, no duplicate names, remaining attributes converted to `provider.OrderedMap`
- `secret()` function calls in context attributes are preserved as `FuncCallVal` for later resolution (#117)
- `exprToValue` duplicated from `engine/convert.go` to avoid an import cycle (engine will import config in #119)

Closes #114

## Test plan

- [x] `go vet ./config/...` passes
- [x] 11 unit tests: SplitFile (mixed/no-contexts/no-resources), ParseContexts (valid/multiple/missing-label/missing-provider/duplicate-name/provider-not-string/provider-as-string-literal/secret-calls-preserved)
- [x] `go test ./... -count=1` full suite green