### PR TITLE
feat(cli): add validate command — offline DCL validation

### DIFF
--- a/cmd/datastorectl/helpers.go
+++ b/cmd/datastorectl/helpers.go
@@ -72,3 +72,9 @@ func contextFlag(cmd *cobra.Command) string {
 	ctx, _ := cmd.Flags().GetString("context")
 	return ctx
 }
+
+// errExit is returned by RunE functions to set a specific exit code
+// without Cobra printing its own error message.
+type errExit struct{ code int }
+
+func (e errExit) Error() string { return fmt.Sprintf("exit %d", e.code) }

--- a/cmd/datastorectl/main.go
+++ b/cmd/datastorectl/main.go
@@ -32,6 +32,9 @@ func init() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
+		if exit, ok := err.(errExit); ok {
+			os.Exit(exit.code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/cmd/datastorectl/validate.go
+++ b/cmd/datastorectl/validate.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MathewBravo/datastorectl/config"
+	"github.com/MathewBravo/datastorectl/dcl"
+	"github.com/MathewBravo/datastorectl/engine"
+	"github.com/MathewBravo/datastorectl/output"
+	"github.com/spf13/cobra"
+)
+
+var validateCmd = &cobra.Command{
+	Use:   "validate [path]",
+	Short: "Parse and type-check DCL offline — no network calls",
+	Long: `Validate parses the DCL file or directory, checks for syntax errors,
+converts resource blocks, and validates context references. No cluster
+connection is made — this is a purely offline check.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidate,
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+}
+
+func runValidate(cmd *cobra.Command, args []string) error {
+	path := args[0]
+	color := colorEnabled(cmd)
+	format := outputFormat(cmd)
+
+	// 1. Load and parse DCL.
+	file, err := loadDCL(path)
+	if err != nil {
+		if format == "json" {
+			// Parse errors are in the error string; wrap as diagnostic JSON.
+			fmt.Println(`{"valid": false, "error": ` + jsonString(err.Error()) + `}`)
+		} else {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		return errExit{code: 1}
+	}
+
+	// 2. Split into context and resource blocks.
+	contextBlocks, resourceBlocks := config.SplitFile(file)
+
+	// 3. Validate context blocks.
+	contexts, err := config.ParseContexts(contextBlocks)
+	if err != nil {
+		return exitWithError(cmd, err, format, color)
+	}
+
+	// 4. Convert resource blocks.
+	resourceSet, err := engine.ConvertBlocks(resourceBlocks)
+	if err != nil {
+		return exitWithError(cmd, err, format, color)
+	}
+
+	// 5. Validate context references on resources (if contexts exist).
+	if len(contexts) > 0 {
+		if _, err := config.ResolveResourceContexts(resourceSet.Resources, contexts); err != nil {
+			return exitWithError(cmd, err, format, color)
+		}
+	}
+
+	// All checks pass.
+	if format == "json" {
+		fmt.Println(`{"valid": true}`)
+	} else {
+		fmt.Println("Valid.")
+	}
+	return nil
+}
+
+func exitWithError(cmd *cobra.Command, err error, format string, color bool) error {
+	if format == "json" {
+		fmt.Println(`{"valid": false, "error": ` + jsonString(err.Error()) + `}`)
+	} else {
+		// Use diagnostic formatting for richer errors when available.
+		fmt.Fprintln(os.Stderr, output.FormatDiagnostics(errToDiag(err), color))
+	}
+	return errExit{code: 1}
+}
+
+// errToDiag wraps a plain error as a single error-severity diagnostic.
+func errToDiag(err error) dcl.Diagnostics {
+	return dcl.Diagnostics{{
+		Severity: dcl.SeverityError,
+		Message:  err.Error(),
+	}}
+}
+
+// jsonString returns a JSON-encoded string value.
+func jsonString(s string) string {
+	// Simple escaping for JSON string values.
+	out := `"`
+	for _, r := range s {
+		switch r {
+		case '"':
+			out += `\"`
+		case '\\':
+			out += `\\`
+		case '\n':
+			out += `\n`
+		case '\r':
+			out += `\r`
+		case '\t':
+			out += `\t`
+		default:
+			out += string(r)
+		}
+	}
+	return out + `"`
+}


### PR DESCRIPTION
## Summary

- `datastorectl validate [path]` — parses DCL file/directory, converts resource blocks, validates context references
- No cluster connection — purely offline check
- Text mode: "Valid." on success, diagnostic errors on failure
- JSON mode: `{"valid": true}` or `{"valid": false, "error": "..."}`
- Exit codes: 0 (valid), 1 (errors)
- Adds `errExit` type for clean exit code handling across all commands

Closes #133

## Test plan

- [x] `go vet ./...` passes
- [x] `validate config/testdata/valid_config.dcl` → "Valid.", exit 0
- [x] `validate config/testdata/invalid_has_resources.dcl` → error about missing context, exit 1
- [x] `validate --output json` → JSON output
- [x] `validate /nonexistent` → error, exit 1
- [x] `validate --help` → shows usage with global flags
- [x] `go test ./... -count=1` full suite green