### PR TITLE
feat(cli): add Cobra scaffold, root command, and global flags

### DIFF
--- a/cmd/datastorectl/helpers.go
+++ b/cmd/datastorectl/helpers.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+	"github.com/MathewBravo/datastorectl/engine"
+	"github.com/MathewBravo/datastorectl/output"
+	"github.com/spf13/cobra"
+)
+
+// loadDCL loads a DCL file or directory. Returns the parsed file or an error
+// wrapping any parse diagnostics.
+func loadDCL(path string) (*dcl.File, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot access %s: %s", path, err)
+	}
+
+	var file *dcl.File
+	var diags dcl.Diagnostics
+
+	if info.IsDir() {
+		file, diags = dcl.LoadDirectory(path)
+	} else {
+		file, diags = dcl.LoadFile(path)
+	}
+
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("%s", diags.Error())
+	}
+
+	return file, nil
+}
+
+// createEngine returns an Engine configured with the default EnvSecretResolver.
+func createEngine() *engine.Engine {
+	return &engine.Engine{SecretResolver: engine.EnvSecretResolver{}}
+}
+
+// colorEnabled returns true when colored output should be used.
+// Respects --no-color flag and TTY detection.
+func colorEnabled(cmd *cobra.Command) bool {
+	noColor, _ := cmd.Flags().GetBool("no-color")
+	if noColor {
+		return false
+	}
+	return output.ShouldColor(os.Stdout)
+}
+
+// outputFormat returns the --output flag value ("text" or "json").
+func outputFormat(cmd *cobra.Command) string {
+	format, _ := cmd.Flags().GetString("output")
+	return format
+}
+
+// isVerbose returns whether the --verbose flag is set.
+func isVerbose(cmd *cobra.Command) bool {
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	return verbose
+}
+
+// configPath returns the --config flag value.
+func configPath(cmd *cobra.Command) string {
+	path, _ := cmd.Flags().GetString("config")
+	return path
+}
+
+// contextFlag returns the --context flag value (empty string if not set).
+func contextFlag(cmd *cobra.Command) string {
+	ctx, _ := cmd.Flags().GetString("context")
+	return ctx
+}

--- a/cmd/datastorectl/main.go
+++ b/cmd/datastorectl/main.go
@@ -1,7 +1,38 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+
+	"github.com/MathewBravo/datastorectl/config"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "datastorectl [command] [path]",
+	Short: "Declarative configuration for running datastores",
+	Long: `datastorectl manages post-provisioning datastore configuration declaratively,
+the same way Terraform manages infrastructure.
+
+Write config in DCL, point it at a live cluster, and run three commands:
+  validate  — parse and type-check DCL offline, no network calls
+  plan      — connect to the cluster, diff against declared state, show what would change
+  apply     — execute the changes`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	rootCmd.PersistentFlags().String("context", "", "select a named context when resources target multiple clusters")
+	rootCmd.PersistentFlags().StringP("output", "o", "text", "output format: text or json")
+	rootCmd.PersistentFlags().Bool("verbose", false, "show full before/after in plan output")
+	rootCmd.PersistentFlags().Bool("no-color", false, "disable colored output")
+	rootCmd.PersistentFlags().String("config", config.DefaultConfigPath(), "path to config file")
+}
 
 func main() {
-	fmt.Println("hello datastorectl")
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/opensearch-project/opensearch-go/v4 v4.6.0 // indirect
+	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,5 +26,15 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBU
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJinbHrDfSJ2GZl4Q//OSSNAVw=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/opensearch-project/opensearch-go/v4 v4.6.0 h1:Ac8aLtDSmLEyOmv0r1qhQLw3b4vcUhE42NE9k+Z4cRc=
 github.com/opensearch-project/opensearch-go/v4 v4.6.0/go.mod h1:3iZtb4SNt3IzaxavKq0dURh1AmtVgYW71E4XqmYnIiQ=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

- Replaces placeholder `main.go` with Cobra root command
- Adds persistent flags: `--context`, `--output` (text|json), `--verbose`, `--no-color`, `--config`
- Shared CLI helpers: `loadDCL` (file/dir detection), `createEngine`, `colorEnabled`, `outputFormat`, `isVerbose`, `configPath`, `contextFlag`
- Adds `github.com/spf13/cobra` dependency

No subcommands yet — scaffold for #133, #134, #135 to build on.

Closes #132

## Test plan

- [x] `go vet ./...` passes
- [x] `go build ./cmd/datastorectl` succeeds
- [x] `./datastorectl --help` shows description and usage
- [x] Flags accepted without error
- [x] `go test ./... -count=1` full suite green