### PR TITLE
feat(config): add BuildConfigs, ResolveResourceContexts, and config file loading

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,10 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/MathewBravo/datastorectl/dcl"
 	"github.com/MathewBravo/datastorectl/provider"
@@ -67,6 +70,113 @@ func ParseContexts(blocks []dcl.Block) ([]Context, error) {
 
 	return contexts, nil
 }
+
+// BuildConfigs converts parsed contexts into the map[string]*provider.OrderedMap
+// format that engine.ConfigureProviders expects. The map key is the provider name
+// (e.g., "opensearch"). For v0.1.0, only one context per provider is supported.
+func BuildConfigs(contexts []Context) (map[string]*provider.OrderedMap, error) {
+	configs := make(map[string]*provider.OrderedMap, len(contexts))
+	for _, ctx := range contexts {
+		if _, dup := configs[ctx.Provider]; dup {
+			return nil, fmt.Errorf("multiple contexts configure provider %q — v0.1.0 supports one context per provider", ctx.Provider)
+		}
+		configs[ctx.Provider] = ctx.Attrs
+	}
+	return configs, nil
+}
+
+// ResolveResourceContexts strips the "context" attribute from each resource body
+// and validates that every resource references a known context whose provider
+// matches the resource type prefix.
+func ResolveResourceContexts(resources []provider.Resource, contexts []Context) ([]provider.Resource, error) {
+	ctxByName := make(map[string]Context, len(contexts))
+	for _, ctx := range contexts {
+		ctxByName[ctx.Name] = ctx
+	}
+
+	resolved := make([]provider.Resource, len(resources))
+	for i, r := range resources {
+		ctxVal, ok := r.Body.Get("context")
+		if !ok {
+			return nil, fmt.Errorf("%s: \"context\" attribute is required — every resource must declare which context it belongs to", r.ID)
+		}
+		if ctxVal.Kind != provider.KindString {
+			return nil, fmt.Errorf("%s: \"context\" must be a name, got %s", r.ID, ctxVal.Kind)
+		}
+
+		ctxName := ctxVal.Str
+		ctx, ok := ctxByName[ctxName]
+		if !ok {
+			return nil, fmt.Errorf("%s: references unknown context %q", r.ID, ctxName)
+		}
+
+		prefix, ok := provider.ProviderForResourceType(r.ID.Type)
+		if !ok {
+			return nil, fmt.Errorf("%s: cannot determine provider from resource type", r.ID)
+		}
+		if prefix != ctx.Provider {
+			return nil, fmt.Errorf("%s: resource type prefix %q does not match context %q provider %q", r.ID, prefix, ctxName, ctx.Provider)
+		}
+
+		body := r.Body.Clone()
+		body.Delete("context")
+		resolved[i] = provider.Resource{ID: r.ID, Body: body, SourceRange: r.SourceRange}
+	}
+
+	return resolved, nil
+}
+
+// LoadConfigFile loads contexts from a DCL config file (e.g., ~/.datastorectl/config.dcl).
+// Returns an empty slice and no error if the file does not exist (config file is optional).
+// Returns an error if the file contains resource blocks (config files are for contexts only).
+func LoadConfigFile(path string) ([]Context, error) {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+
+	file, diags := dcl.LoadFile(path)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("loading config file %s: %s", path, diags.Error())
+	}
+
+	contexts, resources := SplitFile(file)
+	if len(resources) > 0 {
+		return nil, fmt.Errorf("config file %s contains resource blocks — config files should only contain context blocks", path)
+	}
+
+	return ParseContexts(contexts)
+}
+
+// MergeContexts combines contexts from resource files (inline) with contexts
+// from a config file. Duplicate names across sources produce an error.
+func MergeContexts(inline, fromFile []Context) ([]Context, error) {
+	seen := make(map[string]struct{}, len(inline))
+	for _, ctx := range inline {
+		seen[ctx.Name] = struct{}{}
+	}
+	for _, ctx := range fromFile {
+		if _, dup := seen[ctx.Name]; dup {
+			return nil, fmt.Errorf("context %q defined in both resource files and config file — each context name must be unique", ctx.Name)
+		}
+		seen[ctx.Name] = struct{}{}
+	}
+
+	merged := make([]Context, 0, len(inline)+len(fromFile))
+	merged = append(merged, inline...)
+	merged = append(merged, fromFile...)
+	return merged, nil
+}
+
+// DefaultConfigPath returns the default config file path: ~/.datastorectl/config.dcl.
+func DefaultConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join("~", ".datastorectl", "config.dcl")
+	}
+	return filepath.Join(home, ".datastorectl", "config.dcl")
+}
+
+// --- private helpers ---
 
 // extractContextAttrs pulls the "provider" attribute out of a context block
 // and converts the remaining attributes into a provider.OrderedMap.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,13 +1,16 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/MathewBravo/datastorectl/dcl"
 	"github.com/MathewBravo/datastorectl/provider"
 )
 
