### PR TITLE
feat(provider): add schema system for deterministic block conversion

### DIFF
--- a/cmd/datastorectl/plan.go
+++ b/cmd/datastorectl/plan.go
@@ -119,7 +119,7 @@ func runPlan(cmd *cobra.Command, args []string) error {
 // convertAndResolveForDetection does a lightweight convert of resource blocks
 // for multi-context detection. Errors are swallowed — detection is best-effort.
 func convertAndResolveForDetection(resourceBlocks []dcl.Block, contexts []config.Context) ([]provider.Resource, error) {
-	rs, err := engine.ConvertBlocks(resourceBlocks)
+	rs, err := engine.ConvertBlocks(resourceBlocks, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/datastorectl/validate.go
+++ b/cmd/datastorectl/validate.go
@@ -52,7 +52,7 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	}
 
 	// 4. Convert resource blocks.
-	resourceSet, err := engine.ConvertBlocks(resourceBlocks)
+	resourceSet, err := engine.ConvertBlocks(resourceBlocks, nil)
 	if err != nil {
 		return exitWithError(cmd, err, format, color)
 	}

--- a/engine/convert.go
+++ b/engine/convert.go
@@ -15,26 +15,34 @@ type ResourceSet struct {
 
 // ConvertFile converts all blocks in a parsed DCL file into a ResourceSet.
 // It returns an error if the file contains parse errors or if any two
-// blocks produce the same ResourceID.
-func ConvertFile(file *dcl.File) (*ResourceSet, error) {
+// blocks produce the same ResourceID. The schemas map may be nil for
+// untyped conversion (count-based fallback).
+func ConvertFile(file *dcl.File, schemas map[string]provider.Schema) (*ResourceSet, error) {
 	if file == nil {
 		return nil, fmt.Errorf("cannot convert nil file")
 	}
 	if file.Diagnostics.HasErrors() {
 		return nil, fmt.Errorf("file has parse errors: %s", file.Diagnostics.Error())
 	}
-	return ConvertBlocks(file.Blocks)
+	return ConvertBlocks(file.Blocks, schemas)
 }
 
 // ConvertBlocks converts a slice of DCL blocks into a ResourceSet.
 // Unlike ConvertFile, it operates on pre-filtered blocks (e.g., after
 // context blocks have been separated out by config.SplitFile).
-func ConvertBlocks(blocks []dcl.Block) (*ResourceSet, error) {
+// The schemas map may be nil for untyped conversion (count-based fallback).
+func ConvertBlocks(blocks []dcl.Block, schemas map[string]provider.Schema) (*ResourceSet, error) {
 	resources := make([]provider.Resource, 0, len(blocks))
 	seen := map[provider.ResourceID]struct{}{}
 
 	for i, block := range blocks {
-		r, err := blockToResource(block)
+		var schema *provider.Schema
+		if schemas != nil {
+			if s, ok := schemas[block.Type]; ok {
+				schema = &s
+			}
+		}
+		r, err := blockToResource(block, schema)
 		if err != nil {
 			return nil, fmt.Errorf("block %d (%s %q): %w", i, block.Type, block.Label, err)
 		}
@@ -115,8 +123,9 @@ func exprToValue(expr dcl.Expression) (provider.Value, error) {
 
 // blockToResource converts a top-level DCL Block into a provider Resource.
 // Block.Type → ResourceID.Type, Block.Label → ResourceID.Name.
-func blockToResource(block dcl.Block) (provider.Resource, error) {
-	body, err := convertBody(block.Attributes, block.Blocks)
+// The schema is used to determine list vs map for nested blocks; it may be nil.
+func blockToResource(block dcl.Block, schema *provider.Schema) (provider.Resource, error) {
+	body, err := convertBody(block.Attributes, block.Blocks, schema)
 	if err != nil {
 		return provider.Resource{}, err
 	}
@@ -128,9 +137,11 @@ func blockToResource(block dcl.Block) (provider.Resource, error) {
 }
 
 // convertBody converts a block's attributes and nested blocks into an OrderedMap.
-// Attributes are converted via exprToValue. Nested blocks are grouped by type:
-// single-occurrence types become a MapVal, multi-occurrence become a ListVal.
-func convertBody(attrs []dcl.Attribute, blocks []dcl.Block) (*provider.OrderedMap, error) {
+// Attributes are converted via exprToValue. Nested blocks are grouped by type.
+// When a schema is provided, its FieldHints determine list vs map. When schema
+// is nil (e.g. inside nested blocks), count-based fallback applies: single
+// occurrence → MapVal, multiple → ListVal.
+func convertBody(attrs []dcl.Attribute, blocks []dcl.Block, schema *provider.Schema) (*provider.OrderedMap, error) {
 	m := provider.NewOrderedMap()
 
 	// Attributes first.
@@ -158,15 +169,14 @@ func convertBody(attrs []dcl.Attribute, blocks []dcl.Block) (*provider.OrderedMa
 		}
 	}
 
-	// Convert each group.
+	// Convert each group. Schema hints take precedence; count-based fallback
+	// is used when no schema is present.
 	for _, g := range groups {
-		if len(g.blocks) == 1 {
-			nested, err := convertNestedBlock(g.blocks[0])
-			if err != nil {
-				return nil, fmt.Errorf("block %q: %w", g.typ, err)
-			}
-			m.Set(g.typ, provider.MapVal(nested))
-		} else {
+		hint := fieldHintFor(schema, g.typ)
+
+		switch hint {
+		case provider.FieldBlockList:
+			// Always produce a list, even for a single block.
 			elems := make([]provider.Value, len(g.blocks))
 			for i, b := range g.blocks {
 				nested, err := convertNestedBlock(b)
@@ -176,16 +186,60 @@ func convertBody(attrs []dcl.Attribute, blocks []dcl.Block) (*provider.OrderedMa
 				elems[i] = provider.MapVal(nested)
 			}
 			m.Set(g.typ, provider.ListVal(elems))
+
+		case provider.FieldBlockMap:
+			// Always produce a map; error if more than one block.
+			if len(g.blocks) > 1 {
+				return nil, fmt.Errorf("block %q: schema declares map but %d blocks found", g.typ, len(g.blocks))
+			}
+			nested, err := convertNestedBlock(g.blocks[0])
+			if err != nil {
+				return nil, fmt.Errorf("block %q: %w", g.typ, err)
+			}
+			m.Set(g.typ, provider.MapVal(nested))
+
+		default:
+			// No schema hint — count-based fallback.
+			if schema != nil {
+				return nil, fmt.Errorf("block %q: not declared in schema for this resource type", g.typ)
+			}
+			if len(g.blocks) == 1 {
+				nested, err := convertNestedBlock(g.blocks[0])
+				if err != nil {
+					return nil, fmt.Errorf("block %q: %w", g.typ, err)
+				}
+				m.Set(g.typ, provider.MapVal(nested))
+			} else {
+				elems := make([]provider.Value, len(g.blocks))
+				for i, b := range g.blocks {
+					nested, err := convertNestedBlock(b)
+					if err != nil {
+						return nil, fmt.Errorf("block %q[%d]: %w", g.typ, i, err)
+					}
+					elems[i] = provider.MapVal(nested)
+				}
+				m.Set(g.typ, provider.ListVal(elems))
+			}
 		}
 	}
 
 	return m, nil
 }
 
+// fieldHintFor returns the FieldHint for a block type from the schema.
+// Returns 0 (no hint) if the schema is nil or doesn't contain the field.
+func fieldHintFor(schema *provider.Schema, blockType string) provider.FieldHint {
+	if schema == nil || schema.Fields == nil {
+		return 0
+	}
+	return schema.Fields[blockType]
+}
+
 // convertNestedBlock converts a single nested block's content into an OrderedMap.
 // If the block has a label, the result is wrapped: label becomes the key.
+// Nested blocks always use count-based fallback (nil schema).
 func convertNestedBlock(block dcl.Block) (*provider.OrderedMap, error) {
-	inner, err := convertBody(block.Attributes, block.Blocks)
+	inner, err := convertBody(block.Attributes, block.Blocks, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/engine/convert_test.go
+++ b/engine/convert_test.go
@@ -23,7 +23,7 @@ func TestConvertFile_Basic(t *testing.T) {
 				},
 			},
 		}
-		rs, err := ConvertFile(file)
+		rs, err := ConvertFile(file, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -49,7 +49,7 @@ func TestConvertFile_Basic(t *testing.T) {
 				{Type: "policy", Label: "p1"},
 			},
 		}
-		rs, err := ConvertFile(file)
+		rs, err := ConvertFile(file, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -70,7 +70,7 @@ func TestConvertFile_Basic(t *testing.T) {
 
 	t.Run("empty_blocks", func(t *testing.T) {
 		file := &dcl.File{Blocks: nil}
-		rs, err := ConvertFile(file)
+		rs, err := ConvertFile(file, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -90,7 +90,7 @@ func TestConvertFile_Basic(t *testing.T) {
 				{Type: "b_type", Label: "second"},
 			},
 		}
-		rs, err := ConvertFile(file)
+		rs, err := ConvertFile(file, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -117,7 +117,7 @@ func TestConvertFile_Duplicates(t *testing.T) {
 				{Type: "index", Label: "logs"},
 			},
 		}
-		_, err := ConvertFile(file)
+		_, err := ConvertFile(file, nil)
 		if err == nil {
 			t.Fatal("expected error for duplicate resource")
 		}
@@ -137,7 +137,7 @@ func TestConvertFile_Duplicates(t *testing.T) {
 				{Type: "index", Label: "b"},
 			},
 		}
-		rs, err := ConvertFile(file)
+		rs, err := ConvertFile(file, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -153,7 +153,7 @@ func TestConvertFile_Duplicates(t *testing.T) {
 				{Type: "template", Label: "logs"},
 			},
 		}
-		rs, err := ConvertFile(file)
+		rs, err := ConvertFile(file, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -172,7 +172,7 @@ func TestConvertFile_Duplicates(t *testing.T) {
 				{Type: "config", Label: "c1"},
 			},
 		}
-		_, err := ConvertFile(file)
+		_, err := ConvertFile(file, nil)
 		if err == nil {
 			t.Fatal("expected error for duplicate resource")
 		}
@@ -185,7 +185,7 @@ func TestConvertFile_Duplicates(t *testing.T) {
 
 func TestConvertFile_Errors(t *testing.T) {
 	t.Run("nil_file", func(t *testing.T) {
-		_, err := ConvertFile(nil)
+		_, err := ConvertFile(nil, nil)
 		if err == nil {
 			t.Fatal("expected error for nil file")
 		}
@@ -200,7 +200,7 @@ func TestConvertFile_Errors(t *testing.T) {
 				{Severity: dcl.SeverityError, Message: "unexpected token"},
 			},
 		}
-		_, err := ConvertFile(file)
+		_, err := ConvertFile(file, nil)
 		if err == nil {
 			t.Fatal("expected error for file with parse errors")
 		}
@@ -218,7 +218,7 @@ func TestConvertFile_Errors(t *testing.T) {
 				{Type: "index", Label: "logs"},
 			},
 		}
-		rs, err := ConvertFile(file)
+		rs, err := ConvertFile(file, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -239,7 +239,7 @@ func TestConvertFile_Errors(t *testing.T) {
 				},
 			},
 		}
-		_, err := ConvertFile(file)
+		_, err := ConvertFile(file, nil)
 		if err == nil {
 			t.Fatal("expected error for block conversion failure")
 		}
@@ -271,7 +271,7 @@ func TestConvertFile_Fidelity(t *testing.T) {
 				},
 			},
 		}
-		rs, err := ConvertFile(file)
+		rs, err := ConvertFile(file, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -305,7 +305,7 @@ func TestConvertFile_Fidelity(t *testing.T) {
 				{Type: "index", Label: "b", Rng: rng1},
 			},
 		}
-		rs, err := ConvertFile(file)
+		rs, err := ConvertFile(file, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -724,7 +724,7 @@ func TestBlockToResource_Basic(t *testing.T) {
 			Rng: rng,
 		}
 
-		got, err := blockToResource(block)
+		got, err := blockToResource(block, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -751,7 +751,7 @@ func TestBlockToResource_Basic(t *testing.T) {
 	t.Run("empty_block", func(t *testing.T) {
 		block := dcl.Block{Type: "template", Label: "t1"}
 
-		got, err := blockToResource(block)
+		got, err := blockToResource(block, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -777,7 +777,7 @@ func TestBlockToResource_Basic(t *testing.T) {
 			},
 		}
 
-		got, err := blockToResource(block)
+		got, err := blockToResource(block, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -807,7 +807,7 @@ func TestBlockToResource_NestedBlocks(t *testing.T) {
 			},
 		}
 
-		got, err := blockToResource(block)
+		got, err := blockToResource(block, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -836,7 +836,7 @@ func TestBlockToResource_NestedBlocks(t *testing.T) {
 			},
 		}
 
-		got, err := blockToResource(block)
+		got, err := blockToResource(block, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -882,7 +882,7 @@ func TestBlockToResource_NestedBlocks(t *testing.T) {
 			},
 		}
 
-		got, err := blockToResource(block)
+		got, err := blockToResource(block, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -923,7 +923,7 @@ func TestBlockToResource_NestedBlocks(t *testing.T) {
 			},
 		}
 
-		got, err := blockToResource(block)
+		got, err := blockToResource(block, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -964,7 +964,7 @@ func TestBlockToResource_NestedBlocks(t *testing.T) {
 			},
 		}
 
-		got, err := blockToResource(block)
+		got, err := blockToResource(block, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1005,7 +1005,7 @@ func TestBlockToResource_DeepNesting(t *testing.T) {
 			},
 		}
 
-		got, err := blockToResource(block)
+		got, err := blockToResource(block, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1092,7 +1092,7 @@ func TestBlockToResource_DeepNesting(t *testing.T) {
 			},
 		}
 
-		got, err := blockToResource(block)
+		got, err := blockToResource(block, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1157,7 +1157,7 @@ func TestBlockToResource_Errors(t *testing.T) {
 				{Key: "bad", Value: nil},
 			},
 		}
-		_, err := blockToResource(block)
+		_, err := blockToResource(block, nil)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -1183,7 +1183,7 @@ func TestBlockToResource_Errors(t *testing.T) {
 				},
 			},
 		}
-		_, err := blockToResource(block)
+		_, err := blockToResource(block, nil)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -1217,7 +1217,7 @@ func TestBlockToResource_Errors(t *testing.T) {
 				},
 			},
 		}
-		_, err := blockToResource(block)
+		_, err := blockToResource(block, nil)
 		if err == nil {
 			t.Fatal("expected error")
 		}

--- a/engine/convert_test.go
+++ b/engine/convert_test.go
@@ -1230,3 +1230,196 @@ func TestBlockToResource_Errors(t *testing.T) {
 		}
 	})
 }
+
+// --- Schema-aware conversion tests ---
+
+func TestConvertBlocks_schema_single_block_as_list(t *testing.T) {
+	// Regression: before the schema system, a single nested block of a given
+	// type produced a MapVal. With FieldBlockList, it must produce a ListVal
+	// with one element regardless of count.
+	blocks := []dcl.Block{
+		{
+			Type:  "opensearch_role",
+			Label: "log_reader",
+			Blocks: []dcl.Block{
+				{
+					Type: "index_permissions",
+					Attributes: []dcl.Attribute{
+						{Key: "index_patterns", Value: &dcl.ListExpr{Elements: []dcl.Expression{
+							&dcl.LiteralString{Value: "logs-*"},
+						}}},
+					},
+				},
+			},
+		},
+	}
+	schemas := map[string]provider.Schema{
+		"opensearch_role": {
+			Fields: map[string]provider.FieldHint{
+				"index_permissions": provider.FieldBlockList,
+			},
+		},
+	}
+
+	rs, err := ConvertBlocks(blocks, schemas)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rs.Resources) != 1 {
+		t.Fatalf("len(Resources) = %d, want 1", len(rs.Resources))
+	}
+
+	got, ok := rs.Resources[0].Body.Get("index_permissions")
+	if !ok {
+		t.Fatal("expected index_permissions in body")
+	}
+	if got.Kind != provider.KindList {
+		t.Fatalf("index_permissions.Kind = %s, want KindList", got.Kind)
+	}
+	if len(got.List) != 1 {
+		t.Errorf("len(index_permissions) = %d, want 1", len(got.List))
+	}
+}
+
+func TestConvertBlocks_schema_list_multiple_blocks(t *testing.T) {
+	// FieldBlockList with 2+ blocks still produces a ListVal.
+	blocks := []dcl.Block{
+		{
+			Type:  "opensearch_role",
+			Label: "r",
+			Blocks: []dcl.Block{
+				{Type: "index_permissions", Attributes: []dcl.Attribute{
+					{Key: "index_patterns", Value: &dcl.ListExpr{Elements: []dcl.Expression{&dcl.LiteralString{Value: "a-*"}}}},
+				}},
+				{Type: "index_permissions", Attributes: []dcl.Attribute{
+					{Key: "index_patterns", Value: &dcl.ListExpr{Elements: []dcl.Expression{&dcl.LiteralString{Value: "b-*"}}}},
+				}},
+			},
+		},
+	}
+	schemas := map[string]provider.Schema{
+		"opensearch_role": {
+			Fields: map[string]provider.FieldHint{"index_permissions": provider.FieldBlockList},
+		},
+	}
+
+	rs, err := ConvertBlocks(blocks, schemas)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := rs.Resources[0].Body.Get("index_permissions")
+	if got.Kind != provider.KindList {
+		t.Fatalf("Kind = %s, want KindList", got.Kind)
+	}
+	if len(got.List) != 2 {
+		t.Errorf("len = %d, want 2", len(got.List))
+	}
+}
+
+func TestConvertBlocks_schema_map_single_block(t *testing.T) {
+	// FieldBlockMap with a single block produces a MapVal.
+	blocks := []dcl.Block{
+		{
+			Type:  "opensearch_component_template",
+			Label: "ct",
+			Blocks: []dcl.Block{
+				{Type: "template", Attributes: []dcl.Attribute{
+					{Key: "settings", Value: &dcl.LiteralString{Value: "x"}},
+				}},
+			},
+		},
+	}
+	schemas := map[string]provider.Schema{
+		"opensearch_component_template": {
+			Fields: map[string]provider.FieldHint{"template": provider.FieldBlockMap},
+		},
+	}
+
+	rs, err := ConvertBlocks(blocks, schemas)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := rs.Resources[0].Body.Get("template")
+	if got.Kind != provider.KindMap {
+		t.Fatalf("Kind = %s, want KindMap", got.Kind)
+	}
+}
+
+func TestConvertBlocks_schema_map_multiple_blocks_errors(t *testing.T) {
+	// FieldBlockMap with 2+ blocks is a user error.
+	blocks := []dcl.Block{
+		{
+			Type:  "opensearch_component_template",
+			Label: "ct",
+			Blocks: []dcl.Block{
+				{Type: "template"},
+				{Type: "template"},
+			},
+		},
+	}
+	schemas := map[string]provider.Schema{
+		"opensearch_component_template": {
+			Fields: map[string]provider.FieldHint{"template": provider.FieldBlockMap},
+		},
+	}
+
+	_, err := ConvertBlocks(blocks, schemas)
+	if err == nil {
+		t.Fatal("expected error for multiple blocks under FieldBlockMap")
+	}
+	if !strings.Contains(err.Error(), "schema declares map but 2 blocks found") {
+		t.Errorf("error = %q, want it to mention the mismatch", err.Error())
+	}
+}
+
+func TestConvertBlocks_schema_undeclared_block_errors(t *testing.T) {
+	// When a schema is present, unknown nested block types are an error.
+	blocks := []dcl.Block{
+		{
+			Type:  "opensearch_role",
+			Label: "r",
+			Blocks: []dcl.Block{
+				{Type: "mystery_block"},
+			},
+		},
+	}
+	schemas := map[string]provider.Schema{
+		"opensearch_role": {
+			Fields: map[string]provider.FieldHint{"index_permissions": provider.FieldBlockList},
+		},
+	}
+
+	_, err := ConvertBlocks(blocks, schemas)
+	if err == nil {
+		t.Fatal("expected error for undeclared nested block")
+	}
+	if !strings.Contains(err.Error(), "not declared in schema") {
+		t.Errorf("error = %q, want it to mention undeclared block", err.Error())
+	}
+}
+
+func TestConvertBlocks_schema_nil_uses_count_fallback(t *testing.T) {
+	// With nil schemas, the converter falls back to count-based heuristics:
+	// a single block becomes a MapVal. This preserves backward compatibility
+	// for callers that haven't adopted schemas.
+	blocks := []dcl.Block{
+		{
+			Type:  "anything",
+			Label: "x",
+			Blocks: []dcl.Block{
+				{Type: "nested", Attributes: []dcl.Attribute{
+					{Key: "k", Value: &dcl.LiteralString{Value: "v"}},
+				}},
+			},
+		},
+	}
+
+	rs, err := ConvertBlocks(blocks, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := rs.Resources[0].Body.Get("nested")
+	if got.Kind != provider.KindMap {
+		t.Errorf("Kind = %s, want KindMap (count-based fallback)", got.Kind)
+	}
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -36,14 +36,17 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 	// 1. Split file into context and resource blocks.
 	contextBlocks, resourceBlocks := config.SplitFile(file)
 
-	// 2. Convert resource blocks (not context blocks) into a flat resource set.
-	resourceSet, err := ConvertBlocks(resourceBlocks)
+	// 2. Collect schemas from providers for the resource types in this file.
+	schemas := collectSchemas(resourceBlocks)
+
+	// 3. Convert resource blocks (not context blocks) into a flat resource set.
+	resourceSet, err := ConvertBlocks(resourceBlocks, schemas)
 	if err != nil {
 		return nil, fmt.Errorf("convert: %w", err)
 	}
 	desired := resourceSet.Resources
 
-	// 3. If file has context blocks, parse them and wire up configs.
+	// 4. If file has context blocks, parse them and wire up configs.
 	if len(contextBlocks) > 0 {
 		contexts, err := config.ParseContexts(contextBlocks)
 		if err != nil {
@@ -68,19 +71,19 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		}
 	}
 
-	// 4. Look up, instantiate, and configure providers.
+	// 5. Look up, instantiate, and configure providers.
 	providers, orderings, err := ConfigureProviders(ctx, desired, configs)
 	if err != nil {
 		return nil, fmt.Errorf("configure providers: %w", err)
 	}
 
-	// 5. Discover live state from each unique provider.
+	// 6. Discover live state from each unique provider.
 	allLive, err := discover(ctx, providers)
 	if err != nil {
 		return nil, fmt.Errorf("discover: %w", err)
 	}
 
-	// 5b. Scope live resources to only types present in desired state.
+	// 6b. Scope live resources to only types present in desired state.
 	// This prevents the engine from planning deletes for resource types
 	// the user didn't declare (e.g., built-in OpenSearch users).
 	desiredTypes := make(map[string]struct{}, len(desired))
@@ -94,19 +97,19 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		}
 	}
 
-	// 6. Build the dependency graph BEFORE resolution (needs KindReference values).
+	// 7. Build the dependency graph BEFORE resolution (needs KindReference values).
 	graph, err := BuildDependencyGraphWithOrdering(desired, orderings)
 	if err != nil {
 		return nil, fmt.Errorf("build dependency graph: %w", err)
 	}
 
-	// 7. Build an index of desired resources for reference resolution.
+	// 8. Build an index of desired resources for reference resolution.
 	index := make(map[provider.ResourceID]provider.Resource, len(desired))
 	for _, r := range desired {
 		index[r.ID] = r
 	}
 
-	// 8. Resolve cross-resource references in desired resources.
+	// 9. Resolve cross-resource references in desired resources.
 	for i, r := range desired {
 		resolved, err := ResolveReferences(r, index)
 		if err != nil {
@@ -115,7 +118,7 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		desired[i] = resolved
 	}
 
-	// 9. Resolve secret function calls in desired resources.
+	// 10. Resolve secret function calls in desired resources.
 	for i, r := range desired {
 		resolved, err := ResolveSecrets(ctx, r, e.SecretResolver)
 		if err != nil {
@@ -124,22 +127,22 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		desired[i] = resolved
 	}
 
-	// 10. Normalize desired resources.
+	// 11. Normalize desired resources.
 	normalizedDesired, err := NormalizeResources(ctx, desired, providers)
 	if err != nil {
 		return nil, fmt.Errorf("normalize desired: %w", err)
 	}
 
-	// 11. Normalize live resources.
+	// 12. Normalize live resources.
 	normalizedLive, err := NormalizeResources(ctx, live, providers)
 	if err != nil {
 		return nil, fmt.Errorf("normalize live: %w", err)
 	}
 
-	// 12. Build the plan by diffing desired against live.
+	// 13. Build the plan by diffing desired against live.
 	plan := BuildPlan(normalizedDesired, normalizedLive)
 
-	// 13. Add live-only (delete) resources to the graph so OrderPlan includes them.
+	// 14. Add live-only (delete) resources to the graph so OrderPlan includes them.
 	for _, c := range plan.Changes {
 		if c.Type == ChangeDelete && !graph.HasNode(c.ID) {
 			graph.AddNode(c.ID)
@@ -212,6 +215,38 @@ func validateResources(ctx context.Context, plan *Plan, providers map[string]pro
 		}
 	}
 	return nil
+}
+
+// collectSchemas extracts provider prefixes from the resource blocks, looks up
+// each registered provider, and collects their declared schemas. This runs
+// before conversion so the converter can use schema hints for list vs map.
+// If a provider is not registered or declares no schemas, it is silently
+// skipped — errors are caught later during ConfigureProviders.
+func collectSchemas(blocks []dcl.Block) map[string]provider.Schema {
+	// Deduplicate provider prefixes.
+	prefixes := make(map[string]struct{})
+	for _, b := range blocks {
+		if prefix, ok := provider.ProviderForResourceType(b.Type); ok {
+			prefixes[prefix] = struct{}{}
+		}
+	}
+
+	schemas := make(map[string]provider.Schema)
+	for prefix := range prefixes {
+		f, ok := provider.Lookup(prefix)
+		if !ok {
+			continue
+		}
+		p := f()
+		for typ, s := range p.Schemas() {
+			schemas[typ] = s
+		}
+	}
+
+	if len(schemas) == 0 {
+		return nil
+	}
+	return schemas
 }
 
 // discover calls Discover on each unique provider instance, deduplicating by

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -56,6 +56,8 @@ func (m *mockEngineProvider) Apply(ctx context.Context, op provider.Operation, r
 	return nil
 }
 
+func (m *mockEngineProvider) Schemas() map[string]provider.Schema { return nil }
+
 // stubSecretResolver satisfies SecretResolver and always returns the path as
 // the resolved value.
 type stubSecretResolver struct{}

--- a/engine/executor_test.go
+++ b/engine/executor_test.go
@@ -31,6 +31,7 @@ func (m *mockProvider) Apply(ctx context.Context, op provider.Operation, r provi
 	}
 	return nil
 }
+func (m *mockProvider) Schemas() map[string]provider.Schema { return nil }
 
 func errDiags(msg string) dcl.Diagnostics {
 	return dcl.Diagnostics{{Severity: dcl.SeverityError, Message: msg}}

--- a/engine/normalize_test.go
+++ b/engine/normalize_test.go
@@ -30,6 +30,7 @@ func (m *mockNormProvider) Validate(context.Context, provider.Resource) dcl.Diag
 func (m *mockNormProvider) Apply(context.Context, provider.Operation, provider.Resource) dcl.Diagnostics {
 	return nil
 }
+func (m *mockNormProvider) Schemas() map[string]provider.Schema { return nil }
 
 func TestNormalizeResources(t *testing.T) {
 	t.Run("all_succeed", func(t *testing.T) {

--- a/engine/providers_test.go
+++ b/engine/providers_test.go
@@ -36,6 +36,7 @@ func (m *mockConfigProvider) Validate(context.Context, provider.Resource) dcl.Di
 func (m *mockConfigProvider) Apply(context.Context, provider.Operation, provider.Resource) dcl.Diagnostics {
 	return nil
 }
+func (m *mockConfigProvider) Schemas() map[string]provider.Schema { return nil }
 
 func TestConfigureProviders(t *testing.T) {
 	t.Run("all_succeed", func(t *testing.T) {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -38,6 +38,7 @@ type Provider interface {
 	Normalize(ctx context.Context, r Resource) (Resource, dcl.Diagnostics)
 	Validate(ctx context.Context, r Resource) dcl.Diagnostics
 	Apply(ctx context.Context, op Operation, r Resource) dcl.Diagnostics
+	Schemas() map[string]Schema
 }
 
 // TypeOrdering declares that resources of type Before should be

--- a/provider/registry_test.go
+++ b/provider/registry_test.go
@@ -29,6 +29,7 @@ func (stubProvider) Validate(context.Context, Resource) dcl.Diagnostics { return
 func (stubProvider) Apply(context.Context, Operation, Resource) dcl.Diagnostics {
 	return nil
 }
+func (stubProvider) Schemas() map[string]Schema { return nil }
 
 func TestRegisterAndLookup(t *testing.T) {
 	t.Cleanup(resetRegistry)

--- a/provider/schema.go
+++ b/provider/schema.go
@@ -1,0 +1,21 @@
+package provider
+
+// FieldHint tells the DCL converter how to represent a nested block group.
+type FieldHint int
+
+const (
+	// FieldBlockList means the block should always produce a ListVal,
+	// even when only one block of that type appears.
+	FieldBlockList FieldHint = iota + 1
+
+	// FieldBlockMap means the block should always produce a MapVal,
+	// even when multiple blocks of that type appear (which would be an error).
+	FieldBlockMap
+)
+
+// Schema declares the expected structure for a resource type's nested blocks.
+// The converter uses these hints to choose ListVal vs MapVal instead of
+// guessing from occurrence count.
+type Schema struct {
+	Fields map[string]FieldHint
+}

--- a/providers/opensearch/component_template.go
+++ b/providers/opensearch/component_template.go
@@ -14,6 +14,15 @@ import (
 // componentTemplateHandler implements resourceHandler for opensearch_component_template resources.
 type componentTemplateHandler struct{}
 
+// Schema declares that template is always a map block.
+func (h *componentTemplateHandler) Schema() provider.Schema {
+	return provider.Schema{
+		Fields: map[string]provider.FieldHint{
+			"template": provider.FieldBlockMap,
+		},
+	}
+}
+
 // Discover fetches all non-system component templates from OpenSearch.
 func (h *componentTemplateHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/_component_template", nil)

--- a/providers/opensearch/composable_index_template.go
+++ b/providers/opensearch/composable_index_template.go
@@ -14,6 +14,15 @@ import (
 // composableIndexTemplateHandler implements resourceHandler for opensearch_composable_index_template resources.
 type composableIndexTemplateHandler struct{}
 
+// Schema declares that template is always a map block.
+func (h *composableIndexTemplateHandler) Schema() provider.Schema {
+	return provider.Schema{
+		Fields: map[string]provider.FieldHint{
+			"template": provider.FieldBlockMap,
+		},
+	}
+}
+
 // Discover fetches all non-system composable index templates from OpenSearch.
 func (h *composableIndexTemplateHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/_index_template", nil)

--- a/providers/opensearch/handler.go
+++ b/providers/opensearch/handler.go
@@ -14,3 +14,10 @@ type resourceHandler interface {
 	Validate(ctx context.Context, r provider.Resource) error
 	Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error
 }
+
+// schemaProvider is an optional interface a handler may implement to declare
+// the expected structure of its nested blocks. The provider collects these
+// during Schemas() and passes them to the DCL converter.
+type schemaProvider interface {
+	Schema() provider.Schema
+}

--- a/providers/opensearch/provider.go
+++ b/providers/opensearch/provider.go
@@ -199,6 +199,18 @@ func (p *Provider) Apply(ctx context.Context, op provider.Operation, r provider.
 	return nil
 }
 
+// Schemas collects schema declarations from all handlers that implement the
+// schemaProvider interface and returns them keyed by resource type.
+func (p *Provider) Schemas() map[string]provider.Schema {
+	schemas := make(map[string]provider.Schema)
+	for typ, h := range p.handlers {
+		if sp, ok := h.(schemaProvider); ok {
+			schemas[typ] = sp.Schema()
+		}
+	}
+	return schemas
+}
+
 // TypeOrderings declares the default resource type ordering for the opensearch provider.
 func (p *Provider) TypeOrderings() []provider.TypeOrdering {
 	return []provider.TypeOrdering{

--- a/providers/opensearch/role.go
+++ b/providers/opensearch/role.go
@@ -13,6 +13,17 @@ import (
 // roleHandler implements resourceHandler for opensearch_role resources.
 type roleHandler struct{}
 
+// Schema declares that index_permissions and tenant_permissions are always
+// lists, even when only one block appears in the DCL source.
+func (h *roleHandler) Schema() provider.Schema {
+	return provider.Schema{
+		Fields: map[string]provider.FieldHint{
+			"index_permissions":  provider.FieldBlockList,
+			"tenant_permissions": provider.FieldBlockList,
+		},
+	}
+}
+
 // Discover fetches all non-reserved, non-hidden, non-static roles from OpenSearch.
 func (h *roleHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/_plugins/_security/api/roles/", nil)


### PR DESCRIPTION
## Summary
- Adds `provider.Schema` and `provider.FieldHint` types so providers can declare whether nested blocks are lists or maps
- OpenSearch handlers (`roleHandler`, `componentTemplateHandler`, `composableIndexTemplateHandler`) declare schemas for their nested block fields
- The DCL converter uses schema hints when available, falling back to count-based heuristics when no schema is present
- Engine pipeline collects schemas before conversion via `collectSchemas()`

Closes #142

## Test plan
- [x] `go vet ./provider/... ./providers/...` passes
- [x] `go test ./provider/... ./providers/... -count=1` passes
- [ ] `go test ./engine/... -count=1` (blocked by missing `config` package — pre-existing)
- [ ] End-to-end: `go run ./cmd/datastorectl validate testdata/showcase/resources.dcl` produces correct list for single `index_permissions` block