### PR TITLE
fix(opensearch): prevent self-lockout and restore showcase convergence

### DIFF
--- a/cmd/datastorectl/apply.go
+++ b/cmd/datastorectl/apply.go
@@ -27,6 +27,7 @@ Exit codes: 0 = all changes succeeded, 1 = one or more changes failed.`,
 func init() {
 	applyCmd.Flags().Bool("dry-run", false, "validate the full pipeline without applying changes")
 	applyCmd.Flags().Bool("prune", false, "include delete changes (default: additive-only)")
+	applyCmd.Flags().Bool("allow-self-lockout", false, "allow executing deletes that would revoke the authenticated caller's own access")
 	rootCmd.AddCommand(applyCmd)
 }
 
@@ -37,6 +38,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 	verbose := isVerbose(cmd)
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	prune, _ := cmd.Flags().GetBool("prune")
+	allowLockout, _ := cmd.Flags().GetBool("allow-self-lockout")
 	ctx := context.Background()
 
 	// 1. Load DCL.
@@ -120,7 +122,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 	}
 
 	// 5. Full apply path.
-	result, err := eng.Apply(ctx, file, nil, engine.PlanOptions{Prune: prune})
+	result, err := eng.Apply(ctx, file, nil, engine.PlanOptions{Prune: prune, AllowSelfLockout: allowLockout})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return errExit{code: 1}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -164,7 +164,45 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		}
 	}
 
+	// 16. Collect DeleteGuards from any provider that implements DeleteGuarder.
+	plan.Guards = collectDeleteGuards(ctx, plan, providers)
+
 	return &planResult{plan: plan, graph: graph, providers: providers}, nil
+}
+
+// collectDeleteGuards groups deletes by provider and asks each provider
+// that implements DeleteGuarder to annotate them. Guards from all
+// providers are concatenated. Guard diagnostic errors are ignored —
+// a provider failing to produce guards should not block planning,
+// but means we lose the apply-time safety check for that provider.
+func collectDeleteGuards(ctx context.Context, plan *Plan, providers map[string]provider.Provider) []Guard {
+	byProvider := make(map[provider.Provider][]provider.Resource)
+	for _, c := range plan.Changes {
+		if c.Type != ChangeDelete || c.Live == nil {
+			continue
+		}
+		p, ok := providers[c.ID.Type]
+		if !ok {
+			continue
+		}
+		byProvider[p] = append(byProvider[p], *c.Live)
+	}
+
+	var guards []Guard
+	for p, deletes := range byProvider {
+		g, ok := p.(provider.DeleteGuarder)
+		if !ok {
+			continue
+		}
+		providerGuards, diags := g.GuardDeletes(ctx, deletes)
+		if diags.HasErrors() {
+			continue
+		}
+		for _, pg := range providerGuards {
+			guards = append(guards, Guard{Resource: pg.Resource, Reason: pg.Reason})
+		}
+	}
+	return guards
 }
 
 // Plan runs the full planning pipeline and returns the plan and dependency

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/MathewBravo/datastorectl/config"
 	"github.com/MathewBravo/datastorectl/dcl"
@@ -217,10 +218,23 @@ func (e *Engine) Plan(ctx context.Context, file *dcl.File, configs map[string]*p
 
 // Apply runs the full pipeline: plan → validate → order → execute.
 // With PlanOptions{Prune: false} (default), deletes are skipped entirely.
+// If Plan.Guards is non-empty and opts.AllowSelfLockout is false, Apply
+// refuses to execute any operation — guards are a hard stop.
 func (e *Engine) Apply(ctx context.Context, file *dcl.File, configs map[string]*provider.OrderedMap, opts PlanOptions) (*ApplyResult, error) {
 	result, err := e.plan(ctx, file, configs, opts)
 	if err != nil {
 		return nil, fmt.Errorf("plan: %w", err)
+	}
+	if len(result.plan.Guards) > 0 && !opts.AllowSelfLockout {
+		lines := make([]string, len(result.plan.Guards))
+		for i, g := range result.plan.Guards {
+			lines[i] = fmt.Sprintf("  - %s: %s", g.Resource, g.Reason)
+		}
+		return nil, fmt.Errorf(
+			"refusing to apply: %d delete(s) would lock out the authenticated caller:\n%s\n\npass --allow-self-lockout to override",
+			len(result.plan.Guards),
+			strings.Join(lines, "\n"),
+		)
 	}
 	if err := validateResources(ctx, result.plan, result.providers); err != nil {
 		return nil, err

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1056,3 +1056,75 @@ func TestEnginePlan_TypeOrderings(t *testing.T) {
 	})
 }
 
+
+// guardingEngineProvider is a mockEngineProvider that also implements
+// provider.DeleteGuarder, returning a preconfigured guard list.
+type guardingEngineProvider struct {
+	mockEngineProvider
+	guards []provider.DeleteGuard
+}
+
+func (g *guardingEngineProvider) GuardDeletes(context.Context, []provider.Resource) ([]provider.DeleteGuard, dcl.Diagnostics) {
+	return g.guards, nil
+}
+
+func TestEngine_plan_attaches_guards_from_DeleteGuarder(t *testing.T) {
+	liveOnly := provider.Resource{
+		ID: provider.ResourceID{Type: "engguard_role", Name: "victim"},
+	}
+	mock := &guardingEngineProvider{
+		mockEngineProvider: mockEngineProvider{
+			discoverFn: func(context.Context) ([]provider.Resource, dcl.Diagnostics) {
+				return []provider.Resource{liveOnly}, nil
+			},
+		},
+		guards: []provider.DeleteGuard{
+			{Resource: liveOnly.ID, Reason: "would lock out caller"},
+		},
+	}
+	provider.Register("engguard", func() provider.Provider { return mock })
+
+	// Desired has a resource of the same type as the live-only one so
+	// engine scoping keeps the live resource and plans a delete for it.
+	file := makeFile(provider.ResourceID{Type: "engguard_role", Name: "keeper"})
+
+	e := &Engine{SecretResolver: stubSecretResolver{}}
+	plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{Prune: true})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	if len(plan.Guards) != 1 {
+		t.Fatalf("got %d guards, want 1 (plan=%+v)", len(plan.Guards), plan)
+	}
+	if plan.Guards[0].Reason != "would lock out caller" {
+		t.Errorf("Guards[0].Reason = %q, want %q", plan.Guards[0].Reason, "would lock out caller")
+	}
+	if plan.Guards[0].Resource != liveOnly.ID {
+		t.Errorf("Guards[0].Resource = %v, want %v", plan.Guards[0].Resource, liveOnly.ID)
+	}
+}
+
+func TestEngine_plan_no_guards_when_provider_does_not_implement_DeleteGuarder(t *testing.T) {
+	liveOnly := provider.Resource{
+		ID: provider.ResourceID{Type: "engnoguard_role", Name: "victim"},
+	}
+	mock := &mockEngineProvider{
+		discoverFn: func(context.Context) ([]provider.Resource, dcl.Diagnostics) {
+			return []provider.Resource{liveOnly}, nil
+		},
+	}
+	provider.Register("engnoguard", func() provider.Provider { return mock })
+
+	file := makeFile(provider.ResourceID{Type: "engnoguard_role", Name: "keeper"})
+
+	e := &Engine{SecretResolver: stubSecretResolver{}}
+	plan, _, err := e.Plan(context.Background(), file, nil, PlanOptions{Prune: true})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	if len(plan.Guards) != 0 {
+		t.Errorf("expected no guards, got %d", len(plan.Guards))
+	}
+}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1128,3 +1128,62 @@ func TestEngine_plan_no_guards_when_provider_does_not_implement_DeleteGuarder(t 
 		t.Errorf("expected no guards, got %d", len(plan.Guards))
 	}
 }
+
+func TestEngine_Apply_refuses_when_guards_present(t *testing.T) {
+	liveOnly := provider.Resource{
+		ID: provider.ResourceID{Type: "engapplyguard_role", Name: "victim"},
+	}
+	mock := &guardingEngineProvider{
+		mockEngineProvider: mockEngineProvider{
+			discoverFn: func(context.Context) ([]provider.Resource, dcl.Diagnostics) {
+				return []provider.Resource{liveOnly}, nil
+			},
+		},
+		guards: []provider.DeleteGuard{
+			{Resource: liveOnly.ID, Reason: "would revoke caller access"},
+		},
+	}
+	provider.Register("engapplyguard", func() provider.Provider { return mock })
+
+	file := makeFile(provider.ResourceID{Type: "engapplyguard_role", Name: "keeper"})
+	e := &Engine{SecretResolver: stubSecretResolver{}}
+
+	_, err := e.Apply(context.Background(), file, nil, PlanOptions{Prune: true})
+	if err == nil {
+		t.Fatal("Apply should refuse when guards are present and AllowSelfLockout is false")
+	}
+	if !strings.Contains(err.Error(), "refusing to apply") {
+		t.Errorf("error should mention refusal, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "allow-self-lockout") {
+		t.Errorf("error should mention override flag, got: %v", err)
+	}
+}
+
+func TestEngine_Apply_proceeds_when_AllowSelfLockout_set(t *testing.T) {
+	liveOnly := provider.Resource{
+		ID: provider.ResourceID{Type: "engapplyallow_role", Name: "victim"},
+	}
+	mock := &guardingEngineProvider{
+		mockEngineProvider: mockEngineProvider{
+			discoverFn: func(context.Context) ([]provider.Resource, dcl.Diagnostics) {
+				return []provider.Resource{liveOnly}, nil
+			},
+		},
+		guards: []provider.DeleteGuard{
+			{Resource: liveOnly.ID, Reason: "would revoke caller access"},
+		},
+	}
+	provider.Register("engapplyallow", func() provider.Provider { return mock })
+
+	file := makeFile(provider.ResourceID{Type: "engapplyallow_role", Name: "keeper"})
+	e := &Engine{SecretResolver: stubSecretResolver{}}
+
+	result, err := e.Apply(context.Background(), file, nil, PlanOptions{Prune: true, AllowSelfLockout: true})
+	if err != nil {
+		t.Fatalf("Apply should proceed when AllowSelfLockout is true: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected ApplyResult")
+	}
+}

--- a/engine/plan.go
+++ b/engine/plan.go
@@ -44,10 +44,20 @@ type ResourceChange struct {
 // Changes are the actions that will execute (creates, updates, and — when
 // pruning is enabled — deletes). Unmanaged carries delete changes that were
 // discovered but suppressed because pruning is off; they are informational
-// only and never executed.
+// only and never executed. Guards carries provider-supplied annotations
+// on deletes that warrant a warning at plan time and an apply-time stop.
 type Plan struct {
 	Changes   []ResourceChange
 	Unmanaged []ResourceChange
+	Guards    []Guard
+}
+
+// Guard flags a specific planned delete as high-risk. The engine
+// surfaces guards to plan output and blocks apply unless the user
+// explicitly opts in via --allow-self-lockout (or equivalent).
+type Guard struct {
+	Resource provider.ResourceID
+	Reason   string
 }
 
 // PlanOptions tunes the planning pipeline. Zero value means additive-only:

--- a/engine/plan.go
+++ b/engine/plan.go
@@ -67,6 +67,10 @@ type PlanOptions struct {
 	// move to Plan.Unmanaged and are neither displayed per-resource nor
 	// executed.
 	Prune bool
+	// AllowSelfLockout permits Apply to execute even when Plan.Guards is
+	// non-empty. Without this, Apply refuses to run any of the planned
+	// operations when a guard is present.
+	AllowSelfLockout bool
 }
 
 // HasChanges reports whether the plan contains any non-no-op changes.

--- a/output/json.go
+++ b/output/json.go
@@ -12,11 +12,17 @@ import (
 type jsonPlan struct {
 	Changes   []jsonChange    `json:"changes"`
 	Unmanaged []jsonUnmanaged `json:"unmanaged,omitempty"`
+	Guards    []jsonGuard     `json:"guards,omitempty"`
 	Summary   string          `json:"summary"`
 }
 
 type jsonUnmanaged struct {
 	ID jsonResourceID `json:"id"`
+}
+
+type jsonGuard struct {
+	Resource jsonResourceID `json:"resource"`
+	Reason   string         `json:"reason"`
 }
 
 type jsonChange struct {
@@ -82,6 +88,13 @@ func FormatPlanJSON(plan *engine.Plan) ([]byte, error) {
 		jp.Unmanaged = make([]jsonUnmanaged, len(plan.Unmanaged))
 		for i, u := range plan.Unmanaged {
 			jp.Unmanaged[i] = jsonUnmanaged{ID: toJSONID(u.ID)}
+		}
+	}
+
+	if len(plan.Guards) > 0 {
+		jp.Guards = make([]jsonGuard, len(plan.Guards))
+		for i, g := range plan.Guards {
+			jp.Guards[i] = jsonGuard{Resource: toJSONID(g.Resource), Reason: g.Reason}
 		}
 	}
 

--- a/output/json_test.go
+++ b/output/json_test.go
@@ -199,3 +199,37 @@ func TestFormatApplyResultJSON_summary(t *testing.T) {
 		t.Errorf("unexpected summary: %q", got.Summary)
 	}
 }
+
+func TestFormatPlanJSON_includes_guards(t *testing.T) {
+	plan := &engine.Plan{
+		Changes: []engine.ResourceChange{{
+			ID:   provider.ResourceID{Type: "opensearch_role_mapping", Name: "all_access"},
+			Type: engine.ChangeDelete,
+			Live: &provider.Resource{ID: provider.ResourceID{Type: "opensearch_role_mapping", Name: "all_access"}},
+		}},
+		Guards: []engine.Guard{{
+			Resource: provider.ResourceID{Type: "opensearch_role_mapping", Name: "all_access"},
+			Reason:   "would lock out caller",
+		}},
+	}
+
+	data, err := FormatPlanJSON(plan)
+	if err != nil {
+		t.Fatalf("FormatPlanJSON: %v", err)
+	}
+
+	var got jsonPlan
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(got.Guards) != 1 {
+		t.Fatalf("got %d guards, want 1", len(got.Guards))
+	}
+	if got.Guards[0].Resource.Name != "all_access" {
+		t.Errorf("guards[0].Resource.Name = %q", got.Guards[0].Resource.Name)
+	}
+	if got.Guards[0].Reason != "would lock out caller" {
+		t.Errorf("guards[0].Reason = %q", got.Guards[0].Reason)
+	}
+}

--- a/output/plan.go
+++ b/output/plan.go
@@ -5,12 +5,14 @@ import (
 	"strings"
 
 	"github.com/MathewBravo/datastorectl/engine"
+	"github.com/MathewBravo/datastorectl/provider"
 )
 
 // FormatPlan renders a plan as human-readable Terraform-style text.
 // When color is true, ANSI codes highlight creates (green), updates (yellow),
 // and deletes (red). No-op changes are omitted.
 func FormatPlan(plan *engine.Plan, color bool) string {
+	guards := guardMap(plan.Guards)
 	var blocks []string
 	for _, c := range plan.Changes {
 		switch c.Type {
@@ -19,7 +21,7 @@ func FormatPlan(plan *engine.Plan, color bool) string {
 		case engine.ChangeUpdate:
 			blocks = append(blocks, formatUpdate(c, color))
 		case engine.ChangeDelete:
-			blocks = append(blocks, formatDelete(c, color))
+			blocks = append(blocks, formatDelete(c, guards[c.ID], color))
 		}
 	}
 	if len(blocks) == 0 && len(plan.Unmanaged) == 0 {
@@ -31,6 +33,16 @@ func FormatPlan(plan *engine.Plan, color bool) string {
 		return summary + "\n"
 	}
 	return strings.Join(blocks, "\n\n") + "\n\n" + summary + "\n"
+}
+
+// guardMap indexes guards by their resource ID for O(1) lookup during
+// delete-line rendering.
+func guardMap(gs []engine.Guard) map[provider.ResourceID]engine.Guard {
+	out := make(map[provider.ResourceID]engine.Guard, len(gs))
+	for _, g := range gs {
+		out[g.Resource] = g
+	}
+	return out
 }
 
 func formatCreate(c engine.ResourceChange, color bool) string {
@@ -58,9 +70,16 @@ func formatUpdate(c engine.ResourceChange, color bool) string {
 	return b.String()
 }
 
-func formatDelete(c engine.ResourceChange, color bool) string {
+func formatDelete(c engine.ResourceChange, guard engine.Guard, color bool) string {
 	header := fmt.Sprintf("- %s (delete)", c.ID)
-	return red(header, color)
+	if guard.Reason != "" {
+		header += "  (would lock out caller)"
+	}
+	out := red(header, color)
+	if guard.Reason != "" {
+		out += "\n    ! " + guard.Reason
+	}
+	return out
 }
 
 func formatDiffValue(d engine.ValueDiff, color bool) string {

--- a/output/plan_test.go
+++ b/output/plan_test.go
@@ -172,3 +172,61 @@ func TestShouldColor_no_color_env(t *testing.T) {
 		t.Error("expected false when NO_COLOR is set")
 	}
 }
+
+func TestFormatPlan_marks_guarded_deletes(t *testing.T) {
+	plan := &engine.Plan{
+		Changes: []engine.ResourceChange{{
+			ID:   rid("opensearch_role_mapping", "all_access"),
+			Type: engine.ChangeDelete,
+			Live: &provider.Resource{ID: rid("opensearch_role_mapping", "all_access")},
+		}},
+		Guards: []engine.Guard{{
+			Resource: rid("opensearch_role_mapping", "all_access"),
+			Reason:   `would revoke caller "admin" access`,
+		}},
+	}
+
+	out := FormatPlan(plan, false)
+	if !strings.Contains(out, "(would lock out caller)") {
+		t.Errorf("output missing lockout marker: %s", out)
+	}
+	if !strings.Contains(out, `would revoke caller "admin" access`) {
+		t.Errorf("output missing guard reason: %s", out)
+	}
+}
+
+func TestFormatPlan_unguarded_delete_has_no_marker(t *testing.T) {
+	plan := &engine.Plan{
+		Changes: []engine.ResourceChange{{
+			ID:   rid("svc", "deleteme"),
+			Type: engine.ChangeDelete,
+			Live: &provider.Resource{ID: rid("svc", "deleteme")},
+		}},
+	}
+
+	out := FormatPlan(plan, false)
+	if strings.Contains(out, "(would lock out caller)") {
+		t.Errorf("unguarded delete should not have lockout marker: %s", out)
+	}
+}
+
+func TestFormatPlanVerbose_marks_guarded_deletes(t *testing.T) {
+	plan := &engine.Plan{
+		Changes: []engine.ResourceChange{{
+			ID:   rid("opensearch_internal_user", "admin"),
+			Type: engine.ChangeDelete,
+			Live: &provider.Resource{ID: rid("opensearch_internal_user", "admin"), Body: provider.NewOrderedMap()},
+		}},
+		Guards: []engine.Guard{{
+			Resource: rid("opensearch_internal_user", "admin"),
+			Reason:   "would delete caller's own account",
+		}},
+	}
+	out := FormatPlanVerbose(plan, false)
+	if !strings.Contains(out, "(would lock out caller)") {
+		t.Errorf("verbose output missing lockout marker: %s", out)
+	}
+	if !strings.Contains(out, "would delete caller's own account") {
+		t.Errorf("verbose output missing guard reason: %s", out)
+	}
+}

--- a/output/verbose.go
+++ b/output/verbose.go
@@ -12,6 +12,7 @@ import (
 // Creates show the full desired body. Updates show diffs, desired, and live bodies.
 // Deletes show the full live body.
 func FormatPlanVerbose(plan *engine.Plan, color bool) string {
+	guards := guardMap(plan.Guards)
 	var blocks []string
 	for _, c := range plan.Changes {
 		switch c.Type {
@@ -20,7 +21,7 @@ func FormatPlanVerbose(plan *engine.Plan, color bool) string {
 		case engine.ChangeUpdate:
 			blocks = append(blocks, formatVerboseUpdate(c, color))
 		case engine.ChangeDelete:
-			blocks = append(blocks, formatVerboseDelete(c, color))
+			blocks = append(blocks, formatVerboseDelete(c, guards[c.ID], color))
 		}
 	}
 	if len(blocks) == 0 && len(plan.Unmanaged) == 0 {
@@ -62,10 +63,17 @@ func formatVerboseUpdate(c engine.ResourceChange, color bool) string {
 	return b.String()
 }
 
-func formatVerboseDelete(c engine.ResourceChange, color bool) string {
+func formatVerboseDelete(c engine.ResourceChange, guard engine.Guard, color bool) string {
 	var b strings.Builder
 	header := fmt.Sprintf("- %s (delete)", c.ID)
+	if guard.Reason != "" {
+		header += "  (would lock out caller)"
+	}
 	b.WriteString(red(header, color))
+
+	if guard.Reason != "" {
+		b.WriteString("\n    ! " + guard.Reason)
+	}
 
 	if c.Live != nil && c.Live.Body != nil {
 		writeBody(&b, c.Live.Body, color, ansiRed)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -48,6 +48,23 @@ type TypeOrdering struct {
 	After  string
 }
 
+// DeleteGuard is a provider-supplied annotation on a planned delete
+// that warrants a warning at plan time and a hard-stop at apply time.
+// The engine surfaces guards to the user; it does not interpret Reason.
+type DeleteGuard struct {
+	Resource ResourceID
+	Reason   string
+}
+
+// DeleteGuarder is an optional interface a Provider may implement to
+// flag planned deletes that are risky enough that the engine should
+// warn (at plan time) or refuse to execute (at apply time without
+// explicit opt-in). The engine calls GuardDeletes once per provider
+// after the plan is built.
+type DeleteGuarder interface {
+	GuardDeletes(ctx context.Context, deletes []Resource) ([]DeleteGuard, dcl.Diagnostics)
+}
+
 // TypeOrderer is an optional interface a Provider may implement to
 // declare default type-level orderings. The engine collects these
 // during provider configuration and feeds them into the dependency graph.

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -1,8 +1,11 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
+
+	"github.com/MathewBravo/datastorectl/dcl"
 )
 
 // Compile-time check that Operation implements fmt.Stringer.
@@ -49,6 +52,25 @@ func TestTypeOrdererOptional(t *testing.T) {
 	var plain Provider = stubProvider{}
 	if _, ok := plain.(TypeOrderer); ok {
 		t.Error("stubProvider should not satisfy TypeOrderer")
+	}
+}
+
+type stubGuarder struct{ stubProvider }
+
+func (stubGuarder) GuardDeletes(context.Context, []Resource) ([]DeleteGuard, dcl.Diagnostics) {
+	return nil, nil
+}
+
+var _ DeleteGuarder = stubGuarder{}
+
+func TestDeleteGuarderOptional(t *testing.T) {
+	var p Provider = stubGuarder{}
+	if _, ok := p.(DeleteGuarder); !ok {
+		t.Fatal("expected stubGuarder to satisfy DeleteGuarder")
+	}
+	var plain Provider = stubProvider{}
+	if _, ok := plain.(DeleteGuarder); ok {
+		t.Error("stubProvider should not satisfy DeleteGuarder")
 	}
 }
 

--- a/providers/opensearch/account.go
+++ b/providers/opensearch/account.go
@@ -1,0 +1,48 @@
+package opensearch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// callerIdentity captures the authenticated principal on the OpenSearch
+// cluster, as reported by /_plugins/_security/api/account. Used to
+// classify role_mapping and internal_user deletes that would lock out
+// the caller.
+type callerIdentity struct {
+	UserName     string
+	BackendRoles []string
+}
+
+// fetchCallerIdentity queries /_plugins/_security/api/account and returns
+// the authenticated user's name and backend roles. Called once during
+// provider Configure.
+func fetchCallerIdentity(ctx context.Context, client *Client) (callerIdentity, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/_plugins/_security/api/account", nil)
+	if err != nil {
+		return callerIdentity{}, fmt.Errorf("opensearch: caller identity: %s", err)
+	}
+
+	body, status, err := client.do(req)
+	if err != nil {
+		return callerIdentity{}, fmt.Errorf("opensearch: caller identity: %s", err)
+	}
+	if status < 200 || status >= 300 {
+		return callerIdentity{}, fmt.Errorf("opensearch: caller identity failed (%d): %s", status, body)
+	}
+
+	var raw struct {
+		UserName     string   `json:"user_name"`
+		BackendRoles []string `json:"backend_roles"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return callerIdentity{}, fmt.Errorf("opensearch: caller identity: decode: %s", err)
+	}
+
+	return callerIdentity{
+		UserName:     raw.UserName,
+		BackendRoles: raw.BackendRoles,
+	}, nil
+}

