### PR TITLE
feat(output): complete output module — color, JSON, diagnostics, verbose

### DIFF
--- a/output/apply.go
+++ b/output/apply.go
@@ -1,0 +1,61 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MathewBravo/datastorectl/engine"
+)
+
+// FormatApplyResult renders apply outcomes as human-readable text.
+// When color is true, ANSI codes highlight success (green), failure (red),
+// and skipped (yellow) results.
+func FormatApplyResult(result *engine.ApplyResult, color bool) string {
+	var b strings.Builder
+	for i, r := range result.Results {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		symbol := applySymbol(r, color)
+		outcome := applyOutcome(r, color)
+		fmt.Fprintf(&b, "%s %s: %s", symbol, r.ID, outcome)
+	}
+	b.WriteByte('\n')
+	b.WriteByte('\n')
+	b.WriteString(bold(result.Summary(), color))
+	return b.String()
+}
+
+func applySymbol(r engine.ResourceResult, color bool) string {
+	switch r.Status {
+	case engine.StatusFailed:
+		return boldRed("✕", color)
+	case engine.StatusSkipped:
+		return yellow("↓", color)
+	default:
+		switch r.ChangeType {
+		case engine.ChangeCreate:
+			return green("+", color)
+		case engine.ChangeUpdate:
+			return yellow("~", color)
+		case engine.ChangeDelete:
+			return red("-", color)
+		default:
+			return " "
+		}
+	}
+}
+
+func applyOutcome(r engine.ResourceResult, color bool) string {
+	switch r.Status {
+	case engine.StatusSuccess:
+		return r.ChangeType.String() + "d"
+	case engine.StatusFailed:
+		msg := fmt.Sprintf("failed (%s)", r.Error.Error())
+		return red(msg, color)
+	case engine.StatusSkipped:
+		return yellow("skipped", color)
+	default:
+		return r.Status.String()
+	}
+}

