### PR TITLE
docs: refresh README for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,113 +1,181 @@
 # datastorectl
 
-Declarative configuration for running datastores.
+Declarative configuration for day-2 datastore operations. Terraform-style workflow for the stuff Terraform doesn't manage: ISM policies, security roles, role mappings, index templates, ingest pipelines, cluster settings.
 
-> **Work in progress.** datastorectl is under active development and not usable yet. The first release (v0.1.0) will target OpenSearch. See the scope and roadmap below.
+> **Status:** v0.1.0 release candidate. The core framework and the OpenSearch provider are feature-complete and tested. Release plumbing (goreleaser, Homebrew tap) is the next milestone.
 
-## The Problem
+## The problem
 
-Terraform and CloudFormation provision clusters. They don't manage what's inside them: ACL users, index lifecycle policies, eviction strategies, retention rules, role mappings. That config lives in ad-hoc scripts, manual CLI sessions, or brittle Ansible playbooks. When someone changes a security role through the OpenSearch dashboard at 2am, nobody finds out until something breaks.
+Terraform and CloudFormation provision clusters. They don't manage what's inside them. ACL users, lifecycle policies, retention rules, role mappings live in ad-hoc scripts, manual CLI sessions, or brittle Ansible playbooks. When someone edits a security role through the OpenSearch dashboard at 2am, nobody finds out until something breaks.
 
-datastorectl manages post-provisioning datastore configuration declaratively, the same way Terraform manages infrastructure.
+datastorectl manages that layer the same way Terraform manages infrastructure: you declare what you want in code, the tool reads the live cluster, shows you the diff, and applies the changes.
 
-## How It Works
+## A taste of DCL
 
-Write config in DCL (Datastore Configuration Language), an HCL-inspired language purpose-built for datastore resources:
+DCL (Datastore Configuration Language) is HCL-inspired, purpose-built for datastore resources. Connection contexts and resources use the same syntax.
 
 ```hcl
-context "prod-opensearch" {
-  provider = opensearch
-  endpoint = "https://search-prod.us-east-1.es.amazonaws.com"
-  auth     = aws_sigv4("us-east-1")
-}
-
-opensearch_ism_policy "hot_warm_delete" {
-  context = prod-opensearch
-
-  description = "Move to warm after 7d, delete after 90d"
-
-  state "hot" {
-    actions = []
-    transition {
-      state    = warm
-      condition = min_index_age("7d")
-    }
-  }
-
-  state "warm" {
-    actions = [
-      { warm_migration = {} }
-    ]
-    transition {
-      state    = delete
-      condition = min_index_age("90d")
-    }
-  }
-
-  state "delete" {
-    actions = [
-      { delete = {} }
-    ]
-  }
+context "demo" {
+  provider        = opensearch
+  endpoint        = "https://localhost:9200"
+  auth            = "basic"
+  username        = "admin"
+  password        = secret("env", "OPENSEARCH_PASSWORD")
+  tls_skip_verify = true
 }
 
 opensearch_role "log_reader" {
-  context = prod-opensearch
+  context = demo
 
-  cluster_permissions = ["cluster_composite_ops_ro"]
+  cluster_permissions = ["cluster_monitor"]
 
-  index_permissions {
-    index_patterns  = ["logs-*"]
-    allowed_actions = ["read"]
-  }
+  index_permissions = [
+    {
+      index_patterns  = ["logs-*"]
+      allowed_actions = ["read", "search"]
+    }
+  ]
 }
 
-opensearch_role_mapping "log_reader_mapping" {
-  context = prod-opensearch
+opensearch_ism_policy "hot_delete" {
+  context       = demo
+  default_state = "hot"
+  description   = "Delete indices after 30 days"
 
-  role           = opensearch_role.log_reader
-  backend_roles  = ["arn:aws:iam::123456789:role/log-reader"]
+  states = [
+    {
+      name    = "hot"
+      actions = []
+      transitions = [
+        { state_name = "delete", conditions = { min_index_age = "30d" } }
+      ]
+    },
+    {
+      name    = "delete"
+      actions = [{ delete = {} }]
+      transitions = []
+    }
+  ]
 }
 ```
 
-Then run three commands:
+## The three commands
 
-- `datastorectl validate`: parse and type-check DCL offline. No network calls.
-- `datastorectl plan`: connect to the cluster, read live state, diff against declared state, show what would change.
-- `datastorectl apply`: execute the changes. Supports `--dry-run`.
+```
+datastorectl validate [path]   # parse and type-check offline; no network calls
+datastorectl plan [path]       # read live state, compute diff, print it
+datastorectl apply [path]      # execute the diff
+```
 
-Plan output uses Terraform's conventions: `+` green for additions, `~` yellow for modifications, `-` red for deletions. Diffs are attribute-level by default.
+`path` is a file or a directory. Directories are scanned recursively for `.dcl` files.
+
+Plan output uses Terraform's conventions: `+` green for additions, `~` yellow for modifications, `-` red for deletions. Diffs are attribute-level by default. Use `--verbose` for full before/after, or `--output json` for structured output.
+
+### Additive by default, opt-in deletes
+
+`plan` and `apply` only create and update by default. Deletions are filtered out unless you pass `--prune`. This is a deliberate safety rail: a new user pointing at a shared cluster won't accidentally remove resources they didn't declare.
+
+```
+datastorectl plan              # shows creates and updates; deletes listed as "unmanaged"
+datastorectl plan --prune      # include deletes
+datastorectl apply --prune     # actually delete the unmanaged resources
+```
+
+### Self-lockout protection
+
+Some deletes would revoke the caller's own access. The OpenSearch provider detects when a `--prune` pass would delete the role mapping or internal user that owns the current credentials, and refuses. Override with `--allow-self-lockout` if you know what you're doing.
+
+## Quickstart
+
+Local OpenSearch via Docker Compose:
+
+```
+./showcase.sh up                                                # start cluster + build binary
+./datastorectl validate testdata/showcase/resources.dcl
+./datastorectl plan     testdata/showcase/resources.dcl
+./datastorectl apply    testdata/showcase/resources.dcl
+./datastorectl plan     testdata/showcase/resources.dcl         # should report no changes
+./showcase.sh down
+```
+
+Build from source:
+
+```
+go build -o datastorectl ./cmd/datastorectl
+```
 
 ## Stateless
 
