### PR TITLE
feat(config): add multi-context detection and filtering

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -183,6 +183,52 @@ func DefaultConfigPath() string {
 	return filepath.Join(home, ".datastorectl", "config.dcl")
 }
 
+// DetectMultipleContexts scans resource bodies for the "context" attribute
+// (before stripping) and returns the unique context names found. The bool
+// is true when more than one distinct context is referenced.
+func DetectMultipleContexts(resources []provider.Resource) ([]string, bool) {
+	seen := map[string]struct{}{}
+	var names []string
+	for _, r := range resources {
+		v, ok := r.Body.Get("context")
+		if !ok || v.Kind != provider.KindString {
+			continue
+		}
+		if _, dup := seen[v.Str]; !dup {
+			seen[v.Str] = struct{}{}
+			names = append(names, v.Str)
+		}
+	}
+	return names, len(names) > 1
+}
+
+// FilterByContext keeps only the resources that reference contextName and only
+// the contexts whose name matches. Returns an error if no resources match.
+func FilterByContext(resources []provider.Resource, contexts []Context, contextName string) ([]provider.Resource, []Context, error) {
+	var filteredResources []provider.Resource
+	for _, r := range resources {
+		v, ok := r.Body.Get("context")
+		if !ok || v.Kind != provider.KindString {
+			continue
+		}
+		if v.Str == contextName {
+			filteredResources = append(filteredResources, r)
+		}
+	}
+	if len(filteredResources) == 0 {
+		return nil, nil, fmt.Errorf("no resources target context %q", contextName)
+	}
+
+	var filteredContexts []Context
+	for _, ctx := range contexts {
+		if ctx.Name == contextName {
+			filteredContexts = append(filteredContexts, ctx)
+		}
+	}
+
+	return filteredResources, filteredContexts, nil
+}
+
 // ResolveConfigSecrets walks each config's OrderedMap and resolves secret()
 // function calls via the given resolver. Configs are modified in place.
 func ResolveConfigSecrets(ctx context.Context, configs map[string]*provider.OrderedMap, resolver SecretResolver) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -408,6 +408,88 @@ func TestDefaultConfigPath(t *testing.T) {
 	}
 }
 
+// --- DetectMultipleContexts / FilterByContext tests (#120) ---
+
+func TestDetectMultipleContexts_single(t *testing.T) {
+	resources := []provider.Resource{
+		{ID: provider.ResourceID{Type: "opensearch_role", Name: "a"}, Body: buildAttrs("context", provider.StringVal("prod"))},
+		{ID: provider.ResourceID{Type: "opensearch_role", Name: "b"}, Body: buildAttrs("context", provider.StringVal("prod"))},
+	}
+	names, multiple := DetectMultipleContexts(resources)
+	if multiple {
+		t.Error("expected single context, got multiple")
+	}
+	if len(names) != 1 || names[0] != "prod" {
+		t.Errorf("expected [prod], got %v", names)
+	}
+}
+
+func TestDetectMultipleContexts_multiple(t *testing.T) {
+	resources := []provider.Resource{
+		{ID: provider.ResourceID{Type: "opensearch_role", Name: "a"}, Body: buildAttrs("context", provider.StringVal("prod"))},
+		{ID: provider.ResourceID{Type: "opensearch_role", Name: "b"}, Body: buildAttrs("context", provider.StringVal("staging"))},
+	}
+	names, multiple := DetectMultipleContexts(resources)
+	if !multiple {
+		t.Error("expected multiple contexts")
+	}
+	if len(names) != 2 {
+		t.Errorf("expected 2 names, got %d", len(names))
+	}
+}
+
+func TestFilterByContext_selects_matching(t *testing.T) {
+	resources := []provider.Resource{
+		{ID: provider.ResourceID{Type: "opensearch_role", Name: "a"}, Body: buildAttrs("context", provider.StringVal("prod"))},
+		{ID: provider.ResourceID{Type: "opensearch_role", Name: "b"}, Body: buildAttrs("context", provider.StringVal("staging"))},
+		{ID: provider.ResourceID{Type: "opensearch_role", Name: "c"}, Body: buildAttrs("context", provider.StringVal("prod"))},
+	}
+	contexts := []Context{
+		{Name: "prod", Provider: "opensearch"},
+		{Name: "staging", Provider: "opensearch"},
+	}
+
+	filtered, filteredCtx, err := FilterByContext(resources, contexts, "prod")
+	if err != nil {
+		t.Fatalf("FilterByContext failed: %v", err)
+	}
+	if len(filtered) != 2 {
+		t.Errorf("expected 2 filtered resources, got %d", len(filtered))
+	}
+	if len(filteredCtx) != 1 || filteredCtx[0].Name != "prod" {
+		t.Errorf("expected 1 filtered context (prod), got %v", filteredCtx)
+	}
+}
+
+func TestFilterByContext_no_match(t *testing.T) {
+	resources := []provider.Resource{
+		{ID: provider.ResourceID{Type: "opensearch_role", Name: "a"}, Body: buildAttrs("context", provider.StringVal("prod"))},
+	}
+
+	_, _, err := FilterByContext(resources, nil, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for no matching resources")
+	}
+}
+
+func TestFilterByContext_filters_contexts_too(t *testing.T) {
+	resources := []provider.Resource{
+		{ID: provider.ResourceID{Type: "opensearch_role", Name: "a"}, Body: buildAttrs("context", provider.StringVal("staging"))},
+	}
+	contexts := []Context{
+		{Name: "prod", Provider: "opensearch"},
+		{Name: "staging", Provider: "opensearch"},
+	}
+
+	_, filteredCtx, err := FilterByContext(resources, contexts, "staging")
+	if err != nil {
+		t.Fatalf("FilterByContext failed: %v", err)
+	}
+	if len(filteredCtx) != 1 || filteredCtx[0].Name != "staging" {
+		t.Errorf("expected only staging context, got %v", filteredCtx)
+	}
+}
+
 // --- ResolveConfigSecrets tests (#117) ---
 
 // stubResolver implements SecretResolver for testing.


### PR DESCRIPTION
## Summary

- `DetectMultipleContexts` scans resource `context` attributes and returns unique context names + whether there are multiple
- `FilterByContext` keeps only resources and contexts matching a given name, errors if none match
- The CLI will use these to require `--context` when resources target different clusters, preventing accidental applies to the wrong environment

Closes #120

## Test plan

- [x] `go vet ./config/...` passes
- [x] 5 new tests: detect single/multiple, filter selects matching/no match/filters contexts too
- [x] 37 total config tests passing
- [x] `go test ./... -count=1` full suite green