--- a/output/apply_test.go
+++ b/output/apply_test.go
@@ -1,0 +1,103 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/engine"
+)
+
+func TestFormatApplyResult_success_colored(t *testing.T) {
+	result := &engine.ApplyResult{
+		Results: []engine.ResourceResult{
+			{ID: rid("svc", "a"), Status: engine.StatusSuccess, ChangeType: engine.ChangeCreate},
+			{ID: rid("svc", "b"), Status: engine.StatusSuccess, ChangeType: engine.ChangeUpdate},
+			{ID: rid("svc", "c"), Status: engine.StatusSuccess, ChangeType: engine.ChangeDelete},
+		},
+	}
+
+	got := FormatApplyResult(result, true)
+
+	if !strings.Contains(got, "svc.a: created") {
+		t.Errorf("expected created line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "svc.b: updated") {
+		t.Errorf("expected updated line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "svc.c: deleted") {
+		t.Errorf("expected deleted line, got:\n%s", got)
+	}
+	if !strings.Contains(got, ansiGreen) {
+		t.Error("expected green ANSI codes for create symbol")
+	}
+}
+
+func TestFormatApplyResult_failed_colored(t *testing.T) {
+	result := &engine.ApplyResult{
+		Results: []engine.ResourceResult{
+			{ID: rid("svc", "a"), Status: engine.StatusFailed, ChangeType: engine.ChangeUpdate, Error: fmt.Errorf("connection refused")},
+		},
+	}
+
+	got := FormatApplyResult(result, true)
+
+	if !strings.Contains(got, "✕") {
+		t.Error("expected ✕ symbol for failed")
+	}
+	if !strings.Contains(got, "connection refused") {
+		t.Error("expected error message in output")
+	}
+	if !strings.Contains(got, ansiRed) {
+		t.Error("expected red ANSI codes for failure")
+	}
+}
+
+func TestFormatApplyResult_skipped_colored(t *testing.T) {
+	result := &engine.ApplyResult{
+		Results: []engine.ResourceResult{
+			{ID: rid("svc", "a"), Status: engine.StatusSkipped, ChangeType: engine.ChangeCreate},
+		},
+	}
+
+	got := FormatApplyResult(result, true)
+
+	if !strings.Contains(got, "↓") {
+		t.Error("expected ↓ symbol for skipped")
+	}
+	if !strings.Contains(got, ansiYellow) {
+		t.Error("expected yellow ANSI codes for skipped")
+	}
+}
+
+func TestFormatApplyResult_no_color(t *testing.T) {
+	result := &engine.ApplyResult{
+		Results: []engine.ResourceResult{
+			{ID: rid("svc", "a"), Status: engine.StatusSuccess, ChangeType: engine.ChangeCreate},
+			{ID: rid("svc", "b"), Status: engine.StatusFailed, ChangeType: engine.ChangeUpdate, Error: fmt.Errorf("err")},
+		},
+	}
+
+	got := FormatApplyResult(result, false)
+
+	if strings.Contains(got, "\033[") {
+		t.Errorf("expected no ANSI codes when color=false, got:\n%s", got)
+	}
+}
+
+func TestFormatApplyResult_includes_summary(t *testing.T) {
+	result := &engine.ApplyResult{
+		Results: []engine.ResourceResult{
+			{ID: rid("svc", "a"), Status: engine.StatusSuccess, ChangeType: engine.ChangeCreate},
+		},
+	}
+
+	got := FormatApplyResult(result, true)
+
+	if !strings.Contains(got, "Apply complete: 1 succeeded") {
+		t.Errorf("expected summary, got:\n%s", got)
+	}
+	if !strings.Contains(got, ansiBold) {
+		t.Error("expected bold summary when colored")
+	}
+}

--- a/output/color.go
+++ b/output/color.go
@@ -1,0 +1,68 @@
+// Package output renders engine plans, apply results, and diagnostics
+// for terminal and JSON consumption.
+package output
+
+import (
+	"io"
+	"os"
+)
+
+// ANSI escape codes.
+const (
+	ansiReset  = "\033[0m"
+	ansiRed    = "\033[31m"
+	ansiGreen  = "\033[32m"
+	ansiYellow = "\033[33m"
+	ansiBold   = "\033[1m"
+)
+
+func green(s string, color bool) string {
+	if !color {
+		return s
+	}
+	return ansiGreen + s + ansiReset
+}
+
+func red(s string, color bool) string {
+	if !color {
+		return s
+	}
+	return ansiRed + s + ansiReset
+}
+
+func yellow(s string, color bool) string {
+	if !color {
+		return s
+	}
+	return ansiYellow + s + ansiReset
+}
+
+func bold(s string, color bool) string {
+	if !color {
+		return s
+	}
+	return ansiBold + s + ansiReset
+}
+
+func boldRed(s string, color bool) string {
+	if !color {
+		return s
+	}
+	return ansiBold + ansiRed + s + ansiReset
+}
+
+// ShouldColor returns true when w is a TTY and the NO_COLOR env var is not set.
+func ShouldColor(w io.Writer) bool {
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return stat.Mode()&os.ModeCharDevice != 0
+}

--- a/output/diagnostic.go
+++ b/output/diagnostic.go
@@ -1,0 +1,95 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+)
+
+// FormatDiagnostics renders diagnostics as human-readable text with optional color.
+// Errors are red, warnings are yellow. Suggestions are indented below the message.
+func FormatDiagnostics(diags dcl.Diagnostics, color bool) string {
+	var blocks []string
+	for _, d := range diags {
+		blocks = append(blocks, formatDiagnostic(d, color))
+	}
+	return strings.Join(blocks, "\n\n")
+}
+
+func formatDiagnostic(d dcl.Diagnostic, color bool) string {
+	var b strings.Builder
+
+	// Severity label.
+	switch d.Severity {
+	case dcl.SeverityError:
+		b.WriteString(red("error", color))
+	case dcl.SeverityWarning:
+		b.WriteString(yellow("warning", color))
+	}
+
+	// Source location.
+	if d.Range.Start.Line > 0 {
+		fmt.Fprintf(&b, ": %s:%d:%d", d.Range.Start.Filename, d.Range.Start.Line, d.Range.Start.Column)
+	}
+
+	// Message.
+	fmt.Fprintf(&b, ": %s", d.Message)
+
+	// Suggestion.
+	if d.Suggestion != "" {
+		fmt.Fprintf(&b, "\n  suggestion: %s", d.Suggestion)
+	}
+
+	return b.String()
+}
+
+// --- JSON diagnostics ---
+
+type jsonDiagnostics struct {
+	Diagnostics []jsonDiagnostic `json:"diagnostics"`
+}
+
+type jsonDiagnostic struct {
+	Severity   string     `json:"severity"`
+	Message    string     `json:"message"`
+	Range      *jsonRange `json:"range,omitempty"`
+	Suggestion string     `json:"suggestion,omitempty"`
+}
+
+type jsonRange struct {
+	File  string       `json:"file"`
+	Start jsonPosition `json:"start"`
+}
+
+type jsonPosition struct {
+	Line   int `json:"line"`
+	Column int `json:"col"`
+}
+
+// FormatDiagnosticsJSON renders diagnostics as structured JSON.
+func FormatDiagnosticsJSON(diags dcl.Diagnostics) ([]byte, error) {
+	jd := jsonDiagnostics{
+		Diagnostics: make([]jsonDiagnostic, len(diags)),
+	}
+
+	for i, d := range diags {
+		jd.Diagnostics[i] = jsonDiagnostic{
+			Severity:   d.Severity.String(),
+			Message:    d.Message,
+			Suggestion: d.Suggestion,
+		}
+		if d.Range.Start.Line > 0 {
+			jd.Diagnostics[i].Range = &jsonRange{
+				File: d.Range.Start.Filename,
+				Start: jsonPosition{
+					Line:   d.Range.Start.Line,
+					Column: d.Range.Start.Column,
+				},
+			}
+		}
+	}
+
+	return json.MarshalIndent(jd, "", "  ")
+}

--- a/output/diagnostic_test.go
+++ b/output/diagnostic_test.go
@@ -1,0 +1,124 @@
+package output
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+)
+
+func TestFormatDiagnostics_error_colored(t *testing.T) {
+	diags := dcl.Diagnostics{{
+		Severity: dcl.SeverityError,
+		Message:  "something broke",
+	}}
+
+	got := FormatDiagnostics(diags, true)
+
+	if !strings.Contains(got, ansiRed+"error"+ansiReset) {
+		t.Errorf("expected red 'error' label, got:\n%s", got)
+	}
+	if !strings.Contains(got, "something broke") {
+		t.Error("expected message in output")
+	}
+}
+
+func TestFormatDiagnostics_warning_colored(t *testing.T) {
+	diags := dcl.Diagnostics{{
+		Severity: dcl.SeverityWarning,
+		Message:  "heads up",
+	}}
+
+	got := FormatDiagnostics(diags, true)
+
+	if !strings.Contains(got, ansiYellow+"warning"+ansiReset) {
+		t.Errorf("expected yellow 'warning' label, got:\n%s", got)
+	}
+}
+
+func TestFormatDiagnostics_with_suggestion(t *testing.T) {
+	diags := dcl.Diagnostics{{
+		Severity:   dcl.SeverityError,
+		Message:    "missing endpoint",
+		Suggestion: "add endpoint = \"https://...\"",
+	}}
+
+	got := FormatDiagnostics(diags, false)
+
+	if !strings.Contains(got, "suggestion: add endpoint") {
+		t.Errorf("expected suggestion line, got:\n%s", got)
+	}
+}
+
+func TestFormatDiagnostics_with_range(t *testing.T) {
+	diags := dcl.Diagnostics{{
+		Severity: dcl.SeverityError,
+		Message:  "bad value",
+		Range: dcl.Range{
+			Start: dcl.Pos{Filename: "config.dcl", Line: 3, Column: 5},
+		},
+	}}
+
+	got := FormatDiagnostics(diags, false)
+
+	if !strings.Contains(got, "config.dcl:3:5") {
+		t.Errorf("expected file:line:col, got:\n%s", got)
+	}
+}
+
+func TestFormatDiagnostics_no_color(t *testing.T) {
+	diags := dcl.Diagnostics{
+		{Severity: dcl.SeverityError, Message: "err"},
+		{Severity: dcl.SeverityWarning, Message: "warn"},
+	}
+
+	got := FormatDiagnostics(diags, false)
+
+	if strings.Contains(got, "\033[") {
+		t.Errorf("expected no ANSI codes when color=false, got:\n%s", got)
+	}
+}
+
+func TestFormatDiagnosticsJSON_structure(t *testing.T) {
+	diags := dcl.Diagnostics{
+		{
+			Severity:   dcl.SeverityError,
+			Message:    "missing field",
+			Suggestion: "add it",
+			Range: dcl.Range{
+				Start: dcl.Pos{Filename: "test.dcl", Line: 5, Column: 10},
+			},
+		},
+		{
+			Severity: dcl.SeverityWarning,
+			Message:  "deprecated",
+		},
+	}
+
+	data, err := FormatDiagnosticsJSON(diags)
+	if err != nil {
+		t.Fatalf("FormatDiagnosticsJSON failed: %v", err)
+	}
+
+	var got jsonDiagnostics
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(got.Diagnostics) != 2 {
+		t.Fatalf("expected 2 diagnostics, got %d", len(got.Diagnostics))
+	}
+
+	d0 := got.Diagnostics[0]
+	if d0.Severity != "error" || d0.Message != "missing field" || d0.Suggestion != "add it" {
+		t.Errorf("unexpected d0: %+v", d0)
+	}
+	if d0.Range == nil || d0.Range.File != "test.dcl" || d0.Range.Start.Line != 5 {
+		t.Errorf("unexpected range: %+v", d0.Range)
+	}
+
+	d1 := got.Diagnostics[1]
+	if d1.Severity != "warning" || d1.Range != nil {
+		t.Errorf("unexpected d1: %+v", d1)
+	}
+}

