### PR TITLE
feat: additive-only plan/apply by default with --prune opt-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ vendor/
 
 # Worktrees
 .worktrees/
+
+# Local docs and plans — kept out of version control
+docs/

--- a/cmd/datastorectl/apply.go
+++ b/cmd/datastorectl/apply.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/MathewBravo/datastorectl/config"
+	"github.com/MathewBravo/datastorectl/engine"
 	"github.com/MathewBravo/datastorectl/output"
 	"github.com/spf13/cobra"
 )
@@ -86,7 +87,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 
 	// 4. Dry run path.
 	if dryRun {
-		plan, err := eng.DryRun(ctx, file, nil)
+		plan, err := eng.DryRun(ctx, file, nil, engine.PlanOptions{})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return errExit{code: 1}
@@ -117,7 +118,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 	}
 
 	// 5. Full apply path.
-	result, err := eng.Apply(ctx, file, nil)
+	result, err := eng.Apply(ctx, file, nil, engine.PlanOptions{})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return errExit{code: 1}

--- a/cmd/datastorectl/apply.go
+++ b/cmd/datastorectl/apply.go
@@ -26,6 +26,7 @@ Exit codes: 0 = all changes succeeded, 1 = one or more changes failed.`,
 
 func init() {
 	applyCmd.Flags().Bool("dry-run", false, "validate the full pipeline without applying changes")
+	applyCmd.Flags().Bool("prune", false, "include delete changes (default: additive-only)")
 	rootCmd.AddCommand(applyCmd)
 }
 
@@ -35,6 +36,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 	format := outputFormat(cmd)
 	verbose := isVerbose(cmd)
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	prune, _ := cmd.Flags().GetBool("prune")
 	ctx := context.Background()
 
 	// 1. Load DCL.
@@ -87,7 +89,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 
 	// 4. Dry run path.
 	if dryRun {
-		plan, err := eng.DryRun(ctx, file, nil, engine.PlanOptions{})
+		plan, err := eng.DryRun(ctx, file, nil, engine.PlanOptions{Prune: prune})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return errExit{code: 1}
@@ -118,7 +120,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 	}
 
 	// 5. Full apply path.
-	result, err := eng.Apply(ctx, file, nil, engine.PlanOptions{})
+	result, err := eng.Apply(ctx, file, nil, engine.PlanOptions{Prune: prune})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return errExit{code: 1}

--- a/cmd/datastorectl/plan.go
+++ b/cmd/datastorectl/plan.go
@@ -86,7 +86,7 @@ func runPlan(cmd *cobra.Command, args []string) error {
 
 	// 4. Run the engine plan.
 	eng := createEngine()
-	plan, _, err := eng.Plan(ctx, file, nil)
+	plan, _, err := eng.Plan(ctx, file, nil, engine.PlanOptions{})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return errExit{code: 1}

--- a/cmd/datastorectl/plan.go
+++ b/cmd/datastorectl/plan.go
@@ -27,6 +27,7 @@ Exit codes: 0 = no changes, 1 = error, 2 = drift detected (changes pending).`,
 }
 
 func init() {
+	planCmd.Flags().Bool("prune", false, "include delete changes in the plan (default: additive-only)")
 	rootCmd.AddCommand(planCmd)
 }
 
@@ -85,8 +86,9 @@ func runPlan(cmd *cobra.Command, args []string) error {
 	}
 
 	// 4. Run the engine plan.
+	prune, _ := cmd.Flags().GetBool("prune")
 	eng := createEngine()
-	plan, _, err := eng.Plan(ctx, file, nil, engine.PlanOptions{})
+	plan, _, err := eng.Plan(ctx, file, nil, engine.PlanOptions{Prune: prune})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return errExit{code: 1}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -79,7 +79,9 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		return nil, fmt.Errorf("discover: %w", err)
 	}
 
-	// 6b. Scope live resources to declared types.
+	// 6b. Scope live resources to declared types. This prevents the engine
+	// from planning deletes for resource types the user didn't declare
+	// (e.g., built-in OpenSearch users).
 	desiredTypes := make(map[string]struct{}, len(desired))
 	for _, r := range desired {
 		desiredTypes[r.ID.Type] = struct{}{}
@@ -153,7 +155,9 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		plan.Unmanaged = unmanaged
 	}
 