-No state file. datastorectl reads live state from the cluster on every run and computes diffs directly. No lock contention, no state corruption, no drift between a state file and reality.
+No state file. datastorectl reads live state from the cluster on every run and computes diffs directly. No lock contention, no state corruption.
 
-This works because datastore configurations are identifiable by name (an ISM policy, a security role, an ACL user) and queryable through APIs. There's no equivalent of a randomly-assigned EC2 instance ID that forces you to track state externally.
+This works because datastore configurations are identifiable by name. ISM policies, security roles, internal users — each has a stable name that's queryable through the API. There's no equivalent of a randomly-assigned EC2 instance ID that forces you to track state externally.
 
-## v0.1.0 Scope
+## Configuration
+
+Connection contexts live separately from resource declarations. Put them in `~/.datastorectl/config.dcl`:
+
+```hcl
+context "prod" {
+  provider = opensearch
+  endpoint = "https://search-prod.us-east-1.es.amazonaws.com"
+  auth     = "aws_sigv4"
+  region   = "us-east-1"
+}
+
+context "staging" {
+  provider = opensearch
+  endpoint = "https://staging:9200"
+  auth     = "basic"
+  username = "admin"
+  password = secret("env", "STAGING_PASSWORD")
+}
+```
+
+Resource files reference a context by name (`context = prod`). The context config stays local; resource files are safe to commit. Secrets resolve at runtime via `secret("env", "VAR_NAME")` so credentials never sit in files.
+
+When a directory contains resources targeting multiple contexts, pass `--context <name>` to pick one. Safety rail: without the flag, datastorectl refuses to run.
+
+## v0.1.0 scope
 
 OpenSearch as the first provider. 9 resource types:
 
-1. ISM policies
-2. Security roles
-3. Role mappings
-4. Internal users
-5. Composable index templates
-6. Component templates
-7. Ingest pipelines
-8. Cluster settings
-9. Snapshot repositories
+- `opensearch_ism_policy`
+- `opensearch_role`
+- `opensearch_role_mapping`
+- `opensearch_internal_user`
+- `opensearch_composable_index_template`
+- `opensearch_component_template`
+- `opensearch_ingest_pipeline`
+- `opensearch_cluster_setting`
+- `opensearch_snapshot_repository`
+
+Auth: basic (self-hosted) and AWS SigV4 (managed OpenSearch Service).
 
 DCL layers 1 through 4: resource blocks with typed attributes, cross-resource references (`role = opensearch_role.log_reader`), the `secret()` built-in for credential resolution, and named connection contexts.
 
-Three commands: `validate`, `plan`, `apply`.
-
 ## Roadmap
 
-- v0.1.0: OpenSearch provider, core framework, DCL parser
-- v0.5.0: Redis and MongoDB providers, variables/conditionals/iteration in DCL, CEL policy validation, Vault and AWS Secrets Manager backends
-- v1.0.0: MySQL provider, gRPC external plugin protocol, GitOps integration (ArgoCD/Flux)
+- **v0.1.0**: OpenSearch provider, core framework, DCL parser.
+- **v0.2.0**: `import` command (generate DCL from live cluster state).
+- **v0.5.0**: Redis and MongoDB providers. DCL variables, conditionals, and iteration. CEL policy validation. Vault and AWS Secrets Manager backends.
+- **v1.0.0**: MySQL provider. gRPC external plugin protocol. Multi-environment overlays. GitOps integration (ArgoCD, Flux).
+
+## Architecture
+
+Seven modules, each with a narrow job:
+
+| Module | Responsibility |
+|--------|----------------|
+| `dcl` | Hand-written recursive-descent parser. Lexer, AST, diagnostics. No HCL dependency. |
+| `provider` | Provider interface, resource types, schema system. |
+| `engine` | Discover, diff, dependency graph, parallel executor. Owns diffing so providers don't have to. |
+| `providers/opensearch` | OpenSearch provider. HTTP client with basic + SigV4 auth. |
+| `config` | Loads `~/.datastorectl/config.dcl`. Context resolution. Secret lookups. |
+| `output` | Terraform-style colored diffs, JSON output, diagnostic formatting. |
+| `cmd/datastorectl` | Cobra CLI. Thin orchestration layer. |
+
+Independent resources apply in parallel. Dependency chains stop on first error. Per-resource result reporting so you know exactly what succeeded and what failed.
 
 ## License
 
-Apache 2.0
+Apache 2.0.


### PR DESCRIPTION
## Summary
- Drop the "not usable yet" banner. Reframe as a v0.1.0 release candidate.
- Replace the DCL example with syntax verified against `datastorectl validate`.
- Document `--prune` (additive-by-default) and `--allow-self-lockout`.
- Add a Quickstart against `showcase.sh` + Docker Compose.
- Add Configuration section covering `~/.datastorectl/config.dcl`, `secret("env", ...)`, and the multi-context safety rail.
- Add an Architecture table for the seven modules.
- Fix the 9-type resource list to use provider-prefixed names.
- Extend roadmap with v0.2.0 `import`.

## Test plan
- [x] `./datastorectl validate` against the README's full DCL example returns `Valid.`
- [ ] Eyeball render on the PR preview