--- a/output/json.go
+++ b/output/json.go
@@ -1,0 +1,153 @@
+package output
+
+import (
+	"encoding/json"
+
+	"github.com/MathewBravo/datastorectl/engine"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// --- JSON plan ---
+
+type jsonPlan struct {
+	Changes []jsonChange `json:"changes"`
+	Summary string       `json:"summary"`
+}
+
+type jsonChange struct {
+	ID      jsonResourceID  `json:"id"`
+	Action  string          `json:"action"`
+	Desired map[string]any  `json:"desired,omitempty"`
+	Diffs   []jsonValueDiff `json:"diffs,omitempty"`
+}
+
+type jsonResourceID struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+type jsonValueDiff struct {
+	Path string `json:"path"`
+	Kind string `json:"kind"`
+	Old  any    `json:"old,omitempty"`
+	New  any    `json:"new,omitempty"`
+}
+
+// FormatPlanJSON renders a plan as structured JSON.
+func FormatPlanJSON(plan *engine.Plan) ([]byte, error) {
+	jp := jsonPlan{
+		Changes: make([]jsonChange, 0),
+		Summary: plan.Summary(),
+	}
+
+	for _, c := range plan.Changes {
+		if c.Type == engine.ChangeNoOp {
+			continue
+		}
+
+		jc := jsonChange{
+			ID:     toJSONID(c.ID),
+			Action: c.Type.String(),
+		}
+
+		if c.Desired != nil && c.Desired.Body != nil {
+			jc.Desired = bodyToMap(c.Desired.Body)
+		}
+
+		if len(c.Diff.Diffs) > 0 {
+			jc.Diffs = make([]jsonValueDiff, len(c.Diff.Diffs))
+			for i, d := range c.Diff.Diffs {
+				jc.Diffs[i] = jsonValueDiff{
+					Path: d.Path,
+					Kind: d.Kind.String(),
+				}
+				if d.Kind == engine.DiffModified || d.Kind == engine.DiffRemoved {
+					jc.Diffs[i].Old = valueToAny(d.Old)
+				}
+				if d.Kind == engine.DiffModified || d.Kind == engine.DiffAdded {
+					jc.Diffs[i].New = valueToAny(d.New)
+				}
+			}
+		}
+
+		jp.Changes = append(jp.Changes, jc)
+	}
+
+	return json.MarshalIndent(jp, "", "  ")
+}
+
+// --- JSON apply result ---
+
+type jsonApplyResult struct {
+	Results []jsonResult `json:"results"`
+	Summary string       `json:"summary"`
+}
+
+type jsonResult struct {
+	ID     jsonResourceID `json:"id"`
+	Status string         `json:"status"`
+	Action string         `json:"action"`
+	Error  string         `json:"error,omitempty"`
+}
+
+// FormatApplyResultJSON renders an apply result as structured JSON.
+func FormatApplyResultJSON(result *engine.ApplyResult) ([]byte, error) {
+	jr := jsonApplyResult{
+		Results: make([]jsonResult, len(result.Results)),
+		Summary: result.Summary(),
+	}
+
+	for i, r := range result.Results {
+		jr.Results[i] = jsonResult{
+			ID:     toJSONID(r.ID),
+			Status: r.Status.String(),
+			Action: r.ChangeType.String(),
+		}
+		if r.Error != nil {
+			jr.Results[i].Error = r.Error.Error()
+		}
+	}
+
+	return json.MarshalIndent(jr, "", "  ")
+}
+
+// --- helpers ---
+
+func toJSONID(id provider.ResourceID) jsonResourceID {
+	return jsonResourceID{Type: id.Type, Name: id.Name}
+}
+
+func bodyToMap(m *provider.OrderedMap) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, m.Len())
+	for _, k := range m.Keys() {
+		v, _ := m.Get(k)
+		out[k] = valueToAny(v)
+	}
+	return out
+}
+
+func valueToAny(v provider.Value) any {
+	switch v.Kind {
+	case provider.KindString:
+		return v.Str
+	case provider.KindInt:
+		return v.Int
+	case provider.KindFloat:
+		return v.Float
+	case provider.KindBool:
+		return v.Bool
+	case provider.KindList:
+		out := make([]any, len(v.List))
+		for i, e := range v.List {
+			out[i] = valueToAny(e)
+		}
+		return out
+	case provider.KindMap:
+		return bodyToMap(v.Map)
+	default:
+		return nil
+	}
+}