-// --- SplitFile tests ---
+// --- SplitFile tests (#114) ---
 
 func TestSplitFile_separates_contexts_and_resources(t *testing.T) {
 	file := &dcl.File{
@@ -27,7 +30,6 @@ func TestSplitFile_separates_contexts_and_resources(t *testing.T) {
 	if len(resources) != 2 {
 		t.Fatalf("expected 2 resource blocks, got %d", len(resources))
 	}
-
 	if contexts[0].Label != "prod" || contexts[1].Label != "staging" {
 		t.Errorf("context labels: got %q and %q", contexts[0].Label, contexts[1].Label)
 	}
@@ -37,14 +39,8 @@ func TestSplitFile_separates_contexts_and_resources(t *testing.T) {
 }
 
 func TestSplitFile_no_contexts(t *testing.T) {
-	file := &dcl.File{
-		Blocks: []dcl.Block{
-			{Type: "opensearch_role", Label: "reader"},
-		},
-	}
-
+	file := &dcl.File{Blocks: []dcl.Block{{Type: "opensearch_role", Label: "reader"}}}
 	contexts, resources := SplitFile(file)
-
 	if len(contexts) != 0 {
 		t.Errorf("expected 0 contexts, got %d", len(contexts))
 	}
@@ -54,15 +50,8 @@ func TestSplitFile_no_contexts(t *testing.T) {
 }
 
 func TestSplitFile_no_resources(t *testing.T) {
-	file := &dcl.File{
-		Blocks: []dcl.Block{
-			{Type: "context", Label: "prod"},
-			{Type: "context", Label: "staging"},
-		},
-	}
-
+	file := &dcl.File{Blocks: []dcl.Block{{Type: "context", Label: "prod"}, {Type: "context", Label: "staging"}}}
 	contexts, resources := SplitFile(file)
-
 	if len(contexts) != 2 {
 		t.Errorf("expected 2 contexts, got %d", len(contexts))
 	}
@@ -71,27 +60,24 @@ func TestSplitFile_no_resources(t *testing.T) {
 	}
 }
 
-// --- ParseContexts tests ---
+// --- ParseContexts tests (#114) ---
 
 func TestParseContexts_valid(t *testing.T) {
-	blocks := []dcl.Block{
-		{
-			Type:  "context",
-			Label: "prod-opensearch",
-			Attributes: []dcl.Attribute{
-				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
-				{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://search.example.com:9200"}},
-				{Key: "auth", Value: &dcl.LiteralString{Value: "basic"}},
-				{Key: "username", Value: &dcl.LiteralString{Value: "admin"}},
-			},
+	blocks := []dcl.Block{{
+		Type:  "context",
+		Label: "prod-opensearch",
+		Attributes: []dcl.Attribute{
+			{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
+			{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://search.example.com:9200"}},
+			{Key: "auth", Value: &dcl.LiteralString{Value: "basic"}},
+			{Key: "username", Value: &dcl.LiteralString{Value: "admin"}},
 		},
-	}
+	}}
 
 	contexts, err := ParseContexts(blocks)
 	if err != nil {
 		t.Fatalf("ParseContexts failed: %v", err)
 	}
-
 	if len(contexts) != 1 {
 		t.Fatalf("expected 1 context, got %d", len(contexts))
 	}
@@ -103,70 +89,38 @@ func TestParseContexts_valid(t *testing.T) {
 	if ctx.Provider != "opensearch" {
 		t.Errorf("expected provider %q, got %q", "opensearch", ctx.Provider)
 	}
-
-	// Verify provider is NOT in attrs.
 	if _, ok := ctx.Attrs.Get("provider"); ok {
 		t.Error("provider should not appear in Attrs")
 	}
 
-	// Verify other attrs are present.
 	endpoint, ok := ctx.Attrs.Get("endpoint")
 	if !ok || endpoint.Str != "https://search.example.com:9200" {
 		t.Errorf("expected endpoint, got %v", endpoint)
-	}
-	auth, ok := ctx.Attrs.Get("auth")
-	if !ok || auth.Str != "basic" {
-		t.Errorf("expected auth=basic, got %v", auth)
-	}
-	username, ok := ctx.Attrs.Get("username")
-	if !ok || username.Str != "admin" {
-		t.Errorf("expected username=admin, got %v", username)
 	}
 }
 
 func TestParseContexts_multiple(t *testing.T) {
 	blocks := []dcl.Block{
-		{
-			Type:  "context",
-			Label: "prod-os",
-			Attributes: []dcl.Attribute{
-				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
-				{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://prod:9200"}},
-			},
-		},
-		{
-			Type:  "context",
-			Label: "staging-os",
-			Attributes: []dcl.Attribute{
-				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
-				{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://staging:9200"}},
-			},
-		},
+		{Type: "context", Label: "prod-os", Attributes: []dcl.Attribute{
+			{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
+		}},
+		{Type: "context", Label: "staging-os", Attributes: []dcl.Attribute{
+			{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
+		}},
 	}
-
 	contexts, err := ParseContexts(blocks)
 	if err != nil {
 		t.Fatalf("ParseContexts failed: %v", err)
 	}
 	if len(contexts) != 2 {
-		t.Fatalf("expected 2 contexts, got %d", len(contexts))
-	}
-	if contexts[0].Name != "prod-os" || contexts[1].Name != "staging-os" {
-		t.Errorf("got names %q and %q", contexts[0].Name, contexts[1].Name)
+		t.Fatalf("expected 2, got %d", len(contexts))
 	}
 }
 
 func TestParseContexts_missing_label(t *testing.T) {
-	blocks := []dcl.Block{
-		{
-			Type:  "context",
-			Label: "",
-			Attributes: []dcl.Attribute{
-				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
-			},
-		},
-	}
-
+	blocks := []dcl.Block{{Type: "context", Label: "", Attributes: []dcl.Attribute{
+		{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
+	}}}
 	_, err := ParseContexts(blocks)
 	if err == nil {
 		t.Fatal("expected error for missing label")
@@ -174,16 +128,9 @@ func TestParseContexts_missing_label(t *testing.T) {
 }
 
 func TestParseContexts_missing_provider(t *testing.T) {
-	blocks := []dcl.Block{
-		{
-			Type:  "context",
-			Label: "prod",
-			Attributes: []dcl.Attribute{
-				{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://prod:9200"}},
-			},
-		},
-	}
-
+	blocks := []dcl.Block{{Type: "context", Label: "prod", Attributes: []dcl.Attribute{
+		{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://prod:9200"}},
+	}}}
 	_, err := ParseContexts(blocks)
 	if err == nil {
 		t.Fatal("expected error for missing provider")
@@ -192,22 +139,9 @@ func TestParseContexts_missing_provider(t *testing.T) {
 
 func TestParseContexts_duplicate_name(t *testing.T) {
 	blocks := []dcl.Block{
-		{
-			Type:  "context",
-			Label: "prod",
-			Attributes: []dcl.Attribute{
-				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
-			},
-		},
-		{
-			Type:  "context",
-			Label: "prod",
-			Attributes: []dcl.Attribute{
-				{Key: "provider", Value: &dcl.Identifier{Name: "redis"}},
-			},
-		},
+		{Type: "context", Label: "prod", Attributes: []dcl.Attribute{{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}}}},
+		{Type: "context", Label: "prod", Attributes: []dcl.Attribute{{Key: "provider", Value: &dcl.Identifier{Name: "redis"}}}},
 	}
-
 	_, err := ParseContexts(blocks)
 	if err == nil {
 		t.Fatal("expected error for duplicate context name")
@@ -215,16 +149,9 @@ func TestParseContexts_duplicate_name(t *testing.T) {
 }
 
 func TestParseContexts_provider_not_string(t *testing.T) {
-	blocks := []dcl.Block{
-		{
-			Type:  "context",
-			Label: "prod",
-			Attributes: []dcl.Attribute{
-				{Key: "provider", Value: &dcl.LiteralInt{Value: 42}},
-			},
-		},
-	}
-
+	blocks := []dcl.Block{{Type: "context", Label: "prod", Attributes: []dcl.Attribute{
+		{Key: "provider", Value: &dcl.LiteralInt{Value: 42}},
+	}}}
 	_, err := ParseContexts(blocks)
 	if err == nil {
 		t.Fatal("expected error for non-string provider")
@@ -232,17 +159,9 @@ func TestParseContexts_provider_not_string(t *testing.T) {
 }
 
 func TestParseContexts_provider_as_string_literal(t *testing.T) {
-	blocks := []dcl.Block{
-		{
-			Type:  "context",
-			Label: "prod",
-			Attributes: []dcl.Attribute{
-				{Key: "provider", Value: &dcl.LiteralString{Value: "opensearch"}},
-				{Key: "endpoint", Value: &dcl.LiteralString{Value: "https://prod:9200"}},
-			},
-		},
-	}
-
+	blocks := []dcl.Block{{Type: "context", Label: "prod", Attributes: []dcl.Attribute{
+		{Key: "provider", Value: &dcl.LiteralString{Value: "opensearch"}},
+	}}}
 	contexts, err := ParseContexts(blocks)
 	if err != nil {
 		t.Fatalf("ParseContexts failed: %v", err)
@@ -253,37 +172,246 @@ func TestParseContexts_provider_as_string_literal(t *testing.T) {
 }
 
 func TestParseContexts_converts_secret_calls(t *testing.T) {
-	blocks := []dcl.Block{
-		{
-			Type:  "context",
-			Label: "prod",
-			Attributes: []dcl.Attribute{
-				{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
-				{Key: "password", Value: &dcl.FunctionCall{
-					Name: "secret",
-					Args: []dcl.Expression{
-						&dcl.LiteralString{Value: "env"},
-						&dcl.LiteralString{Value: "OS_PASSWORD"},
-					},
-				}},
-			},
-		},
-	}
-
+	blocks := []dcl.Block{{Type: "context", Label: "prod", Attributes: []dcl.Attribute{
+		{Key: "provider", Value: &dcl.Identifier{Name: "opensearch"}},
+		{Key: "password", Value: &dcl.FunctionCall{
+			Name: "secret",
+			Args: []dcl.Expression{&dcl.LiteralString{Value: "env"}, &dcl.LiteralString{Value: "OS_PASSWORD"}},
+		}},
+	}}}
 	contexts, err := ParseContexts(blocks)
 	if err != nil {
 		t.Fatalf("ParseContexts failed: %v", err)
 	}
-
 	pw, ok := contexts[0].Attrs.Get("password")
 	if !ok {
 		t.Fatal("expected password attr")
 	}
-	// Should be preserved as a FuncCallVal for later resolution.
-	if pw.Kind != provider.KindFunctionCall {
-		t.Errorf("expected KindFunctionCall, got %s", pw.Kind)
+	if pw.Kind != provider.KindFunctionCall || pw.FuncName != "secret" {
+		t.Errorf("expected secret FuncCallVal, got %s %q", pw.Kind, pw.FuncName)
 	}
-	if pw.FuncName != "secret" {
-		t.Errorf("expected function name %q, got %q", "secret", pw.FuncName)
+}
+
+// --- BuildConfigs tests (#115) ---
+
+func TestBuildConfigs_single_context(t *testing.T) {
+	contexts := []Context{{
+		Name: "prod", Provider: "opensearch",
+		Attrs: buildAttrs("endpoint", provider.StringVal("https://prod:9200"), "auth", provider.StringVal("basic")),
+	}}
+	configs, err := BuildConfigs(contexts)
+	if err != nil {
+		t.Fatalf("BuildConfigs failed: %v", err)
 	}
+	if len(configs) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(configs))
+	}
+	cfg, ok := configs["opensearch"]
+	if !ok {
+		t.Fatal("expected config for opensearch")
+	}
+	endpoint, _ := cfg.Get("endpoint")
+	if endpoint.Str != "https://prod:9200" {
+		t.Errorf("expected endpoint, got %v", endpoint)
+	}
+}
+
+func TestBuildConfigs_multiple_providers(t *testing.T) {
+	contexts := []Context{
+		{Name: "os-prod", Provider: "opensearch", Attrs: provider.NewOrderedMap()},
+		{Name: "redis-prod", Provider: "redis", Attrs: provider.NewOrderedMap()},
+	}
+	configs, err := BuildConfigs(contexts)
+	if err != nil {
+		t.Fatalf("BuildConfigs failed: %v", err)
+	}
+	if len(configs) != 2 {
+		t.Fatalf("expected 2, got %d", len(configs))
+	}
+}
+
+func TestBuildConfigs_duplicate_provider_error(t *testing.T) {
+	contexts := []Context{
+		{Name: "prod-os", Provider: "opensearch", Attrs: provider.NewOrderedMap()},
+		{Name: "staging-os", Provider: "opensearch", Attrs: provider.NewOrderedMap()},
+	}
+	_, err := BuildConfigs(contexts)
+	if err == nil {
+		t.Fatal("expected error for duplicate provider")
+	}
+}
+
+func TestBuildConfigs_empty(t *testing.T) {
+	configs, err := BuildConfigs(nil)
+	if err != nil {
+		t.Fatalf("BuildConfigs failed: %v", err)
+	}
+	if len(configs) != 0 {
+		t.Errorf("expected empty map, got %d", len(configs))
+	}
+}
+
+// --- ResolveResourceContexts tests (#116) ---
+
+func TestResolveResourceContexts_strips_context(t *testing.T) {
+	resources := []provider.Resource{{
+		ID: provider.ResourceID{Type: "opensearch_role", Name: "reader"},
+		Body: buildAttrs(
+			"context", provider.StringVal("prod"),
+			"cluster_permissions", provider.ListVal([]provider.Value{provider.StringVal("read")}),
+		),
+	}}
+	contexts := []Context{{Name: "prod", Provider: "opensearch", Attrs: provider.NewOrderedMap()}}
+
+	resolved, err := ResolveResourceContexts(resources, contexts)
+	if err != nil {
+		t.Fatalf("failed: %v", err)
+	}
+	if _, ok := resolved[0].Body.Get("context"); ok {
+		t.Error("expected context attribute to be stripped")
+	}
+	if _, ok := resolved[0].Body.Get("cluster_permissions"); !ok {
+		t.Error("expected cluster_permissions to be preserved")
+	}
+}
+
+func TestResolveResourceContexts_unknown_context(t *testing.T) {
+	resources := []provider.Resource{{
+		ID:   provider.ResourceID{Type: "opensearch_role", Name: "reader"},
+		Body: buildAttrs("context", provider.StringVal("nonexistent")),
+	}}
+	_, err := ResolveResourceContexts(resources, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown context")
+	}
+}
+
+func TestResolveResourceContexts_provider_mismatch(t *testing.T) {
+	resources := []provider.Resource{{
+		ID:   provider.ResourceID{Type: "opensearch_role", Name: "reader"},
+		Body: buildAttrs("context", provider.StringVal("redis-prod")),
+	}}
+	contexts := []Context{{Name: "redis-prod", Provider: "redis", Attrs: provider.NewOrderedMap()}}
+
+	_, err := ResolveResourceContexts(resources, contexts)
+	if err == nil {
+		t.Fatal("expected error for provider mismatch")
+	}
+}
+
+func TestResolveResourceContexts_missing_context_attr(t *testing.T) {
+	resources := []provider.Resource{{
+		ID:   provider.ResourceID{Type: "opensearch_role", Name: "reader"},
+		Body: buildAttrs("cluster_permissions", provider.ListVal(nil)),
+	}}
+	_, err := ResolveResourceContexts(resources, nil)
+	if err == nil {
+		t.Fatal("expected error for missing context attribute")
+	}
+}
+
+func TestResolveResourceContexts_multiple_resources(t *testing.T) {
+	resources := []provider.Resource{
+		{ID: provider.ResourceID{Type: "opensearch_role", Name: "reader"}, Body: buildAttrs("context", provider.StringVal("prod"))},
+		{ID: provider.ResourceID{Type: "opensearch_role", Name: "writer"}, Body: buildAttrs("context", provider.StringVal("prod"))},
+	}
+	contexts := []Context{{Name: "prod", Provider: "opensearch", Attrs: provider.NewOrderedMap()}}
+
+	resolved, err := ResolveResourceContexts(resources, contexts)
+	if err != nil {
+		t.Fatalf("failed: %v", err)
+	}
+	if len(resolved) != 2 {
+		t.Fatalf("expected 2, got %d", len(resolved))
+	}
+	for _, r := range resolved {
+		if _, ok := r.Body.Get("context"); ok {
+			t.Errorf("resource %s still has context attribute", r.ID)
+		}
+	}
+}
+
+// --- LoadConfigFile tests (#118) ---
+
+func TestLoadConfigFile_valid(t *testing.T) {
+	contexts, err := LoadConfigFile("testdata/valid_config.dcl")
+	if err != nil {
+		t.Fatalf("LoadConfigFile failed: %v", err)
+	}
+	if len(contexts) != 2 {
+		t.Fatalf("expected 2 contexts, got %d", len(contexts))
+	}
+	if contexts[0].Name != "prod" || contexts[1].Name != "staging" {
+		t.Errorf("got names %q and %q", contexts[0].Name, contexts[1].Name)
+	}
+}
+
+func TestLoadConfigFile_rejects_resource_blocks(t *testing.T) {
+	_, err := LoadConfigFile("testdata/invalid_has_resources.dcl")
+	if err == nil {
+		t.Fatal("expected error for resource blocks in config file")
+	}
+}
+
+func TestLoadConfigFile_missing_file(t *testing.T) {
+	contexts, err := LoadConfigFile("/nonexistent/path/config.dcl")
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got: %v", err)
+	}
+	if len(contexts) != 0 {
+		t.Errorf("expected empty slice, got %d contexts", len(contexts))
+	}
+}
+
+func TestLoadConfigFile_parse_error(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.dcl")
+	os.WriteFile(path, []byte("this is not { valid dcl !!!"), 0644)
+
+	_, err := LoadConfigFile(path)
+	if err == nil {
+		t.Fatal("expected error for malformed DCL")
+	}
+}
+
+// --- MergeContexts tests (#118) ---
+
+func TestMergeContexts_no_overlap(t *testing.T) {
+	inline := []Context{{Name: "prod", Provider: "opensearch"}}
+	fromFile := []Context{{Name: "staging", Provider: "opensearch"}}
+
+	merged, err := MergeContexts(inline, fromFile)
+	if err != nil {
+		t.Fatalf("MergeContexts failed: %v", err)
+	}
+	if len(merged) != 2 {
+		t.Fatalf("expected 2, got %d", len(merged))
+	}
+}
+
+func TestMergeContexts_duplicate_name_error(t *testing.T) {
+	inline := []Context{{Name: "prod", Provider: "opensearch"}}
+	fromFile := []Context{{Name: "prod", Provider: "opensearch"}}
+
+	_, err := MergeContexts(inline, fromFile)
+	if err == nil {
+		t.Fatal("expected error for duplicate context name")
+	}
+}
+
+func TestDefaultConfigPath(t *testing.T) {
+	path := DefaultConfigPath()
+	if !strings.HasSuffix(path, filepath.Join(".datastorectl", "config.dcl")) {
+		t.Errorf("unexpected path: %s", path)
+	}
+}
+
+// --- test helpers ---
+
+func buildAttrs(kvs ...any) *provider.OrderedMap {
+	m := provider.NewOrderedMap()
+	for i := 0; i < len(kvs); i += 2 {
+		m.Set(kvs[i].(string), kvs[i+1].(provider.Value))
+	}
+	return m
 }

--- a/config/testdata/invalid_has_resources.dcl
+++ b/config/testdata/invalid_has_resources.dcl
@@ -1,0 +1,8 @@
+context "prod" {
+  provider = opensearch
+  endpoint = "https://prod:9200"
+}
+
+opensearch_role "reader" {
+  cluster_permissions = ["read"]
+}

--- a/config/testdata/valid_config.dcl
+++ b/config/testdata/valid_config.dcl
@@ -1,0 +1,15 @@
+context "prod" {
+  provider = opensearch
+  endpoint = "https://prod:9200"
+  auth     = "basic"
+  username = "admin"
+  password = "secret"
+}
+
+context "staging" {
+  provider = opensearch
+  endpoint = "https://staging:9200"
+  auth     = "basic"
+  username = "admin"
+  password = "secret"
+}


### PR DESCRIPTION
## Summary

Implements the three independent config module tickets that depend on #114:

- **BuildConfigs** (#115) — converts `[]Context` to `map[string]*provider.OrderedMap` for `ConfigureProviders()`. One context per provider for v0.1.0; duplicate provider error.
- **ResolveResourceContexts** (#116) — strips `context` attribute from resource bodies, validates referenced context exists, validates resource type prefix matches context provider.
- **LoadConfigFile + MergeContexts + DefaultConfigPath** (#118) — loads contexts from `~/.datastorectl/config.dcl` (missing file = no error), rejects resource blocks in config files, merges inline and file contexts with duplicate detection.

Closes #115
Closes #116
Closes #118

## Test plan

- [x] `go vet ./config/...` passes
- [x] 27 unit tests across all config functions (up from 11 in #114)
- [x] Test fixtures: `config/testdata/valid_config.dcl`, `config/testdata/invalid_has_resources.dcl`
- [x] `go test ./... -count=1` full suite green