--- a/providers/opensearch/account_test.go
+++ b/providers/opensearch/account_test.go
@@ -1,0 +1,58 @@
+package opensearch
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetchCallerIdentity_parses_response(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_plugins/_security/api/account" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"user_name": "admin",
+			"backend_roles": ["admin", "ops"],
+			"roles": ["all_access", "own_index"]
+		}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(srv.URL, "u", "p", false)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	id, err := fetchCallerIdentity(context.Background(), client)
+	if err != nil {
+		t.Fatalf("fetchCallerIdentity: %v", err)
+	}
+	if id.UserName != "admin" {
+		t.Errorf("UserName = %q, want admin", id.UserName)
+	}
+	if len(id.BackendRoles) != 2 || id.BackendRoles[0] != "admin" || id.BackendRoles[1] != "ops" {
+		t.Errorf("BackendRoles = %v, want [admin ops]", id.BackendRoles)
+	}
+}
+
+func TestFetchCallerIdentity_error_on_non_2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	client, _ := NewClient(srv.URL, "u", "p", false)
+
+	_, err := fetchCallerIdentity(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected error on 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error should mention status code: %v", err)
+	}
+}

--- a/providers/opensearch/internal_user.go
+++ b/providers/opensearch/internal_user.go
@@ -203,3 +203,9 @@ func (h *internalUserHandler) Apply(ctx context.Context, client *Client, op prov
 		return fmt.Errorf("opensearch_internal_user.%s: unsupported operation %s", r.ID.Name, op)
 	}
 }