--- a/output/json_test.go
+++ b/output/json_test.go
@@ -1,0 +1,165 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/engine"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+func TestFormatPlanJSON_create(t *testing.T) {
+	res := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+	res.Body.Set("name", provider.StringVal("hello"))
+
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{ID: rid("svc", "a"), Type: engine.ChangeCreate, Desired: res},
+	}}
+
+	data, err := FormatPlanJSON(plan)
+	if err != nil {
+		t.Fatalf("FormatPlanJSON failed: %v", err)
+	}
+
+	var got jsonPlan
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(got.Changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(got.Changes))
+	}
+	if got.Changes[0].Action != "create" {
+		t.Errorf("expected action=create, got %q", got.Changes[0].Action)
+	}
+	if got.Changes[0].ID.Type != "svc" || got.Changes[0].ID.Name != "a" {
+		t.Errorf("unexpected ID: %+v", got.Changes[0].ID)
+	}
+	if got.Changes[0].Desired["name"] != "hello" {
+		t.Errorf("expected desired name=hello, got %v", got.Changes[0].Desired["name"])
+	}
+}
+
+func TestFormatPlanJSON_update(t *testing.T) {
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{
+			ID:   rid("svc", "a"),
+			Type: engine.ChangeUpdate,
+			Diff: engine.ResourceDiff{
+				ID: rid("svc", "a"),
+				Diffs: []engine.ValueDiff{
+					{Kind: engine.DiffModified, Path: "timeout", Old: provider.StringVal("7d"), New: provider.StringVal("14d")},
+				},
+			},
+		},
+	}}
+
+	data, err := FormatPlanJSON(plan)
+	if err != nil {
+		t.Fatalf("FormatPlanJSON failed: %v", err)
+	}
+
+	var got jsonPlan
+	json.Unmarshal(data, &got)
+
+	if len(got.Changes[0].Diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(got.Changes[0].Diffs))
+	}
+	d := got.Changes[0].Diffs[0]
+	if d.Path != "timeout" || d.Kind != "modified" {
+		t.Errorf("unexpected diff: %+v", d)
+	}
+	if d.Old != "7d" || d.New != "14d" {
+		t.Errorf("expected old=7d new=14d, got old=%v new=%v", d.Old, d.New)
+	}
+}
+
+func TestFormatPlanJSON_delete(t *testing.T) {
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{ID: rid("svc", "a"), Type: engine.ChangeDelete},
+	}}
+
+	data, err := FormatPlanJSON(plan)
+	if err != nil {
+		t.Fatalf("FormatPlanJSON failed: %v", err)
+	}
+
+	var got jsonPlan
+	json.Unmarshal(data, &got)
+
+	if got.Changes[0].Action != "delete" {
+		t.Errorf("expected action=delete, got %q", got.Changes[0].Action)
+	}
+}
+
+func TestFormatPlanJSON_no_changes(t *testing.T) {
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{ID: rid("svc", "a"), Type: engine.ChangeNoOp},
+	}}
+
+	data, err := FormatPlanJSON(plan)
+	if err != nil {
+		t.Fatalf("FormatPlanJSON failed: %v", err)
+	}
+
+	var got jsonPlan
+	json.Unmarshal(data, &got)
+
+	if len(got.Changes) != 0 {
+		t.Errorf("expected 0 changes (no-ops omitted), got %d", len(got.Changes))
+	}
+	if got.Summary == "" {
+		t.Error("expected summary to be present")
+	}
+}
+
+func TestFormatApplyResultJSON_mixed(t *testing.T) {
+	result := &engine.ApplyResult{
+		Results: []engine.ResourceResult{
+			{ID: rid("svc", "a"), Status: engine.StatusSuccess, ChangeType: engine.ChangeCreate},
+			{ID: rid("svc", "b"), Status: engine.StatusFailed, ChangeType: engine.ChangeUpdate, Error: fmt.Errorf("timeout")},
+			{ID: rid("svc", "c"), Status: engine.StatusSkipped, ChangeType: engine.ChangeCreate},
+		},
+	}
+
+	data, err := FormatApplyResultJSON(result)
+	if err != nil {
+		t.Fatalf("FormatApplyResultJSON failed: %v", err)
+	}
+
+	var got jsonApplyResult
+	json.Unmarshal(data, &got)
+
+	if len(got.Results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(got.Results))
+	}
+	if got.Results[0].Status != "success" {
+		t.Errorf("expected success, got %q", got.Results[0].Status)
+	}
+	if got.Results[1].Status != "failed" || got.Results[1].Error != "timeout" {
+		t.Errorf("expected failed with timeout, got %+v", got.Results[1])
+	}
+	if got.Results[2].Status != "skipped" {
+		t.Errorf("expected skipped, got %q", got.Results[2].Status)
+	}
+}
+
+func TestFormatApplyResultJSON_summary(t *testing.T) {
+	result := &engine.ApplyResult{
+		Results: []engine.ResourceResult{
+			{ID: rid("svc", "a"), Status: engine.StatusSuccess, ChangeType: engine.ChangeCreate},
+		},
+	}
+
+	data, err := FormatApplyResultJSON(result)
+	if err != nil {
+		t.Fatalf("FormatApplyResultJSON failed: %v", err)
+	}
+
+	var got jsonApplyResult
+	json.Unmarshal(data, &got)
+
+	if got.Summary != "Apply complete: 1 succeeded, 0 failed, 0 skipped" {
+		t.Errorf("unexpected summary: %q", got.Summary)
+	}
+}

