### PR TITLE
fix(dcl): reject duplicate attribute and block names within a block

### DIFF
--- a/dcl/parser.go
+++ b/dcl/parser.go
@@ -226,6 +226,10 @@ func (p *parser) parseBlock() (Block, bool) {
 
 	var attrs []Attribute
 	var blocks []Block
+	// Track names seen within this block scope so we can reject duplicates.
+	// Attributes may never repeat; blocks may repeat (list syntax) but cannot
+	// collide with an attribute of the same name.
+	seen := map[string]string{} // name → "attribute" | "block"
 
 	for !p.tooManyErrors {
 		p.skipNewlines()
@@ -242,18 +246,42 @@ func (p *parser) parseBlock() (Block, bool) {
 
 		// Disambiguation inside block body.
 		if p.peek.Type == TokenEquals {
+			namePos := p.cur.Pos
+			name := p.cur.Literal
 			attr, ok := p.parseAttribute()
 			if ok {
-				attrs = append(attrs, attr)
+				if prev, dup := seen[name]; dup {
+					if prev == "attribute" {
+						p.addError(namePos, fmt.Sprintf(
+							"duplicate attribute %q: an attribute with this name was already defined in this block",
+							name))
+					} else {
+						p.addError(namePos, fmt.Sprintf(
+							"duplicate name %q: a nested block with this name was already defined in this block, so this attribute conflicts",
+							name))
+					}
+				} else {
+					seen[name] = "attribute"
+					attrs = append(attrs, attr)
+				}
 			}
 			continue
 		}
 
 		// ident + peek string/{ → nested block (recursive).
 		if p.peek.Type == TokenString || p.peek.Type == TokenLBrace {
+			namePos := p.cur.Pos
+			name := p.cur.Literal
 			block, ok := p.parseBlock()
 			if ok {
-				blocks = append(blocks, block)
+				if prev, dup := seen[name]; dup && prev == "attribute" {
+					p.addError(namePos, fmt.Sprintf(
+						"duplicate name %q: an attribute with this name was already defined in this block, so this nested block conflicts",
+						name))
+				} else {
+					seen[name] = "block"
+					blocks = append(blocks, block)
+				}
 			}
 			continue
 		}

--- a/dcl/parser_test.go
+++ b/dcl/parser_test.go
@@ -1363,3 +1363,130 @@ func TestRecovery_ValidFileUnaffected(t *testing.T) {
 		t.Errorf("unexpected second nested: type=%q label=%q", logging.Type, logging.Label)
 	}
 }
+
+// --- Duplicate name detection (issue #145) ---
+
+func TestParseDuplicateAttribute(t *testing.T) {
+	src := `opensearch_role "r" {
+  cluster_permissions = ["read"]
+  cluster_permissions = ["write"]
+}`
+	_, diags := Parse("test.dcl", []byte(src))
+	if !diags.HasErrors() {
+		t.Fatal("expected error for duplicate attribute, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if containsSubstring(d.Message, "duplicate") && containsSubstring(d.Message, "cluster_permissions") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected diagnostic mentioning duplicate and cluster_permissions, got: %s", diags.Error())
+	}
+}
+
+func TestParseDuplicateAttributeAndBlock(t *testing.T) {
+	src := `opensearch_role "r" {
+  index_permissions = [{ index_patterns = ["a"] }]
+  index_permissions {
+    index_patterns = ["b"]
+  }
+}`
+	_, diags := Parse("test.dcl", []byte(src))
+	if !diags.HasErrors() {
+		t.Fatal("expected error for attribute/block name collision, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if containsSubstring(d.Message, "index_permissions") &&
+			(containsSubstring(d.Message, "duplicate") || containsSubstring(d.Message, "already")) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected diagnostic mentioning index_permissions collision, got: %s", diags.Error())
+	}
+}
+
+func TestParseDuplicateBlockThenAttribute(t *testing.T) {
+	src := `opensearch_role "r" {
+  index_permissions {
+    index_patterns = ["a"]
+  }
+  index_permissions = [{ index_patterns = ["b"] }]
+}`
+	_, diags := Parse("test.dcl", []byte(src))
+	if !diags.HasErrors() {
+		t.Fatal("expected error for block/attribute name collision, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if containsSubstring(d.Message, "index_permissions") &&
+			(containsSubstring(d.Message, "duplicate") || containsSubstring(d.Message, "already")) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected diagnostic mentioning index_permissions collision, got: %s", diags.Error())
+	}
+}
+
+func TestParseRepeatedBlocksAllowed(t *testing.T) {
+	src := `opensearch_role "r" {
+  index_permissions {
+    index_patterns = ["a"]
+  }
+  index_permissions {
+    index_patterns = ["b"]
+  }
+}`
+	f := parseString(t, src)
+	if len(f.Blocks) != 1 {
+		t.Fatalf("expected 1 top-level block, got %d", len(f.Blocks))
+	}
+	role := f.Blocks[0]
+	if len(role.Blocks) != 2 {
+		t.Errorf("expected 2 nested index_permissions blocks, got %d", len(role.Blocks))
+	}
+}
+
+func TestParseDuplicateDetectionScopedToBlock(t *testing.T) {
+	// Same attribute name in sibling blocks is fine.
+	src := `opensearch_role "a" {
+  name = "one"
+}
+opensearch_role "b" {
+  name = "two"
+}`
+	f := parseString(t, src)
+	if len(f.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(f.Blocks))
+	}
+}
+
+func TestParseDuplicateInNestedBlock(t *testing.T) {
+	src := `opensearch_role "r" {
+  index_permissions {
+    index_patterns = ["a"]
+    index_patterns = ["b"]
+  }
+}`
+	_, diags := Parse("test.dcl", []byte(src))
+	if !diags.HasErrors() {
+		t.Fatal("expected error for duplicate in nested block, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if containsSubstring(d.Message, "duplicate") && containsSubstring(d.Message, "index_patterns") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected diagnostic mentioning duplicate index_patterns, got: %s", diags.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- Parser now errors when two attributes share a name, or when an attribute and a nested block share a name, within the same block scope.
- Repeated nested blocks of the same type remain valid (list syntax).
- Previous behavior silently dropped the first definition during block conversion, losing user data.

## Test plan
- [x] `TestParseDuplicateAttribute` — two attrs, same key
- [x] `TestParseDuplicateAttributeAndBlock` — attr then block, same name
- [x] `TestParseDuplicateBlockThenAttribute` — block then attr, same name
- [x] `TestParseDuplicateInNestedBlock` — duplicates detected in nested scopes
- [x] `TestParseRepeatedBlocksAllowed` — multiple blocks of same type still valid
- [x] `TestParseDuplicateDetectionScopedToBlock` — same name across sibling blocks is fine
- [x] Full suite (`go test ./...`) green

Closes #145