### PR TITLE
feat(config): add secret resolution in context configs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -13,6 +14,12 @@ import (
 	"github.com/MathewBravo/datastorectl/dcl"
 	"github.com/MathewBravo/datastorectl/provider"
 )
+
+// SecretResolver resolves a secret reference to its plaintext value.
+// This mirrors engine.SecretResolver — defined locally to avoid an import cycle.
+type SecretResolver interface {
+	Resolve(ctx context.Context, backend, path string) (string, error)
+}
 
 // Context is a validated, structured representation of a DCL context block.
 type Context struct {
@@ -174,6 +181,72 @@ func DefaultConfigPath() string {
 		return filepath.Join("~", ".datastorectl", "config.dcl")
 	}
 	return filepath.Join(home, ".datastorectl", "config.dcl")
+}
+
+// ResolveConfigSecrets walks each config's OrderedMap and resolves secret()
+// function calls via the given resolver. Configs are modified in place.
+func ResolveConfigSecrets(ctx context.Context, configs map[string]*provider.OrderedMap, resolver SecretResolver) error {
+	for providerName, cfg := range configs {
+		for _, key := range cfg.Keys() {
+			v, _ := cfg.Get(key)
+			rv, err := resolveSecretValue(ctx, v, resolver)
+			if err != nil {
+				return fmt.Errorf("provider %q config attribute %q: %s", providerName, key, err)
+			}
+			cfg.Set(key, rv)
+		}
+	}
+	return nil
+}
+
+// resolveSecretValue recursively walks a Value tree, resolving any secret() calls.
+func resolveSecretValue(ctx context.Context, v provider.Value, resolver SecretResolver) (provider.Value, error) {
+	switch v.Kind {
+	case provider.KindFunctionCall:
+		if v.FuncName != "secret" {
+			return provider.Value{}, fmt.Errorf("unsupported function %q — only secret() is supported", v.FuncName)
+		}
+		if len(v.FuncArgs) != 2 {
+			return provider.Value{}, fmt.Errorf("secret() requires exactly 2 arguments, got %d", len(v.FuncArgs))
+		}
+		if v.FuncArgs[0].Kind != provider.KindString {
+			return provider.Value{}, fmt.Errorf("secret() argument 0 must be a string, got %s", v.FuncArgs[0].Kind)
+		}
+		if v.FuncArgs[1].Kind != provider.KindString {
+			return provider.Value{}, fmt.Errorf("secret() argument 1 must be a string, got %s", v.FuncArgs[1].Kind)
+		}
+		resolved, err := resolver.Resolve(ctx, v.FuncArgs[0].Str, v.FuncArgs[1].Str)
+		if err != nil {
+			return provider.Value{}, fmt.Errorf("secret(%q, %q): %s", v.FuncArgs[0].Str, v.FuncArgs[1].Str, err)
+		}
+		return provider.StringVal(resolved), nil
+
+	case provider.KindList:
+		elems := make([]provider.Value, len(v.List))
+		for i, elem := range v.List {
+			rv, err := resolveSecretValue(ctx, elem, resolver)
+			if err != nil {
+				return provider.Value{}, fmt.Errorf("list element %d: %s", i, err)
+			}
+			elems[i] = rv
+		}
+		return provider.ListVal(elems), nil
+
+	case provider.KindMap:
+		m := provider.NewOrderedMap()
+		for _, key := range v.Map.Keys() {
+			val, _ := v.Map.Get(key)
+			rv, err := resolveSecretValue(ctx, val, resolver)
+			if err != nil {
+				return provider.Value{}, fmt.Errorf("key %q: %s", key, err)
+			}
+			m.Set(key, rv)
+		}
+		return provider.MapVal(m), nil
+
+	default:
+		return v, nil
+	}
 }
 
 // --- private helpers ---

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -403,6 +405,107 @@ func TestDefaultConfigPath(t *testing.T) {
 	path := DefaultConfigPath()
 	if !strings.HasSuffix(path, filepath.Join(".datastorectl", "config.dcl")) {
 		t.Errorf("unexpected path: %s", path)
+	}
+}
+
+// --- ResolveConfigSecrets tests (#117) ---
+
+// stubResolver implements SecretResolver for testing.
+type stubResolver struct{}
+
+func (stubResolver) Resolve(_ context.Context, backend, path string) (string, error) {
+	if backend != "env" {
+		return "", fmt.Errorf("unsupported secret backend %q", backend)
+	}
+	v, ok := os.LookupEnv(path)
+	if !ok {
+		return "", fmt.Errorf("environment variable %q is not set", path)
+	}
+	return v, nil
+}
+
+func TestResolveConfigSecrets_env_resolved(t *testing.T) {
+	t.Setenv("TEST_SECRET_VALUE", "my-password")
+
+	configs := map[string]*provider.OrderedMap{
+		"opensearch": buildAttrs(
+			"endpoint", provider.StringVal("https://prod:9200"),
+			"password", provider.FuncCallVal("secret", []provider.Value{
+				provider.StringVal("env"),
+				provider.StringVal("TEST_SECRET_VALUE"),
+			}),
+		),
+	}
+
+	err := ResolveConfigSecrets(context.Background(), configs, stubResolver{})
+	if err != nil {
+		t.Fatalf("ResolveConfigSecrets failed: %v", err)
+	}
+
+	pw, _ := configs["opensearch"].Get("password")
+	if pw.Kind != provider.KindString || pw.Str != "my-password" {
+		t.Errorf("expected resolved string \"my-password\", got %s %q", pw.Kind, pw.Str)
+	}
+}
+
+func TestResolveConfigSecrets_unsupported_backend(t *testing.T) {
+	configs := map[string]*provider.OrderedMap{
+		"opensearch": buildAttrs(
+			"password", provider.FuncCallVal("secret", []provider.Value{
+				provider.StringVal("vault"),
+				provider.StringVal("path/to/secret"),
+			}),
+		),
+	}
+
+	err := ResolveConfigSecrets(context.Background(), configs, stubResolver{})
+	if err == nil {
+		t.Fatal("expected error for unsupported backend")
+	}
+}
+
+func TestResolveConfigSecrets_missing_env_var(t *testing.T) {
+	configs := map[string]*provider.OrderedMap{
+		"opensearch": buildAttrs(
+			"password", provider.FuncCallVal("secret", []provider.Value{
+				provider.StringVal("env"),
+				provider.StringVal("DEFINITELY_NOT_SET_12345"),
+			}),
+		),
+	}
+
+	err := ResolveConfigSecrets(context.Background(), configs, stubResolver{})
+	if err == nil {
+		t.Fatal("expected error for missing env var")
+	}
+}
+
+func TestResolveConfigSecrets_non_secret_function(t *testing.T) {
+	configs := map[string]*provider.OrderedMap{
+		"opensearch": buildAttrs(
+			"value", provider.FuncCallVal("other_func", []provider.Value{
+				provider.StringVal("arg"),
+			}),
+		),
+	}
+
+	err := ResolveConfigSecrets(context.Background(), configs, stubResolver{})
+	if err == nil {
+		t.Fatal("expected error for unsupported function")
+	}
+}
+
+func TestResolveConfigSecrets_no_secrets(t *testing.T) {
+	configs := map[string]*provider.OrderedMap{
+		"opensearch": buildAttrs(
+			"endpoint", provider.StringVal("https://prod:9200"),
+			"auth", provider.StringVal("basic"),
+		),
+	}
+
+	err := ResolveConfigSecrets(context.Background(), configs, stubResolver{})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `ResolveConfigSecrets` walks each config's `OrderedMap`, finds `secret()` function calls, and resolves them via a `SecretResolver` interface
- Same semantics as `engine.ResolveSecrets`: only `secret()` supported, requires exactly 2 string args (backend, path), recurses into lists and maps
- Defines a local `SecretResolver` interface matching `engine.SecretResolver` to avoid an import cycle (engine will import config in #119)

Closes #117

## Test plan

- [x] `go vet ./config/...` passes
- [x] 5 new tests: env resolved, unsupported backend error, missing env var error, non-secret function error, no-op when no secrets
- [x] 32 total config tests passing
- [x] `go test ./... -count=1` full suite green