--- a/output/plan.go
+++ b/output/plan.go
@@ -1,0 +1,72 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MathewBravo/datastorectl/engine"
+)
+
+// FormatPlan renders a plan as human-readable Terraform-style text.
+// When color is true, ANSI codes highlight creates (green), updates (yellow),
+// and deletes (red). No-op changes are omitted.
+func FormatPlan(plan *engine.Plan, color bool) string {
+	var blocks []string
+	for _, c := range plan.Changes {
+		switch c.Type {
+		case engine.ChangeCreate:
+			blocks = append(blocks, formatCreate(c, color))
+		case engine.ChangeUpdate:
+			blocks = append(blocks, formatUpdate(c, color))
+		case engine.ChangeDelete:
+			blocks = append(blocks, formatDelete(c, color))
+		}
+	}
+	if len(blocks) == 0 {
+		return "No changes."
+	}
+	return strings.Join(blocks, "\n\n") + "\n\n" + bold(plan.Summary(), color) + "\n"
+}
+
+func formatCreate(c engine.ResourceChange, color bool) string {
+	var b strings.Builder
+	header := fmt.Sprintf("+ %s (create)", c.ID)
+	b.WriteString(green(header, color))
+	for _, key := range c.Desired.Body.Keys() {
+		v, _ := c.Desired.Body.Get(key)
+		line := fmt.Sprintf("\n    %s: %s", key, v.String())
+		b.WriteString(green(line, color))
+	}
+	return b.String()
+}
+
+func formatUpdate(c engine.ResourceChange, color bool) string {
+	var b strings.Builder
+	header := fmt.Sprintf("~ %s (update)", c.ID)
+	b.WriteString(yellow(header, color))
+	for _, d := range c.Diff.Diffs {
+		b.WriteString("\n    ")
+		b.WriteString(d.Path)
+		b.WriteString(": ")
+		b.WriteString(formatDiffValue(d, color))
+	}
+	return b.String()
+}
+
+func formatDelete(c engine.ResourceChange, color bool) string {
+	header := fmt.Sprintf("- %s (delete)", c.ID)
+	return red(header, color)
+}
+
+func formatDiffValue(d engine.ValueDiff, color bool) string {
+	switch d.Kind {
+	case engine.DiffModified:
+		return red(d.Old.String(), color) + " => " + green(d.New.String(), color)
+	case engine.DiffAdded:
+		return "(added) " + green(d.New.String(), color)
+	case engine.DiffRemoved:
+		return "(removed) " + red(d.Old.String(), color)
+	default:
+		return ""
+	}
+}

