### PR TITLE
feat(mysql): scaffold provider package with registration and stub handlers

### DIFF
--- a/cmd/datastorectl/main.go
+++ b/cmd/datastorectl/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	// Register built-in providers.
+	_ "github.com/MathewBravo/datastorectl/providers/mysql"
 	_ "github.com/MathewBravo/datastorectl/providers/opensearch"
 )
 

--- a/providers/mysql/handler.go
+++ b/providers/mysql/handler.go
@@ -1,0 +1,51 @@
+package mysql
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// resourceHandler is the internal interface each resource type implements.
+// The top-level Provider dispatches to the matching handler by resource type.
+type resourceHandler interface {
+	Discover(ctx context.Context) ([]provider.Resource, error)
+	Normalize(ctx context.Context, r provider.Resource) (provider.Resource, error)
+	Validate(ctx context.Context, r provider.Resource) error
+	Apply(ctx context.Context, op provider.Operation, r provider.Resource) error
+}
+
+// schemaProvider is an optional interface a handler may implement to declare
+// the expected structure of its nested blocks. The provider collects these
+// during Schemas() and passes them to the DCL converter.
+type schemaProvider interface {
+	Schema() provider.Schema
+}
+
+// errNotImplemented is returned by scaffold handlers until the real
+// implementation lands in later phases.
+var errNotImplemented = errors.New("mysql provider handler is not implemented yet")
+
+// stubHandler is the placeholder used for every resource type in the
+// Phase 18 scaffold. Every method returns errNotImplemented so callers
+// get a deterministic signal that the handler is registered but empty.
+type stubHandler struct {
+	typeName string
+}
+
+func (h *stubHandler) Discover(ctx context.Context) ([]provider.Resource, error) {
+	return nil, errNotImplemented
+}
+
+func (h *stubHandler) Normalize(ctx context.Context, r provider.Resource) (provider.Resource, error) {
+	return r, errNotImplemented
+}
+
+func (h *stubHandler) Validate(ctx context.Context, r provider.Resource) error {
+	return errNotImplemented
+}
+
+func (h *stubHandler) Apply(ctx context.Context, op provider.Operation, r provider.Resource) error {
+	return errNotImplemented
+}

--- a/providers/mysql/provider.go
+++ b/providers/mysql/provider.go
@@ -1,0 +1,128 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+func init() {
+	provider.Register("mysql", func() provider.Provider {
+		return &Provider{
+			handlers: map[string]resourceHandler{
+				"mysql_user":     &stubHandler{typeName: "mysql_user"},
+				"mysql_grant":    &stubHandler{typeName: "mysql_grant"},
+				"mysql_role":     &stubHandler{typeName: "mysql_role"},
+				"mysql_database": &stubHandler{typeName: "mysql_database"},
+			},
+		}
+	})
+}
+
+// Provider implements provider.Provider for MySQL clusters. The Phase 18
+// scaffold wires registration, handler dispatch, and placeholder
+// diagnostics. Real configuration, discovery, and application land in
+// subsequent phases.
+type Provider struct {
+	handlers map[string]resourceHandler
+}
+
+// Configure is not yet implemented. The scaffold returns a deterministic
+// diagnostic so integration code can detect the placeholder state
+// without crashing.
+func (p *Provider) Configure(_ context.Context, _ *provider.OrderedMap) dcl.Diagnostics {
+	return dcl.Diagnostics{{
+		Severity: dcl.SeverityError,
+		Message:  "mysql provider Configure is not implemented yet (Phase 18 scaffold)",
+	}}
+}
+
+// Discover iterates registered handlers and collects any discovered
+// resources. In the scaffold every handler errors, so this returns an
+// aggregated diagnostics list.
+func (p *Provider) Discover(ctx context.Context) ([]provider.Resource, dcl.Diagnostics) {
+	var all []provider.Resource
+	var diags dcl.Diagnostics
+	for _, h := range p.handlers {
+		resources, err := h.Discover(ctx)
+		if err != nil {
+			diags = append(diags, dcl.Diagnostic{Severity: dcl.SeverityError, Message: err.Error()})
+			continue
+		}
+		all = append(all, resources...)
+	}
+	return all, diags
+}
+
+// Normalize delegates to the handler registered for the resource type.
+func (p *Provider) Normalize(ctx context.Context, r provider.Resource) (provider.Resource, dcl.Diagnostics) {
+	h, ok := p.handlers[r.ID.Type]
+	if !ok {
+		return r, dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  fmt.Sprintf("resource type %q is not supported by the mysql provider", r.ID.Type),
+		}}
+	}
+	out, err := h.Normalize(ctx, r)
+	if err != nil {
+		return r, dcl.Diagnostics{{Severity: dcl.SeverityError, Message: err.Error()}}
+	}
+	return out, nil
+}
+
+// Validate delegates to the handler registered for the resource type.
+func (p *Provider) Validate(ctx context.Context, r provider.Resource) dcl.Diagnostics {
+	h, ok := p.handlers[r.ID.Type]
+	if !ok {
+		return dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  fmt.Sprintf("resource type %q is not supported by the mysql provider", r.ID.Type),
+		}}
+	}
+	if err := h.Validate(ctx, r); err != nil {
+		return dcl.Diagnostics{{Severity: dcl.SeverityError, Message: err.Error()}}
+	}
+	return nil
+}
+
+// Apply delegates to the handler registered for the resource type.
+func (p *Provider) Apply(ctx context.Context, op provider.Operation, r provider.Resource) dcl.Diagnostics {
+	h, ok := p.handlers[r.ID.Type]
+	if !ok {
+		return dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  fmt.Sprintf("resource type %q is not supported by the mysql provider", r.ID.Type),
+		}}
+	}
+	if err := h.Apply(ctx, op, r); err != nil {
+		return dcl.Diagnostics{{Severity: dcl.SeverityError, Message: err.Error()}}
+	}
+	return nil
+}
+
+// Schemas collects schema declarations from handlers that implement
+// schemaProvider. Scaffold handlers do not yet declare schemas, so this
+// returns an empty map until real handlers land.
+func (p *Provider) Schemas() map[string]provider.Schema {
+	schemas := make(map[string]provider.Schema)
+	for typ, h := range p.handlers {
+		if sp, ok := h.(schemaProvider); ok {
+			schemas[typ] = sp.Schema()
+		}
+	}
+	return schemas
+}
+
+// TypeOrderings declares the default resource type ordering for the
+// mysql provider. Per ADR 0008: users before grants and roles, roles
+// before grants (so role-to-role edges see the role created). Databases
+// have no hard ordering dependency with the others.
+func (p *Provider) TypeOrderings() []provider.TypeOrdering {
+	return []provider.TypeOrdering{
+		{Before: "mysql_user", After: "mysql_grant"},
+		{Before: "mysql_user", After: "mysql_role"},
+		{Before: "mysql_role", After: "mysql_grant"},
+	}
+}