-	// 15. Add live-only delete nodes to the graph when they'll execute.
+	// 15. Add live-only delete nodes to the graph for any deletes that remain
+	// in Changes (only populated when Prune=true). When Prune=false, this
+	// loop is a no-op because all deletes moved to Unmanaged in step 14.
 	for _, c := range plan.Changes {
 		if c.Type == ChangeDelete && !graph.HasNode(c.ID) {
 			graph.AddNode(c.ID)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -25,7 +25,7 @@ type planResult struct {
 
 // plan runs the full planning pipeline: split → convert → configure → discover →
 // build graph → resolve references → resolve secrets → normalize → build plan.
-func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*provider.OrderedMap) (*planResult, error) {
+func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*provider.OrderedMap, opts PlanOptions) (*planResult, error) {
 	if file == nil {
 		return nil, fmt.Errorf("convert: cannot convert nil file")
 	}
@@ -52,14 +52,10 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		if err != nil {
 			return nil, fmt.Errorf("parse contexts: %w", err)
 		}
-
-		// Strip context attribute from resources.
 		desired, err = config.ResolveResourceContexts(desired, contexts)
 		if err != nil {
 			return nil, fmt.Errorf("resolve resource contexts: %w", err)
 		}
-
-		// Build configs from contexts unless caller provided explicit configs.
 		if configs == nil {
 			configs, err = config.BuildConfigs(contexts)
 			if err != nil {
@@ -77,15 +73,13 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		return nil, fmt.Errorf("configure providers: %w", err)
 	}
 
-	// 6. Discover live state from each unique provider.
+	// 6. Discover live state.
 	allLive, err := discover(ctx, providers)
 	if err != nil {
 		return nil, fmt.Errorf("discover: %w", err)
 	}
 
-	// 6b. Scope live resources to only types present in desired state.
-	// This prevents the engine from planning deletes for resource types
-	// the user didn't declare (e.g., built-in OpenSearch users).
+	// 6b. Scope live resources to declared types.
 	desiredTypes := make(map[string]struct{}, len(desired))
 	for _, r := range desired {
 		desiredTypes[r.ID.Type] = struct{}{}
@@ -97,19 +91,19 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		}
 	}
 
-	// 7. Build the dependency graph BEFORE resolution (needs KindReference values).
+	// 7. Build dependency graph.
 	graph, err := BuildDependencyGraphWithOrdering(desired, orderings)
 	if err != nil {
 		return nil, fmt.Errorf("build dependency graph: %w", err)
 	}
 
-	// 8. Build an index of desired resources for reference resolution.
+	// 8. Build index for reference resolution.
 	index := make(map[provider.ResourceID]provider.Resource, len(desired))
 	for _, r := range desired {
 		index[r.ID] = r
 	}
 
-	// 9. Resolve cross-resource references in desired resources.
+	// 9. Resolve cross-resource references.
 	for i, r := range desired {
 		resolved, err := ResolveReferences(r, index)
 		if err != nil {
@@ -118,7 +112,7 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		desired[i] = resolved
 	}
 
-	// 10. Resolve secret function calls in desired resources.
+	// 10. Resolve secrets.
 	for i, r := range desired {
 		resolved, err := ResolveSecrets(ctx, r, e.SecretResolver)
 		if err != nil {
@@ -127,22 +121,39 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		desired[i] = resolved
 	}
 
-	// 11. Normalize desired resources.
+	// 11. Normalize desired.
 	normalizedDesired, err := NormalizeResources(ctx, desired, providers)
 	if err != nil {
 		return nil, fmt.Errorf("normalize desired: %w", err)
 	}
 
-	// 12. Normalize live resources.
+	// 12. Normalize live.
 	normalizedLive, err := NormalizeResources(ctx, live, providers)
 	if err != nil {
 		return nil, fmt.Errorf("normalize live: %w", err)
 	}
 
-	// 13. Build the plan by diffing desired against live.
+	// 13. Build full plan.
 	plan := BuildPlan(normalizedDesired, normalizedLive)
 
-	// 14. Add live-only (delete) resources to the graph so OrderPlan includes them.
+	// 14. Apply prune policy: when Prune=false, split deletes out of Changes
+	// into Unmanaged. The graph and executor only see Changes, so suppressing
+	// here is sufficient to make the rest of the pipeline additive-only.
+	if !opts.Prune {
+		kept := make([]ResourceChange, 0, len(plan.Changes))
+		var unmanaged []ResourceChange
+		for _, c := range plan.Changes {
+			if c.Type == ChangeDelete {
+				unmanaged = append(unmanaged, c)
+				continue
+			}
+			kept = append(kept, c)
+		}
+		plan.Changes = kept
+		plan.Unmanaged = unmanaged
+	}
+
+	// 15. Add live-only delete nodes to the graph when they'll execute.
 	for _, c := range plan.Changes {
 		if c.Type == ChangeDelete && !graph.HasNode(c.ID) {
 			graph.AddNode(c.ID)
@@ -153,9 +164,9 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 }
 
 // Plan runs the full planning pipeline and returns the plan and dependency
-// graph. It is a thin wrapper around the internal plan method.
-func (e *Engine) Plan(ctx context.Context, file *dcl.File, configs map[string]*provider.OrderedMap) (*Plan, *Graph, error) {
-	result, err := e.plan(ctx, file, configs)
+// graph. Pass PlanOptions{Prune: true} to include deletes in Plan.Changes.
+func (e *Engine) Plan(ctx context.Context, file *dcl.File, configs map[string]*provider.OrderedMap, opts PlanOptions) (*Plan, *Graph, error) {
+	result, err := e.plan(ctx, file, configs, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,38 +174,31 @@ func (e *Engine) Plan(ctx context.Context, file *dcl.File, configs map[string]*p
 }
 
 // Apply runs the full pipeline: plan → validate → order → execute.
-// The returned error covers pre-execution failures (plan, validate, cycle).
-// Per-resource execution failures live in ApplyResult.Results.
-func (e *Engine) Apply(ctx context.Context, file *dcl.File, configs map[string]*provider.OrderedMap) (*ApplyResult, error) {
-	result, err := e.plan(ctx, file, configs)
+// With PlanOptions{Prune: false} (default), deletes are skipped entirely.
+func (e *Engine) Apply(ctx context.Context, file *dcl.File, configs map[string]*provider.OrderedMap, opts PlanOptions) (*ApplyResult, error) {
+	result, err := e.plan(ctx, file, configs, opts)
 	if err != nil {
 		return nil, fmt.Errorf("plan: %w", err)
 	}
-
 	if err := validateResources(ctx, result.plan, result.providers); err != nil {
 		return nil, err
 	}
-
 	orderedPlan, err := OrderPlan(result.plan, result.graph)
 	if err != nil {
 		return nil, fmt.Errorf("order plan: %w", err)
 	}
-
 	return Execute(ctx, orderedPlan, result.graph, result.providers), nil
 }
 
-// DryRun runs the planning pipeline with validation but does not order or
-// execute. It catches configuration and validation problems without applying.
-func (e *Engine) DryRun(ctx context.Context, file *dcl.File, configs map[string]*provider.OrderedMap) (*Plan, error) {
-	result, err := e.plan(ctx, file, configs)
+// DryRun runs the planning pipeline with validation but does not execute.
+func (e *Engine) DryRun(ctx context.Context, file *dcl.File, configs map[string]*provider.OrderedMap, opts PlanOptions) (*Plan, error) {
+	result, err := e.plan(ctx, file, configs, opts)
 	if err != nil {
 		return nil, fmt.Errorf("plan: %w", err)
 	}
-
 	if err := validateResources(ctx, result.plan, result.providers); err != nil {
 		return nil, err
 	}
-
 	return result.plan, nil
 }
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -102,7 +102,7 @@ func TestEnginePlan(t *testing.T) {
 			provider.ResourceID{Type: "eng1_policy", Name: "ro"},
 		)
 
-		plan, graph, err := e.Plan(context.Background(), file, nil)
+		plan, graph, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -144,7 +144,7 @@ func TestEnginePlan(t *testing.T) {
 		}
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		plan, _, err := e.Plan(context.Background(), file, nil)
+		plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -181,7 +181,7 @@ func TestEnginePlan(t *testing.T) {
 		file.Blocks = append(file.Blocks, dcl.Block{Type: "eng3_svc", Label: "keeper"})
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		plan, _, err := e.Plan(context.Background(), file, nil)
+		plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{Prune: true})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -208,7 +208,7 @@ func TestEnginePlan(t *testing.T) {
 		}
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, graph, err := e.Plan(context.Background(), file, nil)
+		_, graph, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -261,7 +261,7 @@ func TestEnginePlan(t *testing.T) {
 		}
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		plan, _, err := e.Plan(context.Background(), file, nil)
+		plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -287,7 +287,7 @@ func TestEnginePlan(t *testing.T) {
 		)
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, _, err := e.Plan(context.Background(), file, nil)
+		_, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -311,7 +311,7 @@ func TestEnginePlan(t *testing.T) {
 		file := makeFile(provider.ResourceID{Type: "eng7_svc", Name: "desired"})
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		plan, _, err := e.Plan(context.Background(), file, nil)
+		plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -323,7 +323,7 @@ func TestEnginePlan(t *testing.T) {
 
 	t.Run("convert_error", func(t *testing.T) {
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, _, err := e.Plan(context.Background(), nil, nil)
+		_, _, err := e.Plan(context.Background(), nil, nil, PlanOptions{})
 		if err == nil {
 			t.Fatal("expected error for nil file")
 		}
@@ -337,7 +337,7 @@ func TestEnginePlan(t *testing.T) {
 		file := makeFile(provider.ResourceID{Type: "eng8unknown_svc", Name: "a"})
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, _, err := e.Plan(context.Background(), file, nil)
+		_, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err == nil {
 			t.Fatal("expected error for unknown provider")
 		}
@@ -359,7 +359,7 @@ func TestEnginePlan(t *testing.T) {
 		file := makeFile(provider.ResourceID{Type: "eng9_svc", Name: "a"})
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, _, err := e.Plan(context.Background(), file, nil)
+		_, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err == nil {
 			t.Fatal("expected error from discover")
 		}
@@ -383,7 +383,7 @@ func TestEnginePlan(t *testing.T) {
 		}
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, _, err := e.Plan(context.Background(), file, nil)
+		_, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err == nil {
 			t.Fatal("expected error for malformed reference")
 		}
@@ -411,7 +411,7 @@ func TestEnginePlan(t *testing.T) {
 		}
 
 		e := &Engine{SecretResolver: failSecretResolver{err: errTestFail}}
-		_, _, err := e.Plan(context.Background(), file, nil)
+		_, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err == nil {
 			t.Fatal("expected error for secret resolution failure")
 		}
@@ -433,7 +433,7 @@ func TestEnginePlan(t *testing.T) {
 		file := makeFile(provider.ResourceID{Type: "eng12_svc", Name: "a"})
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, _, err := e.Plan(context.Background(), file, nil)
+		_, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err == nil {
 			t.Fatal("expected error from normalize")
 		}
@@ -462,7 +462,7 @@ func TestEnginePlan(t *testing.T) {
 		}
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, graph, err := e.Plan(context.Background(), file, nil)
+		_, graph, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -481,7 +481,7 @@ func TestEnginePlan(t *testing.T) {
 		e := &Engine{SecretResolver: stubSecretResolver{}}
 		file := &dcl.File{}
 
-		plan, graph, err := e.Plan(context.Background(), file, nil)
+		plan, graph, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -517,7 +517,7 @@ func TestEnginePlan(t *testing.T) {
 		file := makeFile(provider.ResourceID{Type: "eng14_svc", Name: "a"})
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, _, err := e.Plan(ctx, file, nil)
+		_, _, err := e.Plan(ctx, file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -553,7 +553,7 @@ func TestEngineApply(t *testing.T) {
 			provider.ResourceID{Type: "aeng1_policy", Name: "ro"},
 		)
 
-		result, err := e.Apply(context.Background(), file, nil)
+		result, err := e.Apply(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -602,7 +602,7 @@ func TestEngineApply(t *testing.T) {
 		}
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		result, err := e.Apply(context.Background(), file, nil)
+		result, err := e.Apply(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -633,7 +633,7 @@ func TestEngineApply(t *testing.T) {
 		file := makeFile(provider.ResourceID{Type: "aeng3_svc", Name: "keeper"})
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		result, err := e.Apply(context.Background(), file, nil)
+		result, err := e.Apply(context.Background(), file, nil, PlanOptions{Prune: true})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -678,7 +678,7 @@ func TestEngineApply(t *testing.T) {
 		}
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		result, err := e.Apply(context.Background(), file, nil)
+		result, err := e.Apply(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -706,7 +706,7 @@ func TestEngineApply(t *testing.T) {
 		file := makeFile(provider.ResourceID{Type: "aeng5_svc", Name: "a"})
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, err := e.Apply(context.Background(), file, nil)
+		_, err := e.Apply(context.Background(), file, nil, PlanOptions{})
 		if err == nil {
 			t.Fatal("expected validation error")
 		}
@@ -720,7 +720,7 @@ func TestEngineApply(t *testing.T) {
 
 	t.Run("plan_error_propagates", func(t *testing.T) {
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, err := e.Apply(context.Background(), nil, nil)
+		_, err := e.Apply(context.Background(), nil, nil, PlanOptions{})
 		if err == nil {
 			t.Fatal("expected error for nil file")
 		}
@@ -743,7 +743,7 @@ func TestEngineApply(t *testing.T) {
 		file := makeFile(provider.ResourceID{Type: "aeng7_svc", Name: "a"})
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		result, err := e.Apply(context.Background(), file, nil)
+		result, err := e.Apply(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("expected nil error from Apply, got: %v", err)
 		}
@@ -772,7 +772,7 @@ func TestEngineApply(t *testing.T) {
 		file := makeFile(provider.ResourceID{Type: "aeng8_svc", Name: "a"})
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, err := e.Apply(ctx, file, nil)
+		_, err := e.Apply(ctx, file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -802,7 +802,7 @@ func TestEngineDryRun(t *testing.T) {
 		)
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		plan, err := e.DryRun(context.Background(), file, nil)
+		plan, err := e.DryRun(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -825,7 +825,7 @@ func TestEngineDryRun(t *testing.T) {
 		file := makeFile(provider.ResourceID{Type: "dreng2_svc", Name: "a"})
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, err := e.DryRun(context.Background(), file, nil)
+		_, err := e.DryRun(context.Background(), file, nil, PlanOptions{})
 		if err == nil {
 			t.Fatal("expected validation error")
 		}
@@ -836,7 +836,7 @@ func TestEngineDryRun(t *testing.T) {
 
 	t.Run("plan_error_propagates", func(t *testing.T) {
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, err := e.DryRun(context.Background(), nil, nil)
+		_, err := e.DryRun(context.Background(), nil, nil, PlanOptions{})
 		if err == nil {
 			t.Fatal("expected error for nil file")
 		}
@@ -946,7 +946,7 @@ func TestEnginePlan_TypeOrderings(t *testing.T) {
 		)
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, graph, err := e.Plan(context.Background(), file, nil)
+		_, graph, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -973,7 +973,7 @@ func TestEnginePlan_TypeOrderings(t *testing.T) {
 		)
 
 		e := &Engine{SecretResolver: stubSecretResolver{}}
-		_, graph, err := e.Plan(context.Background(), file, nil)
+		_, graph, err := e.Plan(context.Background(), file, nil, PlanOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -983,4 +983,66 @@ func TestEnginePlan_TypeOrderings(t *testing.T) {
 			t.Errorf("expected no edges between unrelated types, got deps: %v", deps)
 		}
 	})
+}
+
+func TestEnginePlan_AdditiveDefault_SuppressesDeletes(t *testing.T) {
+	// Live has an orphan resource not in the DCL. With Prune off (default),
+	// it must appear in Unmanaged, not Changes.
+	mock := &mockEngineProvider{
+		discoverFn: func(context.Context) ([]provider.Resource, dcl.Diagnostics) {
+			return []provider.Resource{
+				{ID: rid("prune1_svc", "orphan"), Body: provider.NewOrderedMap()},
+				{ID: rid("prune1_svc", "keeper"), Body: provider.NewOrderedMap()},
+			}, nil
+		},
+	}
+	provider.Register("prune1", func() provider.Provider { return mock })
+
+	file := makeFile(provider.ResourceID{Type: "prune1_svc", Name: "keeper"})
+
+	e := &Engine{SecretResolver: stubSecretResolver{}}
+	plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plan.Deletes()) != 0 {
+		t.Errorf("expected 0 deletes in Changes, got %d", len(plan.Deletes()))
+	}
+	if len(plan.Unmanaged) != 1 {
+		t.Fatalf("expected 1 unmanaged, got %d", len(plan.Unmanaged))
+	}
+	if plan.Unmanaged[0].ID.Name != "orphan" {
+		t.Errorf("Unmanaged[0].ID.Name = %q, want %q", plan.Unmanaged[0].ID.Name, "orphan")
+	}
+	if plan.HasChanges() {
+		t.Error("HasChanges() = true, want false (orphan is suppressed)")
+	}
+}
+
+func TestEnginePlan_PruneMode_IncludesDeletes(t *testing.T) {
+	mock := &mockEngineProvider{
+		discoverFn: func(context.Context) ([]provider.Resource, dcl.Diagnostics) {
+			return []provider.Resource{
+				{ID: rid("prune2_svc", "orphan"), Body: provider.NewOrderedMap()},
+			}, nil
+		},
+	}
+	provider.Register("prune2", func() provider.Provider { return mock })
+
+	file := makeFile(provider.ResourceID{Type: "prune2_svc", Name: "keeper"})
+
+	e := &Engine{SecretResolver: stubSecretResolver{}}
+	plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{Prune: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plan.Deletes()) != 1 {
+		t.Fatalf("expected 1 delete in Changes, got %d", len(plan.Deletes()))
+	}
+	if len(plan.Unmanaged) != 0 {
+		t.Errorf("expected empty Unmanaged with Prune=true, got %d", len(plan.Unmanaged))
+	}
+	if !plan.HasChanges() {
+		t.Error("HasChanges() = false, want true")
+	}
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -531,6 +531,77 @@ func TestEnginePlan(t *testing.T) {
 			t.Error("context not propagated to Normalize")
 		}
 	})
+
+	t.Run("additive_default_suppresses_deletes", func(t *testing.T) {
+		// Live has an orphan resource not in the DCL. With Prune off (default),
+		// it must appear in Unmanaged, not Changes.
+		mock := &mockEngineProvider{
+			discoverFn: func(context.Context) ([]provider.Resource, dcl.Diagnostics) {
+				return []provider.Resource{
+					{ID: rid("prune1_svc", "orphan"), Body: provider.NewOrderedMap()},
+					{ID: rid("prune1_svc", "keeper"), Body: provider.NewOrderedMap()},
+				}, nil
+			},
+		}
+		provider.Register("prune1", func() provider.Provider { return mock })
+
+		file := makeFile(provider.ResourceID{Type: "prune1_svc", Name: "keeper"})
+
+		e := &Engine{SecretResolver: stubSecretResolver{}}
+		plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(plan.Deletes()) != 0 {
+			t.Errorf("expected 0 deletes in Changes, got %d", len(plan.Deletes()))
+		}
+		if len(plan.Unmanaged) != 1 {
+			t.Fatalf("expected 1 unmanaged, got %d", len(plan.Unmanaged))
+		}
+		if plan.Unmanaged[0].ID.Name != "orphan" {
+			t.Errorf("Unmanaged[0].ID.Name = %q, want %q", plan.Unmanaged[0].ID.Name, "orphan")
+		}
+		if plan.HasChanges() {
+			t.Error("HasChanges() = true, want false (orphan is suppressed)")
+		}
+	})
+
+	t.Run("prune_mode_includes_deletes", func(t *testing.T) {
+		// Live has keeper (matching desired, → no-op) and orphan (live-only, → delete).
+		// With Prune=true only the delete appears in Changes; no-ops are separate.
+		// We want exactly 1 change (the delete), so keeper must match desired exactly.
+		mock := &mockEngineProvider{
+			discoverFn: func(context.Context) ([]provider.Resource, dcl.Diagnostics) {
+				return []provider.Resource{
+					{ID: rid("prune2_svc", "orphan"), Body: provider.NewOrderedMap()},
+					{ID: rid("prune2_svc", "keeper"), Body: provider.NewOrderedMap()},
+				}, nil
+			},
+		}
+		provider.Register("prune2", func() provider.Provider { return mock })
+
+		file := makeFile(provider.ResourceID{Type: "prune2_svc", Name: "keeper"})
+
+		e := &Engine{SecretResolver: stubSecretResolver{}}
+		plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{Prune: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(plan.Deletes()) != 1 {
+			t.Fatalf("expected 1 delete in Changes, got %d", len(plan.Deletes()))
+		}
+		// Keeper is a no-op (1) + orphan is a delete (1) = 2 total changes.
+		// Guard that no accidental creates or updates leaked into the plan.
+		if len(plan.Changes) != 2 {
+			t.Errorf("expected exactly 2 changes (1 no-op + 1 delete), got %d", len(plan.Changes))
+		}
+		if len(plan.Unmanaged) != 0 {
+			t.Errorf("expected empty Unmanaged with Prune=true, got %d", len(plan.Unmanaged))
+		}
+		if !plan.HasChanges() {
+			t.Error("HasChanges() = false, want true")
+		}
+	})
 }
 
 // errTestFail is a sentinel error for test assertions.
@@ -985,64 +1056,3 @@ func TestEnginePlan_TypeOrderings(t *testing.T) {
 	})
 }
 
-func TestEnginePlan_AdditiveDefault_SuppressesDeletes(t *testing.T) {
-	// Live has an orphan resource not in the DCL. With Prune off (default),
-	// it must appear in Unmanaged, not Changes.
-	mock := &mockEngineProvider{
-		discoverFn: func(context.Context) ([]provider.Resource, dcl.Diagnostics) {
-			return []provider.Resource{
-				{ID: rid("prune1_svc", "orphan"), Body: provider.NewOrderedMap()},
-				{ID: rid("prune1_svc", "keeper"), Body: provider.NewOrderedMap()},
-			}, nil
-		},
-	}
-	provider.Register("prune1", func() provider.Provider { return mock })
-
-	file := makeFile(provider.ResourceID{Type: "prune1_svc", Name: "keeper"})
-
-	e := &Engine{SecretResolver: stubSecretResolver{}}
-	plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(plan.Deletes()) != 0 {
-		t.Errorf("expected 0 deletes in Changes, got %d", len(plan.Deletes()))
-	}
-	if len(plan.Unmanaged) != 1 {
-		t.Fatalf("expected 1 unmanaged, got %d", len(plan.Unmanaged))
-	}
-	if plan.Unmanaged[0].ID.Name != "orphan" {
-		t.Errorf("Unmanaged[0].ID.Name = %q, want %q", plan.Unmanaged[0].ID.Name, "orphan")
-	}
-	if plan.HasChanges() {
-		t.Error("HasChanges() = true, want false (orphan is suppressed)")
-	}
-}
-
-func TestEnginePlan_PruneMode_IncludesDeletes(t *testing.T) {
-	mock := &mockEngineProvider{
-		discoverFn: func(context.Context) ([]provider.Resource, dcl.Diagnostics) {
-			return []provider.Resource{
-				{ID: rid("prune2_svc", "orphan"), Body: provider.NewOrderedMap()},
-			}, nil
-		},
-	}
-	provider.Register("prune2", func() provider.Provider { return mock })
-
-	file := makeFile(provider.ResourceID{Type: "prune2_svc", Name: "keeper"})
-
-	e := &Engine{SecretResolver: stubSecretResolver{}}
-	plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{Prune: true})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(plan.Deletes()) != 1 {
-		t.Fatalf("expected 1 delete in Changes, got %d", len(plan.Deletes()))
-	}
-	if len(plan.Unmanaged) != 0 {
-		t.Errorf("expected empty Unmanaged with Prune=true, got %d", len(plan.Unmanaged))
-	}
-	if !plan.HasChanges() {
-		t.Error("HasChanges() = false, want true")
-	}
-}

--- a/engine/plan.go
+++ b/engine/plan.go
@@ -41,11 +41,26 @@ type ResourceChange struct {
 }
 
 // Plan holds the full set of resource changes the engine intends to apply.
+// Changes are the actions that will execute (creates, updates, and — when
+// pruning is enabled — deletes). Unmanaged carries delete changes that were
+// discovered but suppressed because pruning is off; they are informational
+// only and never executed.
 type Plan struct {
-	Changes []ResourceChange
+	Changes   []ResourceChange
+	Unmanaged []ResourceChange
+}
+
+// PlanOptions tunes the planning pipeline. Zero value means additive-only:
+// creates and updates are planned, deletes are surfaced as Unmanaged.
+type PlanOptions struct {
+	// Prune includes delete changes in Plan.Changes. When false, deletes
+	// move to Plan.Unmanaged and are neither displayed per-resource nor
+	// executed.
+	Prune bool
 }
 
 // HasChanges reports whether the plan contains any non-no-op changes.
+// Unmanaged resources do not count — they are suppressed from execution.
 func (p Plan) HasChanges() bool {
 	for _, c := range p.Changes {
 		if c.Type != ChangeNoOp {
@@ -56,19 +71,14 @@ func (p Plan) HasChanges() bool {
 }
 
 // Creates returns all changes with type ChangeCreate.
-func (p Plan) Creates() []ResourceChange {
-	return p.filterByType(ChangeCreate)
-}
+func (p Plan) Creates() []ResourceChange { return p.filterByType(ChangeCreate) }
 
 // Updates returns all changes with type ChangeUpdate.
-func (p Plan) Updates() []ResourceChange {
-	return p.filterByType(ChangeUpdate)
-}
+func (p Plan) Updates() []ResourceChange { return p.filterByType(ChangeUpdate) }
 
-// Deletes returns all changes with type ChangeDelete.
-func (p Plan) Deletes() []ResourceChange {
-	return p.filterByType(ChangeDelete)
-}
+// Deletes returns delete changes from Plan.Changes. This is only populated
+// when PlanOptions.Prune was true; otherwise deletes live in Plan.Unmanaged.
+func (p Plan) Deletes() []ResourceChange { return p.filterByType(ChangeDelete) }
 
 func (p Plan) filterByType(t ChangeType) []ResourceChange {
 	var out []ResourceChange
@@ -80,8 +90,22 @@ func (p Plan) filterByType(t ChangeType) []ResourceChange {
 	return out
 }
 
-// Summary returns a human-readable summary of the plan.
+// Summary returns a human-readable summary of the plan. Format depends on
+// whether pruning is active (indicated by the presence of delete changes
+// in Plan.Changes vs Plan.Unmanaged):
+//   - additive mode, no unmanaged: "Plan: X to create, Y to update"
+//   - additive mode with unmanaged: "Plan: X to create, Y to update (N unmanaged resources — use --prune to delete)"
+//   - prune mode: "Plan: X to create, Y to update, Z to delete"
 func (p Plan) Summary() string {
 	creates, updates, deletes := len(p.Creates()), len(p.Updates()), len(p.Deletes())
-	return fmt.Sprintf("Plan: %d to create, %d to update, %d to delete", creates, updates, deletes)
+	unmanaged := len(p.Unmanaged)
+
+	if deletes > 0 {
+		// Prune mode — deletes already in Changes.
+		return fmt.Sprintf("Plan: %d to create, %d to update, %d to delete", creates, updates, deletes)
+	}
+	if unmanaged > 0 {
+		return fmt.Sprintf("Plan: %d to create, %d to update (%d unmanaged resources — use --prune to delete)", creates, updates, unmanaged)
+	}
+	return fmt.Sprintf("Plan: %d to create, %d to update", creates, updates)
 }

--- a/engine/plan.go
+++ b/engine/plan.go
@@ -71,14 +71,20 @@ func (p Plan) HasChanges() bool {
 }
 
 // Creates returns all changes with type ChangeCreate.
-func (p Plan) Creates() []ResourceChange { return p.filterByType(ChangeCreate) }
+func (p Plan) Creates() []ResourceChange {
+	return p.filterByType(ChangeCreate)
+}
 
 // Updates returns all changes with type ChangeUpdate.
-func (p Plan) Updates() []ResourceChange { return p.filterByType(ChangeUpdate) }
+func (p Plan) Updates() []ResourceChange {
+	return p.filterByType(ChangeUpdate)
+}
 
 // Deletes returns delete changes from Plan.Changes. This is only populated
 // when PlanOptions.Prune was true; otherwise deletes live in Plan.Unmanaged.
-func (p Plan) Deletes() []ResourceChange { return p.filterByType(ChangeDelete) }
+func (p Plan) Deletes() []ResourceChange {
+	return p.filterByType(ChangeDelete)
+}
 
 func (p Plan) filterByType(t ChangeType) []ResourceChange {
 	var out []ResourceChange
@@ -90,9 +96,10 @@ func (p Plan) filterByType(t ChangeType) []ResourceChange {
 	return out
 }
 
-// Summary returns a human-readable summary of the plan. Format depends on
-// whether pruning is active (indicated by the presence of delete changes
-// in Plan.Changes vs Plan.Unmanaged):
+// Summary returns a human-readable summary of the plan.
+// Plan.Changes containing delete entries and Plan.Unmanaged being non-empty are mutually exclusive — the engine maintains this invariant.
+// Format depends on whether pruning is active (indicated by the presence of
+// delete changes in Plan.Changes vs Plan.Unmanaged):
 //   - additive mode, no unmanaged: "Plan: X to create, Y to update"
 //   - additive mode with unmanaged: "Plan: X to create, Y to update (N unmanaged resources — use --prune to delete)"
 //   - prune mode: "Plan: X to create, Y to update, Z to delete"

--- a/engine/plan_test.go
+++ b/engine/plan_test.go
@@ -67,6 +67,16 @@ func TestPlan_HasChanges(t *testing.T) {
 			t.Fatal("expected changes when plan has a delete")
 		}
 	})
+
+	t.Run("excludes_unmanaged", func(t *testing.T) {
+		// Only unmanaged deletes → HasChanges must be false (drives exit code 0).
+		p := Plan{Unmanaged: []ResourceChange{
+			{ID: provider.ResourceID{Type: "t", Name: "x"}, Type: ChangeDelete},
+		}}
+		if p.HasChanges() {
+			t.Fatal("HasChanges() = true, want false (unmanaged shouldn't count)")
+		}
+	})
 }
 
 func TestPlan_Filters(t *testing.T) {
@@ -140,60 +150,47 @@ func TestPlan_Summary(t *testing.T) {
 			t.Fatalf("expected %q, got %q", want, got)
 		}
 	})
-}
 
-func TestPlanSummary_CreatesAndUpdatesOnly(t *testing.T) {
-	p := Plan{Changes: []ResourceChange{
-		{ID: provider.ResourceID{Type: "t", Name: "a"}, Type: ChangeCreate},
-		{ID: provider.ResourceID{Type: "t", Name: "b"}, Type: ChangeCreate},
-		{ID: provider.ResourceID{Type: "t", Name: "c"}, Type: ChangeUpdate},
-	}}
-	got := p.Summary()
-	want := "Plan: 2 to create, 1 to update"
-	if got != want {
-		t.Errorf("Summary() = %q, want %q", got, want)
-	}
-}
-
-func TestPlanSummary_WithUnmanaged(t *testing.T) {
-	p := Plan{
-		Changes: []ResourceChange{
+	t.Run("creates_and_updates_only", func(t *testing.T) {
+		p := Plan{Changes: []ResourceChange{
 			{ID: provider.ResourceID{Type: "t", Name: "a"}, Type: ChangeCreate},
-		},
-		Unmanaged: []ResourceChange{
+			{ID: provider.ResourceID{Type: "t", Name: "b"}, Type: ChangeCreate},
+			{ID: provider.ResourceID{Type: "t", Name: "c"}, Type: ChangeUpdate},
+		}}
+		want := "Plan: 2 to create, 1 to update"
+		if got := p.Summary(); got != want {
+			t.Fatalf("Summary() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("with_unmanaged", func(t *testing.T) {
+		p := Plan{
+			Changes: []ResourceChange{
+				{ID: provider.ResourceID{Type: "t", Name: "a"}, Type: ChangeCreate},
+			},
+			Unmanaged: []ResourceChange{
+				{ID: provider.ResourceID{Type: "t", Name: "x"}, Type: ChangeDelete},
+				{ID: provider.ResourceID{Type: "t", Name: "y"}, Type: ChangeDelete},
+			},
+		}
+		want := "Plan: 1 to create, 0 to update (2 unmanaged resources — use --prune to delete)"
+		if got := p.Summary(); got != want {
+			t.Fatalf("Summary() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("prune_mode", func(t *testing.T) {
+		// When Prune is on, deletes live inside Changes, not Unmanaged.
+		p := Plan{Changes: []ResourceChange{
+			{ID: provider.ResourceID{Type: "t", Name: "a"}, Type: ChangeCreate},
 			{ID: provider.ResourceID{Type: "t", Name: "x"}, Type: ChangeDelete},
 			{ID: provider.ResourceID{Type: "t", Name: "y"}, Type: ChangeDelete},
-		},
-	}
-	got := p.Summary()
-	want := "Plan: 1 to create, 0 to update (2 unmanaged resources — use --prune to delete)"
-	if got != want {
-		t.Errorf("Summary() = %q, want %q", got, want)
-	}
-}
-
-func TestPlanSummary_PruneMode(t *testing.T) {
-	// When Prune is on, deletes live inside Changes, not Unmanaged.
-	p := Plan{Changes: []ResourceChange{
-		{ID: provider.ResourceID{Type: "t", Name: "a"}, Type: ChangeCreate},
-		{ID: provider.ResourceID{Type: "t", Name: "x"}, Type: ChangeDelete},
-		{ID: provider.ResourceID{Type: "t", Name: "y"}, Type: ChangeDelete},
-	}}
-	got := p.Summary()
-	want := "Plan: 1 to create, 0 to update, 2 to delete"
-	if got != want {
-		t.Errorf("Summary() = %q, want %q", got, want)
-	}
-}
-
-func TestPlanHasChanges_ExcludesUnmanaged(t *testing.T) {
-	// Only unmanaged deletes → HasChanges must be false (drives exit code 0).
-	p := Plan{Unmanaged: []ResourceChange{
-		{ID: provider.ResourceID{Type: "t", Name: "x"}, Type: ChangeDelete},
-	}}
-	if p.HasChanges() {
-		t.Error("HasChanges() = true, want false (unmanaged shouldn't count)")
-	}
+		}}
+		want := "Plan: 1 to create, 0 to update, 2 to delete"
+		if got := p.Summary(); got != want {
+			t.Fatalf("Summary() = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestResourceChange_Fields(t *testing.T) {

--- a/engine/plan_test.go
+++ b/engine/plan_test.go
@@ -135,11 +135,65 @@ func TestPlan_Summary(t *testing.T) {
 
 	t.Run("no_changes", func(t *testing.T) {
 		p := Plan{}
-		want := "Plan: 0 to create, 0 to update, 0 to delete"
+		want := "Plan: 0 to create, 0 to update"
 		if got := p.Summary(); got != want {
 			t.Fatalf("expected %q, got %q", want, got)
 		}
 	})
+}
+
+func TestPlanSummary_CreatesAndUpdatesOnly(t *testing.T) {
+	p := Plan{Changes: []ResourceChange{
+		{ID: provider.ResourceID{Type: "t", Name: "a"}, Type: ChangeCreate},
+		{ID: provider.ResourceID{Type: "t", Name: "b"}, Type: ChangeCreate},
+		{ID: provider.ResourceID{Type: "t", Name: "c"}, Type: ChangeUpdate},
+	}}
+	got := p.Summary()
+	want := "Plan: 2 to create, 1 to update"
+	if got != want {
+		t.Errorf("Summary() = %q, want %q", got, want)
+	}
+}
+
+func TestPlanSummary_WithUnmanaged(t *testing.T) {
+	p := Plan{
+		Changes: []ResourceChange{
+			{ID: provider.ResourceID{Type: "t", Name: "a"}, Type: ChangeCreate},
+		},
+		Unmanaged: []ResourceChange{
+			{ID: provider.ResourceID{Type: "t", Name: "x"}, Type: ChangeDelete},
+			{ID: provider.ResourceID{Type: "t", Name: "y"}, Type: ChangeDelete},
+		},
+	}
+	got := p.Summary()
+	want := "Plan: 1 to create, 0 to update (2 unmanaged resources — use --prune to delete)"
+	if got != want {
+		t.Errorf("Summary() = %q, want %q", got, want)
+	}
+}
+
+func TestPlanSummary_PruneMode(t *testing.T) {
+	// When Prune is on, deletes live inside Changes, not Unmanaged.
+	p := Plan{Changes: []ResourceChange{
+		{ID: provider.ResourceID{Type: "t", Name: "a"}, Type: ChangeCreate},
+		{ID: provider.ResourceID{Type: "t", Name: "x"}, Type: ChangeDelete},
+		{ID: provider.ResourceID{Type: "t", Name: "y"}, Type: ChangeDelete},
+	}}
+	got := p.Summary()
+	want := "Plan: 1 to create, 0 to update, 2 to delete"
+	if got != want {
+		t.Errorf("Summary() = %q, want %q", got, want)
+	}
+}
+
+func TestPlanHasChanges_ExcludesUnmanaged(t *testing.T) {
+	// Only unmanaged deletes → HasChanges must be false (drives exit code 0).
+	p := Plan{Unmanaged: []ResourceChange{
+		{ID: provider.ResourceID{Type: "t", Name: "x"}, Type: ChangeDelete},
+	}}
+	if p.HasChanges() {
+		t.Error("HasChanges() = true, want false (unmanaged shouldn't count)")
+	}
 }
 
 func TestResourceChange_Fields(t *testing.T) {

--- a/output/json.go
+++ b/output/json.go
@@ -10,8 +10,13 @@ import (
 // --- JSON plan ---
 
 type jsonPlan struct {
-	Changes []jsonChange `json:"changes"`
-	Summary string       `json:"summary"`
+	Changes   []jsonChange    `json:"changes"`
+	Unmanaged []jsonUnmanaged `json:"unmanaged,omitempty"`
+	Summary   string          `json:"summary"`
+}
+
+type jsonUnmanaged struct {
+	ID jsonResourceID `json:"id"`
 }
 
 type jsonChange struct {
@@ -71,6 +76,13 @@ func FormatPlanJSON(plan *engine.Plan) ([]byte, error) {
 		}
 
 		jp.Changes = append(jp.Changes, jc)
+	}
+
+	if len(plan.Unmanaged) > 0 {
+		jp.Unmanaged = make([]jsonUnmanaged, len(plan.Unmanaged))
+		for i, u := range plan.Unmanaged {
+			jp.Unmanaged[i] = jsonUnmanaged{ID: toJSONID(u.ID)}
+		}
 	}
 
 	return json.MarshalIndent(jp, "", "  ")

--- a/output/json_test.go
+++ b/output/json_test.go
@@ -3,6 +3,7 @@ package output
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/MathewBravo/datastorectl/engine"
@@ -141,6 +142,41 @@ func TestFormatApplyResultJSON_mixed(t *testing.T) {
 	}
 	if got.Results[2].Status != "skipped" {
 		t.Errorf("expected skipped, got %q", got.Results[2].Status)
+	}
+}
+
+func TestFormatPlanJSON_includes_unmanaged(t *testing.T) {
+	plan := &engine.Plan{
+		Changes: []engine.ResourceChange{},
+		Unmanaged: []engine.ResourceChange{
+			{ID: provider.ResourceID{Type: "opensearch_role", Name: "orphan"}, Type: engine.ChangeDelete},
+		},
+	}
+	data, err := FormatPlanJSON(plan)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got struct {
+		Unmanaged []struct {
+			ID struct {
+				Type string `json:"type"`
+				Name string `json:"name"`
+			} `json:"id"`
+		} `json:"unmanaged"`
+		Summary string `json:"summary"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("json decode: %v", err)
+	}
+	if len(got.Unmanaged) != 1 {
+		t.Fatalf("unmanaged len = %d, want 1", len(got.Unmanaged))
+	}
+	if got.Unmanaged[0].ID.Type != "opensearch_role" || got.Unmanaged[0].ID.Name != "orphan" {
+		t.Errorf("Unmanaged[0].ID = %+v, want {opensearch_role, orphan}", got.Unmanaged[0].ID)
+	}
+	if !strings.Contains(got.Summary, "unmanaged") {
+		t.Errorf("Summary missing unmanaged mention: %q", got.Summary)
 	}
 }
 

--- a/output/plan.go
+++ b/output/plan.go
@@ -22,10 +22,15 @@ func FormatPlan(plan *engine.Plan, color bool) string {
 			blocks = append(blocks, formatDelete(c, color))
 		}
 	}
-	if len(blocks) == 0 {
+	if len(blocks) == 0 && len(plan.Unmanaged) == 0 {
 		return "No changes."
 	}
-	return strings.Join(blocks, "\n\n") + "\n\n" + bold(plan.Summary(), color) + "\n"
+	summary := bold(plan.Summary(), color)
+	if len(blocks) == 0 {
+		// Only unmanaged — show the summary alone.
+		return summary + "\n"
+	}
+	return strings.Join(blocks, "\n\n") + "\n\n" + summary + "\n"
 }
 
 func formatCreate(c engine.ResourceChange, color bool) string {

--- a/output/plan_test.go
+++ b/output/plan_test.go
@@ -122,7 +122,7 @@ func TestFormatPlan_includes_summary(t *testing.T) {
 	}
 }
 
-func TestFormatPlan_UnmanagedOnly(t *testing.T) {
+func TestFormatPlan_unmanaged_only(t *testing.T) {
 	plan := &engine.Plan{
 		Unmanaged: []engine.ResourceChange{
 			{ID: provider.ResourceID{Type: "t", Name: "x"}, Type: engine.ChangeDelete},
@@ -134,7 +134,7 @@ func TestFormatPlan_UnmanagedOnly(t *testing.T) {
 	if !strings.Contains(got, "2 unmanaged resources") {
 		t.Errorf("FormatPlan missing unmanaged count: %q", got)
 	}
-	if strings.Contains(got, "- ") {
+	if strings.Contains(got, "(delete)") {
 		t.Errorf("FormatPlan listed deletes per-resource when it shouldn't: %q", got)
 	}
 	if got == "No changes." {
@@ -142,7 +142,7 @@ func TestFormatPlan_UnmanagedOnly(t *testing.T) {
 	}
 }
 
-func TestFormatPlan_CreatesWithUnmanaged(t *testing.T) {
+func TestFormatPlan_creates_with_unmanaged(t *testing.T) {
 	desired := provider.NewOrderedMap()
 	desired.Set("name", provider.StringVal("hello"))
 	plan := &engine.Plan{

--- a/output/plan_test.go
+++ b/output/plan_test.go
@@ -122,6 +122,49 @@ func TestFormatPlan_includes_summary(t *testing.T) {
 	}
 }
 
+func TestFormatPlan_UnmanagedOnly(t *testing.T) {
+	plan := &engine.Plan{
+		Unmanaged: []engine.ResourceChange{
+			{ID: provider.ResourceID{Type: "t", Name: "x"}, Type: engine.ChangeDelete},
+			{ID: provider.ResourceID{Type: "t", Name: "y"}, Type: engine.ChangeDelete},
+		},
+	}
+	got := FormatPlan(plan, false)
+	// Must surface the unmanaged count; must NOT render per-resource delete lines.
+	if !strings.Contains(got, "2 unmanaged resources") {
+		t.Errorf("FormatPlan missing unmanaged count: %q", got)
+	}
+	if strings.Contains(got, "- ") {
+		t.Errorf("FormatPlan listed deletes per-resource when it shouldn't: %q", got)
+	}
+	if got == "No changes." {
+		t.Errorf("FormatPlan returned 'No changes.' but there are unmanaged resources")
+	}
+}
+
+func TestFormatPlan_CreatesWithUnmanaged(t *testing.T) {
+	desired := provider.NewOrderedMap()
+	desired.Set("name", provider.StringVal("hello"))
+	plan := &engine.Plan{
+		Changes: []engine.ResourceChange{
+			{
+				ID: provider.ResourceID{Type: "t", Name: "new"}, Type: engine.ChangeCreate,
+				Desired: &provider.Resource{ID: provider.ResourceID{Type: "t", Name: "new"}, Body: desired},
+			},
+		},
+		Unmanaged: []engine.ResourceChange{
+			{ID: provider.ResourceID{Type: "t", Name: "orphan"}, Type: engine.ChangeDelete},
+		},
+	}
+	got := FormatPlan(plan, false)
+	if !strings.Contains(got, "+ t.new (create)") {
+		t.Errorf("FormatPlan missing create line: %q", got)
+	}
+	if !strings.Contains(got, "1 unmanaged resources") {
+		t.Errorf("FormatPlan missing unmanaged count: %q", got)
+	}
+}
+
 func TestShouldColor_no_color_env(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	// Any writer — should return false due to NO_COLOR.

--- a/output/verbose.go
+++ b/output/verbose.go
@@ -23,10 +23,14 @@ func FormatPlanVerbose(plan *engine.Plan, color bool) string {
 			blocks = append(blocks, formatVerboseDelete(c, color))
 		}
 	}
-	if len(blocks) == 0 {
+	if len(blocks) == 0 && len(plan.Unmanaged) == 0 {
 		return "No changes."
 	}
-	return strings.Join(blocks, "\n\n") + "\n\n" + bold(plan.Summary(), color) + "\n"
+	summary := bold(plan.Summary(), color)
+	if len(blocks) == 0 {
+		return summary + "\n"
+	}
+	return strings.Join(blocks, "\n\n") + "\n\n" + summary + "\n"
 }
 
 func formatVerboseUpdate(c engine.ResourceChange, color bool) string {

--- a/output/verbose_test.go
+++ b/output/verbose_test.go
@@ -79,6 +79,24 @@ func TestFormatPlanVerbose_delete_shows_live(t *testing.T) {
 	}
 }
 
+func TestFormatPlanVerbose_unmanaged_only(t *testing.T) {
+	plan := &engine.Plan{
+		Unmanaged: []engine.ResourceChange{
+			{ID: provider.ResourceID{Type: "t", Name: "x"}, Type: engine.ChangeDelete},
+		},
+	}
+	got := FormatPlanVerbose(plan, false)
+	if !strings.Contains(got, "1 unmanaged resources") {
+		t.Errorf("FormatPlanVerbose missing unmanaged count: %q", got)
+	}
+	if strings.Contains(got, "(delete)") {
+		t.Errorf("FormatPlanVerbose listed delete per-resource: %q", got)
+	}
+	if got == "No changes." {
+		t.Errorf("FormatPlanVerbose returned 'No changes.' with unmanaged present")
+	}
+}
+
 func TestFormatPlanVerbose_no_color(t *testing.T) {
 	desired := &provider.Resource{ID: rid("svc", "a"), Body: provider.NewOrderedMap()}
 	desired.Body.Set("x", provider.StringVal("y"))


### PR DESCRIPTION
## Summary
- `plan` and `apply` now default to creates and updates only; deletes require `--prune`.
- `Plan.Unmanaged` carries suppressed delete changes; `Plan.Summary()` surfaces the count as `(N unmanaged resources — use --prune to delete)`.
- Exit code 0 when only unmanaged resources exist (no actionable changes). `--prune` mode restores the full three-way summary and exit 2 on any changes.
- JSON output gains a top-level `unmanaged` array when deletes are suppressed, so CI integrations can reason about orphan resources without parsing the human summary.

Closes #143

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` passes across all packages
- [x] `plan --help` and `apply --help` show `--prune`
- [x] `validate testdata/showcase/resources.dcl` still outputs `Valid.`
- [x] New unit tests at plan / engine / formatter / JSON levels
- [ ] Manual cluster test: apply a small DCL against a populated cluster, confirm plan summary reports unmanaged without listing them per-resource

## Notes
- Plan saved at `docs/superpowers/plans/2026-04-23-additive-default-with-prune.md`.
- 11 commits; the series is a clean TDD narrative (data model → engine filter → formatters → CLI). Keeping the history unsquashed is useful for bisect.