--- a/output/plan_test.go
+++ b/output/plan_test.go
@@ -1,0 +1,131 @@
+package output
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/engine"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+func rid(typ, name string) provider.ResourceID {
+	return provider.ResourceID{Type: typ, Name: name}
+}
+
+func TestFormatPlan_create_colored(t *testing.T) {
+	res := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+	res.Body.Set("name", provider.StringVal("hello"))
+
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{ID: rid("svc", "a"), Type: engine.ChangeCreate, Desired: res},
+	}}
+
+	got := FormatPlan(plan, true)
+
+	if !strings.Contains(got, ansiGreen) {
+		t.Error("expected green ANSI codes for create")
+	}
+	if !strings.Contains(got, "+ svc.a (create)") {
+		t.Errorf("expected create header, got:\n%s", got)
+	}
+}
+
+func TestFormatPlan_update_colored(t *testing.T) {
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{
+			ID:   rid("svc", "a"),
+			Type: engine.ChangeUpdate,
+			Diff: engine.ResourceDiff{
+				ID: rid("svc", "a"),
+				Diffs: []engine.ValueDiff{
+					{Kind: engine.DiffModified, Path: "timeout", Old: provider.StringVal("7d"), New: provider.StringVal("14d")},
+				},
+			},
+		},
+	}}
+
+	got := FormatPlan(plan, true)
+
+	if !strings.Contains(got, ansiYellow) {
+		t.Error("expected yellow ANSI codes for update header")
+	}
+	if !strings.Contains(got, ansiRed) {
+		t.Error("expected red ANSI codes for old value")
+	}
+	if !strings.Contains(got, ansiGreen) {
+		t.Error("expected green ANSI codes for new value")
+	}
+}
+
+func TestFormatPlan_delete_colored(t *testing.T) {
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{ID: rid("svc", "a"), Type: engine.ChangeDelete},
+	}}
+
+	got := FormatPlan(plan, true)
+
+	if !strings.Contains(got, ansiRed) {
+		t.Error("expected red ANSI codes for delete")
+	}
+	if !strings.Contains(got, "- svc.a (delete)") {
+		t.Errorf("expected delete header, got:\n%s", got)
+	}
+}
+
+func TestFormatPlan_no_color(t *testing.T) {
+	res := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+	res.Body.Set("name", provider.StringVal("hello"))
+
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{ID: rid("svc", "a"), Type: engine.ChangeCreate, Desired: res},
+		{ID: rid("svc", "b"), Type: engine.ChangeDelete},
+	}}
+
+	got := FormatPlan(plan, false)
+
+	if strings.Contains(got, "\033[") {
+		t.Errorf("expected no ANSI codes when color=false, got:\n%s", got)
+	}
+	if !strings.Contains(got, "+ svc.a (create)") {
+		t.Error("expected create header")
+	}
+	if !strings.Contains(got, "- svc.b (delete)") {
+		t.Error("expected delete header")
+	}
+}
+
+func TestFormatPlan_no_changes(t *testing.T) {
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{ID: rid("svc", "a"), Type: engine.ChangeNoOp},
+	}}
+
+	got := FormatPlan(plan, true)
+
+	if got != "No changes." {
+		t.Errorf("expected 'No changes.', got: %s", got)
+	}
+}
+
+func TestFormatPlan_includes_summary(t *testing.T) {
+	res := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{ID: rid("svc", "a"), Type: engine.ChangeCreate, Desired: res},
+	}}
+
+	got := FormatPlan(plan, true)
+
+	if !strings.Contains(got, "Plan: 1 to create") {
+		t.Errorf("expected summary line, got:\n%s", got)
+	}
+	if !strings.Contains(got, ansiBold) {
+		t.Error("expected bold summary when colored")
+	}
+}
+
+func TestShouldColor_no_color_env(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	// Any writer — should return false due to NO_COLOR.
+	if ShouldColor(nil) {
+		t.Error("expected false when NO_COLOR is set")
+	}
+}