--- a/providers/mysql/provider_test.go
+++ b/providers/mysql/provider_test.go
@@ -1,0 +1,61 @@
+package mysql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// TestProviderRegistered confirms the init() side-effect wired the
+// "mysql" entry into the central registry.
+func TestProviderRegistered(t *testing.T) {
+	f, ok := provider.Lookup("mysql")
+	if !ok {
+		t.Fatal(`provider.Lookup("mysql") returned ok=false; expected registered`)
+	}
+	p := f()
+	if p == nil {
+		t.Fatal("factory returned nil provider")
+	}
+}
+
+// TestConfigureReturnsNotImplemented asserts the scaffold's Configure
+// returns a deterministic "not implemented" diagnostic so callers get
+// a clear signal that the provider is a placeholder.
+func TestConfigureReturnsNotImplemented(t *testing.T) {
+	f, _ := provider.Lookup("mysql")
+	p := f()
+	diags := p.Configure(context.Background(), nil)
+	if !diags.HasErrors() {
+		t.Fatal("expected Configure to return an error diagnostic, got none")
+	}
+	if !strings.Contains(strings.ToLower(diags[0].Message), "not implemented") {
+		t.Errorf("expected diagnostic to mention 'not implemented', got: %q", diags[0].Message)
+	}
+}
+
+// TestHandlersRegisteredForAllResourceTypes probes the handlers map via
+// Validate — a registered type returns a handler-level error (scaffold
+// stub), an unregistered type returns the central "is not supported"
+// message. The test passes if all four types are registered.
+func TestHandlersRegisteredForAllResourceTypes(t *testing.T) {
+	f, _ := provider.Lookup("mysql")
+	p := f()
+	types := []string{
+		"mysql_user",
+		"mysql_grant",
+		"mysql_role",
+		"mysql_database",
+	}
+	for _, typ := range types {
+		r := provider.Resource{ID: provider.ResourceID{Type: typ, Name: "probe"}}
+		diags := p.Validate(context.Background(), r)
+		for _, d := range diags {
+			if strings.Contains(d.Message, "is not supported by the mysql provider") {
+				t.Errorf("type %q: expected a registered handler, got 'is not supported' diagnostic", typ)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Scaffold `providers/mysql/` package with `Provider` struct implementing all seven interface methods.
- `init()` registers the provider as `"mysql"`, factory produces stub handlers for `mysql_user`, `mysql_grant`, `mysql_role`, and `mysql_database`.
- Configure returns a deterministic "not implemented" diagnostic so callers get a clear placeholder signal.
- `TypeOrderings` encodes ADR 0008: users before grants and roles; roles before grants.
- Blank-import in `cmd/datastorectl/main.go` so the init() wiring runs in the CLI binary.

## Test plan
- [x] `TestProviderRegistered` — `provider.Lookup("mysql")` returns a non-nil factory.
- [x] `TestConfigureReturnsNotImplemented` — Configure returns a diagnostic whose message contains "not implemented".
- [x] `TestHandlersRegisteredForAllResourceTypes` — Validate on each of the four types returns a handler-level error, not the central "is not supported" message.
- [x] `go build ./...` succeeds.
- [x] `go test ./...` all packages pass.

Closes #161