+
+// classifyInternalUserLockout reports whether deleting the given
+// internal user would delete the caller's own account.
+func classifyInternalUserLockout(r provider.Resource, caller callerIdentity) bool {
+	return caller.UserName != "" && r.ID.Name == caller.UserName
+}

--- a/providers/opensearch/internal_user_test.go
+++ b/providers/opensearch/internal_user_test.go
@@ -384,3 +384,29 @@ func TestInternalUserHandler_Integration(t *testing.T) {
 		}
 	})
 }
+
+func TestInternalUserClassifyLockout(t *testing.T) {
+	caller := callerIdentity{UserName: "admin", BackendRoles: []string{"admin"}}
+
+	tests := []struct {
+		name    string
+		resName string
+		want    bool
+	}{
+		{"caller_self_delete", "admin", true},
+		{"other_user_delete", "kibanaro", false},
+		{"empty_name", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := provider.Resource{
+				ID: provider.ResourceID{Type: "opensearch_internal_user", Name: tc.resName},
+			}
+			got := classifyInternalUserLockout(r, caller)
+			if got != tc.want {
+				t.Errorf("classifyInternalUserLockout = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/providers/opensearch/provider.go
+++ b/providers/opensearch/provider.go
@@ -29,6 +29,7 @@ func init() {
 // Provider implements provider.Provider for OpenSearch clusters.
 type Provider struct {
 	client   *Client
+	caller   callerIdentity
 	handlers map[string]resourceHandler
 }
 
@@ -65,7 +66,7 @@ func (p *Provider) Configure(ctx context.Context, config *provider.OrderedMap) d
 
 	switch auth {
 	case "basic":
-		return p.configureBasicAuth(endpoint, config)
+		return p.configureBasicAuth(ctx, endpoint, config)
 	case "sigv4":
 		return p.configureSigV4(ctx, endpoint, config)
 	default:
@@ -86,7 +87,7 @@ func tlsSkipVerify(config *provider.OrderedMap) bool {
 }
 
 // configureBasicAuth validates username/password and creates a basic-auth client.
-func (p *Provider) configureBasicAuth(endpoint string, config *provider.OrderedMap) dcl.Diagnostics {
+func (p *Provider) configureBasicAuth(ctx context.Context, endpoint string, config *provider.OrderedMap) dcl.Diagnostics {
 	usernameVal, ok := config.Get("username")
 	if !ok || usernameVal.Kind != provider.KindString || usernameVal.Str == "" {
 		return dcl.Diagnostics{{
@@ -113,7 +114,7 @@ func (p *Provider) configureBasicAuth(endpoint string, config *provider.OrderedM
 		}}
 	}
 	p.client = client
-	return nil
+	return p.fetchAndCacheCallerIdentity(ctx)
 }
 
 // configureSigV4 validates the region field and creates a SigV4-signing client.
@@ -135,6 +136,22 @@ func (p *Provider) configureSigV4(ctx context.Context, endpoint string, config *
 		}}
 	}
 	p.client = client
+	return p.fetchAndCacheCallerIdentity(ctx)
+}
+
+// fetchAndCacheCallerIdentity hits /_plugins/_security/api/account and
+// caches the caller's user_name and backend_roles for self-lockout
+// protection. Called at the end of both auth paths.
+func (p *Provider) fetchAndCacheCallerIdentity(ctx context.Context) dcl.Diagnostics {
+	id, err := fetchCallerIdentity(ctx, p.client)
+	if err != nil {
+		return dcl.Diagnostics{{
+			Severity:   dcl.SeverityError,
+			Message:    fmt.Sprintf("opensearch: unable to fetch caller identity for self-lockout protection: %s", err),
+			Suggestion: "verify the credentials have access to /_plugins/_security/api/account",
+		}}
+	}
+	p.caller = id
 	return nil
 }
 
@@ -209,6 +226,33 @@ func (p *Provider) Schemas() map[string]provider.Schema {
 		}
 	}
 	return schemas
+}
+
+// GuardDeletes implements provider.DeleteGuarder. It flags any delete
+// that would lock out the authenticated caller — either a role_mapping
+// whose users/backend_roles cover the caller, or the caller's own
+// internal_user account.
+func (p *Provider) GuardDeletes(_ context.Context, deletes []provider.Resource) ([]provider.DeleteGuard, dcl.Diagnostics) {
+	var guards []provider.DeleteGuard
+	for _, r := range deletes {
+		switch r.ID.Type {
+		case "opensearch_role_mapping":
+			if classifyRoleMappingLockout(r, p.caller) {
+				guards = append(guards, provider.DeleteGuard{
+					Resource: r.ID,
+					Reason:   fmt.Sprintf("would revoke caller %q access (mapping grants privileges the caller currently uses)", p.caller.UserName),
+				})
+			}
+		case "opensearch_internal_user":
+			if classifyInternalUserLockout(r, p.caller) {
+				guards = append(guards, provider.DeleteGuard{
+					Resource: r.ID,
+					Reason:   fmt.Sprintf("would delete caller %q's own user account", p.caller.UserName),
+				})
+			}
+		}
+	}
+	return guards, nil
 }
 
 // TypeOrderings declares the default resource type ordering for the opensearch provider.

--- a/providers/opensearch/provider_test.go
+++ b/providers/opensearch/provider_test.go
@@ -2,11 +2,29 @@ package opensearch
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/MathewBravo/datastorectl/provider"
 )
+
+// newAccountAwareServer returns an httptest server whose
+// /_plugins/_security/api/account endpoint returns a stub identity.
+// Other paths return 404. Used by Configure success tests that need
+// the post-client caller-identity fetch to succeed.
+func newAccountAwareServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_plugins/_security/api/account" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"user_name":"test","backend_roles":[]}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
 
 // helper builds an *OrderedMap from key-value string pairs.
 func configMap(kvs ...string) *provider.OrderedMap {
@@ -78,11 +96,6 @@ func TestConfigure(t *testing.T) {
 			errSubstr: "region",
 		},
 		{
-			name:    "sigv4_success",
-			config:  configMap("endpoint", "https://search.us-east-1.es.amazonaws.com", "auth", "sigv4", "region", "us-east-1"),
-			wantErr: false,
-		},
-		{
 			name:      "basic_missing_username",
 			config:    configMap("endpoint", "https://localhost:9200", "auth", "basic", "password", "secret"),
 			wantErr:   true,
@@ -93,16 +106,6 @@ func TestConfigure(t *testing.T) {
 			config:    configMap("endpoint", "https://localhost:9200", "auth", "basic", "username", "admin"),
 			wantErr:   true,
 			errSubstr: "password",
-		},
-		{
-			name:    "basic_auth_success",
-			config:  configMap("endpoint", "https://localhost:9200", "auth", "basic", "username", "admin", "password", "secret"),
-			wantErr: false,
-		},
-		{
-			name:    "basic_auth_with_tls_skip_verify",
-			config:  configMapWithBool("endpoint", "https://localhost:9200", "auth", "basic", "username", "admin", "password", "secret", "tls_skip_verify", true),
-			wantErr: false,
 		},
 	}
 
@@ -127,6 +130,109 @@ func TestConfigure(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestConfigure_basic_auth_success(t *testing.T) {
+	srv := newAccountAwareServer(t)
+	defer srv.Close()
+
+	p := &Provider{handlers: map[string]resourceHandler{}}
+	cfg := configMap("endpoint", srv.URL, "auth", "basic", "username", "admin", "password", "secret")
+
+	diags := p.Configure(context.Background(), cfg)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %s", diags.Error())
+	}
+	if p.client == nil {
+		t.Fatal("expected client to be set after successful Configure")
+	}
+	if p.caller.UserName != "test" {
+		t.Errorf("caller.UserName = %q, want test", p.caller.UserName)
+	}
+}
+
+func TestConfigure_basic_auth_with_tls_skip_verify(t *testing.T) {
+	srv := newAccountAwareServer(t)
+	defer srv.Close()
+
+	p := &Provider{handlers: map[string]resourceHandler{}}
+	cfg := configMapWithBool("endpoint", srv.URL, "auth", "basic", "username", "admin", "password", "secret", "tls_skip_verify", true)
+
+	diags := p.Configure(context.Background(), cfg)
+	if diags.HasErrors() {
+		t.Fatalf("unexpected error: %s", diags.Error())
+	}
+	if p.client == nil {
+		t.Fatal("expected client to be set after successful Configure")
+	}
+}
+
+func TestConfigure_basic_auth_identity_fetch_failure_errors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := &Provider{handlers: map[string]resourceHandler{}}
+	cfg := configMap("endpoint", srv.URL, "auth", "basic", "username", "admin", "password", "secret")
+
+	diags := p.Configure(context.Background(), cfg)
+	if !diags.HasErrors() {
+		t.Fatal("Configure should error when /api/account returns 500")
+	}
+	if !strings.Contains(diags.Error(), "caller identity") {
+		t.Errorf("error should mention caller identity, got: %s", diags.Error())
+	}
+}
+
+func TestProvider_GuardDeletes_flags_role_mapping_and_internal_user(t *testing.T) {
+	p := &Provider{
+		handlers: map[string]resourceHandler{
+			"opensearch_role_mapping":  &roleMappingHandler{},
+			"opensearch_internal_user": &internalUserHandler{},
+		},
+		caller: callerIdentity{UserName: "admin", BackendRoles: []string{"admin"}},
+	}
+
+	deletes := []provider.Resource{
+		{
+			ID: provider.ResourceID{Type: "opensearch_role_mapping", Name: "all_access"},
+			Body: buildMap(
+				"backend_roles", provider.ListVal([]provider.Value{provider.StringVal("admin")}),
+			),
+		},
+		{
+			ID: provider.ResourceID{Type: "opensearch_role_mapping", Name: "readall"},
+			Body: buildMap(
+				"backend_roles", provider.ListVal([]provider.Value{provider.StringVal("readall")}),
+			),
+		},
+		{ID: provider.ResourceID{Type: "opensearch_internal_user", Name: "admin"}},
+		{ID: provider.ResourceID{Type: "opensearch_internal_user", Name: "kibanaro"}},
+		{ID: provider.ResourceID{Type: "opensearch_ism_policy", Name: "hot_delete"}},
+	}
+
+	guards, diags := p.GuardDeletes(context.Background(), deletes)
+	if diags.HasErrors() {
+		t.Fatalf("GuardDeletes: %s", diags.Error())
+	}
+
+	want := map[string]bool{
+		"opensearch_role_mapping.all_access": true,
+		"opensearch_internal_user.admin":     true,
+	}
+	if len(guards) != len(want) {
+		t.Fatalf("got %d guards, want %d: %+v", len(guards), len(want), guards)
+	}
+	for _, g := range guards {
+		key := g.Resource.String()
+		if !want[key] {
+			t.Errorf("unexpected guard on %s", key)
+		}
+		if g.Reason == "" {
+			t.Errorf("guard on %s has empty reason", key)
+		}
 	}
 }
 

--- a/providers/opensearch/role_mapping.go
+++ b/providers/opensearch/role_mapping.go
@@ -194,3 +194,36 @@ func (h *roleMappingHandler) Apply(ctx context.Context, client *Client, op provi
 		return fmt.Errorf("opensearch_role_mapping.%s: unsupported operation %s", r.ID.Name, op)
 	}
 }
+
+// classifyRoleMappingLockout reports whether deleting the given role
+// mapping would revoke access for the caller. It is a lockout delete if:
+//   - the mapping's users list contains the caller's user_name, OR
+//   - the mapping's users list contains "*" (matches every user), OR
+//   - the mapping's backend_roles intersects the caller's backend_roles.
+func classifyRoleMappingLockout(r provider.Resource, caller callerIdentity) bool {
+	if users, ok := r.Body.Get("users"); ok && users.Kind == provider.KindList {
+		for _, v := range users.List {
+			if v.Kind != provider.KindString {
+				continue
+			}
+			if v.Str == "*" || v.Str == caller.UserName {
+				return true
+			}
+		}
+	}
+	if backendRoles, ok := r.Body.Get("backend_roles"); ok && backendRoles.Kind == provider.KindList {
+		callerSet := make(map[string]struct{}, len(caller.BackendRoles))
+		for _, br := range caller.BackendRoles {
+			callerSet[br] = struct{}{}
+		}
+		for _, v := range backendRoles.List {
+			if v.Kind != provider.KindString {
+				continue
+			}
+			if _, hit := callerSet[v.Str]; hit {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/providers/opensearch/role_mapping_test.go
+++ b/providers/opensearch/role_mapping_test.go
@@ -355,3 +355,61 @@ func TestRoleMappingHandler_Integration(t *testing.T) {
 		}
 	})
 }
+
+func TestRoleMappingClassifyLockout(t *testing.T) {
+	caller := callerIdentity{UserName: "admin", BackendRoles: []string{"admin", "ops"}}
+
+	tests := []struct {
+		name string
+		body *provider.OrderedMap
+		want bool
+	}{
+		{
+			name: "backend_roles_intersection",
+			body: buildMap(
+				"backend_roles", provider.ListVal([]provider.Value{provider.StringVal("admin")}),
+			),
+			want: true,
+		},
+		{
+			name: "users_contains_caller",
+			body: buildMap(
+				"users", provider.ListVal([]provider.Value{provider.StringVal("admin")}),
+			),
+			want: true,
+		},
+		{
+			name: "users_wildcard",
+			body: buildMap(
+				"users", provider.ListVal([]provider.Value{provider.StringVal("*")}),
+			),
+			want: true,
+		},
+		{
+			name: "no_overlap",
+			body: buildMap(
+				"backend_roles", provider.ListVal([]provider.Value{provider.StringVal("readall")}),
+				"users", provider.ListVal([]provider.Value{provider.StringVal("someone_else")}),
+			),
+			want: false,
+		},
+		{
+			name: "empty_body",
+			body: buildMap(),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := provider.Resource{
+				ID:   provider.ResourceID{Type: "opensearch_role_mapping", Name: "test"},
+				Body: tc.body,
+			}
+			got := classifyRoleMappingLockout(r, caller)
+			if got != tc.want {
+				t.Errorf("classifyRoleMappingLockout = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/testdata/showcase/resources.dcl
+++ b/testdata/showcase/resources.dcl
@@ -26,6 +26,44 @@ opensearch_role_mapping "log_reader" {
   description   = "Map IAM role to log_reader"
 }
 
+# Bootstrap role mappings shipped by OpenSearch's security plugin.
+# Declared verbatim so prune sees them as no-ops instead of deletes.
+# Without these declarations, apply would delete all_access (locking
+# out admin) and the five other bootstrap mappings.
+
+opensearch_role_mapping "all_access" {
+  context       = demo
+  backend_roles = ["admin"]
+  description   = "Maps admin to all_access"
+}
+
+opensearch_role_mapping "readall" {
+  context       = demo
+  backend_roles = ["readall"]
+}
+
+opensearch_role_mapping "own_index" {
+  context     = demo
+  users       = ["*"]
+  description = "Allow full access to an index named like the username"
+}
+
+opensearch_role_mapping "logstash" {
+  context       = demo
+  backend_roles = ["logstash"]
+}
+
+opensearch_role_mapping "kibana_user" {
+  context       = demo
+  backend_roles = ["kibanauser"]
+  description   = "Maps kibanauser to kibana_user"
+}
+
+opensearch_role_mapping "manage_snapshots" {
+  context       = demo
+  backend_roles = ["snapshotrestore"]
+}
+
 opensearch_ism_policy "hot_delete" {
   context = demo
 


### PR DESCRIPTION
## Summary
- **Showcase:** declare the six OpenSearch bootstrap role mappings (`all_access`, `readall`, `own_index`, `logstash`, `kibana_user`, `manage_snapshots`) in `testdata/showcase/resources.dcl`. Prune now sees them as no-ops instead of queueing deletes that would lock out admin.
- **Provider:** add `provider.DeleteGuarder` optional interface. The OpenSearch provider fetches caller identity at Configure time via `/_plugins/_security/api/account` and implements `GuardDeletes` to flag `opensearch_role_mapping` and `opensearch_internal_user` deletes that would revoke the authenticated caller's own access.
- **Output:** plan text, verbose, and JSON renderers include a `(would lock out caller)` marker plus the provider-supplied reason on guarded deletes.
- **CLI:** `apply` refuses to execute when guards are present unless `--allow-self-lockout` is passed.

## Investigation notes
The issue proposed filtering `reserved: true` role mappings at discovery time. That filter already exists (`providers/opensearch/role_mapping.go:44`) — it doesn't fire here because OpenSearch returns the bootstrap mappings as `reserved: false` (they're user-editable by design). The same asymmetry exists for `opensearch_internal_user`, so self-lockout protection covers both.

Classifier rule for `opensearch_role_mapping` delete: mapping is a lockout if its `users` contains the caller's `user_name`, contains `"*"`, or its `backend_roles` intersects the caller's `backend_roles`.

## Test plan
- [x] `go test ./...` passes
- [x] `./showcase.sh up && ./datastorectl apply testdata/showcase/resources.dcl` creates 3 resources, marks 6 bootstrap mappings as no-ops, 0 deletes
- [x] Second `./datastorectl plan testdata/showcase/resources.dcl` reports `No changes.`
- [x] Removing `all_access` from the DCL surfaces `- opensearch_role_mapping.all_access (delete)  (would lock out caller)` in plan output
- [x] `apply --prune` without the flag exits non-zero with a refusal message listing the guarded resource and pointing to `--allow-self-lockout`

Closes #155