--- a/output/verbose.go
+++ b/output/verbose.go
@@ -1,0 +1,83 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MathewBravo/datastorectl/engine"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// FormatPlanVerbose renders a plan with full before/after bodies for each change.
+// Creates show the full desired body. Updates show diffs, desired, and live bodies.
+// Deletes show the full live body.
+func FormatPlanVerbose(plan *engine.Plan, color bool) string {
+	var blocks []string
+	for _, c := range plan.Changes {
+		switch c.Type {
+		case engine.ChangeCreate:
+			blocks = append(blocks, formatCreate(c, color))
+		case engine.ChangeUpdate:
+			blocks = append(blocks, formatVerboseUpdate(c, color))
+		case engine.ChangeDelete:
+			blocks = append(blocks, formatVerboseDelete(c, color))
+		}
+	}
+	if len(blocks) == 0 {
+		return "No changes."
+	}
+	return strings.Join(blocks, "\n\n") + "\n\n" + bold(plan.Summary(), color) + "\n"
+}
+
+func formatVerboseUpdate(c engine.ResourceChange, color bool) string {
+	var b strings.Builder
+	header := fmt.Sprintf("~ %s (update)", c.ID)
+	b.WriteString(yellow(header, color))
+
+	// Diffs.
+	b.WriteString("\n  diffs:")
+	for _, d := range c.Diff.Diffs {
+		b.WriteString("\n    ")
+		b.WriteString(d.Path)
+		b.WriteString(": ")
+		b.WriteString(formatDiffValue(d, color))
+	}
+
+	// Full desired body.
+	if c.Desired != nil && c.Desired.Body != nil {
+		b.WriteString("\n  desired:")
+		writeBody(&b, c.Desired.Body, color, ansiGreen)
+	}
+
+	// Full live body.
+	if c.Live != nil && c.Live.Body != nil {
+		b.WriteString("\n  live:")
+		writeBody(&b, c.Live.Body, color, ansiRed)
+	}
+
+	return b.String()
+}
+
+func formatVerboseDelete(c engine.ResourceChange, color bool) string {
+	var b strings.Builder
+	header := fmt.Sprintf("- %s (delete)", c.ID)
+	b.WriteString(red(header, color))
+
+	if c.Live != nil && c.Live.Body != nil {
+		writeBody(&b, c.Live.Body, color, ansiRed)
+	}
+
+	return b.String()
+}
+
+func writeBody(b *strings.Builder, body *provider.OrderedMap, color bool, ansiCode string) {
+	for _, key := range body.Keys() {
+		v, _ := body.Get(key)
+		line := fmt.Sprintf("\n    %s: %s", key, v.String())
+		if color && ansiCode != "" {
+			b.WriteString(ansiCode + line + ansiReset)
+		} else {
+			b.WriteString(line)
+		}
+	}
+}

--- a/output/verbose_test.go
+++ b/output/verbose_test.go
@@ -1,0 +1,104 @@
+package output
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/engine"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+func TestFormatPlanVerbose_create(t *testing.T) {
+	res := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+	res.Body.Set("name", provider.StringVal("hello"))
+
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{ID: rid("svc", "a"), Type: engine.ChangeCreate, Desired: res},
+	}}
+
+	got := FormatPlanVerbose(plan, false)
+
+	if !strings.Contains(got, "+ svc.a (create)") {
+		t.Errorf("expected create header, got:\n%s", got)
+	}
+	if !strings.Contains(got, `name: "hello"`) {
+		t.Errorf("expected body attribute, got:\n%s", got)
+	}
+}
+
+func TestFormatPlanVerbose_update_shows_bodies(t *testing.T) {
+	desired := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+	desired.Body.Set("timeout", provider.StringVal("14d"))
+	live := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+	live.Body.Set("timeout", provider.StringVal("7d"))
+
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{
+			ID: rid("svc", "a"), Type: engine.ChangeUpdate,
+			Desired: desired, Live: live,
+			Diff: engine.ResourceDiff{
+				ID: rid("svc", "a"),
+				Diffs: []engine.ValueDiff{
+					{Kind: engine.DiffModified, Path: "timeout", Old: provider.StringVal("7d"), New: provider.StringVal("14d")},
+				},
+			},
+		},
+	}}
+
+	got := FormatPlanVerbose(plan, false)
+
+	if !strings.Contains(got, "diffs:") {
+		t.Errorf("expected diffs section, got:\n%s", got)
+	}
+	if !strings.Contains(got, "desired:") {
+		t.Errorf("expected desired section, got:\n%s", got)
+	}
+	if !strings.Contains(got, "live:") {
+		t.Errorf("expected live section, got:\n%s", got)
+	}
+	if !strings.Contains(got, `"7d" => "14d"`) {
+		t.Errorf("expected diff value, got:\n%s", got)
+	}
+}
+
+func TestFormatPlanVerbose_delete_shows_live(t *testing.T) {
+	live := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+	live.Body.Set("name", provider.StringVal("orphan"))
+
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{ID: rid("svc", "a"), Type: engine.ChangeDelete, Live: live},
+	}}
+
+	got := FormatPlanVerbose(plan, false)
+
+	if !strings.Contains(got, "- svc.a (delete)") {
+		t.Errorf("expected delete header, got:\n%s", got)
+	}
+	if !strings.Contains(got, `name: "orphan"`) {
+		t.Errorf("expected live body, got:\n%s", got)
+	}
+}
+
+func TestFormatPlanVerbose_no_color(t *testing.T) {
+	desired := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+	desired.Body.Set("x", provider.StringVal("y"))
+	live := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
+	live.Body.Set("x", provider.StringVal("z"))
+
+	plan := &engine.Plan{Changes: []engine.ResourceChange{
+		{
+			ID: rid("svc", "a"), Type: engine.ChangeUpdate,
+			Desired: desired, Live: live,
+			Diff: engine.ResourceDiff{
+				ID:    rid("svc", "a"),
+				Diffs: []engine.ValueDiff{{Kind: engine.DiffModified, Path: "x", Old: provider.StringVal("z"), New: provider.StringVal("y")}},
+			},
+		},
+	}}
+
+	got := FormatPlanVerbose(plan, false)
+
+	if strings.Contains(got, "\033[") {
+		t.Errorf("expected no ANSI codes when color=false, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Complete `output/` package implementing all 5 output module tickets:

**Colored terminal rendering (#126, #127):**
- `FormatPlan` with green creates, yellow updates, red deletes, bold summary
- `FormatApplyResult` with colored symbols per status
- `ShouldColor` for TTY detection + `NO_COLOR` env var support

**JSON output (#128):**
- `FormatPlanJSON` — structured JSON with changes, diffs, and summary
- `FormatApplyResultJSON` — structured JSON with per-resource status

**Diagnostic formatting (#129):**
- `FormatDiagnostics` — red errors, yellow warnings, source location, suggestions
- `FormatDiagnosticsJSON` — structured JSON with source ranges

**Verbose mode (#130):**
- `FormatPlanVerbose` — full before/after bodies for updates and deletes

Closes #126
Closes #127
Closes #128
Closes #129
Closes #130

## Test plan

- [x] `go vet ./output/...` passes
- [x] 28 output tests: plan (7), apply (5), JSON (6), diagnostics (6), verbose (4)
- [x] `go test ./... -count=1` full suite green