### PR TITLE
feat(mysql): implement password auth mode with TLS via go-sql-driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/MathewBravo/datastorectl
 go 1.25.0
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.5 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.14 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
@@ -17,6 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
+	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/opensearch-project/opensearch-go/v4 v4.6.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
@@ -27,6 +29,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJi
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
+github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/opensearch-project/opensearch-go/v4 v4.6.0 h1:Ac8aLtDSmLEyOmv0r1qhQLw3b4vcUhE42NE9k+Z4cRc=

--- a/providers/mysql/client.go
+++ b/providers/mysql/client.go
@@ -1,0 +1,145 @@
+package mysql
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// Client wraps the *sql.DB used to talk to a MySQL server. The pool is
+// sized at one connection since datastorectl is a short-lived CLI.
+type Client struct {
+	db *sql.DB
+}
+
+// Close releases the underlying connection pool.
+func (c *Client) Close() error {
+	if c == nil || c.db == nil {
+		return nil
+	}
+	return c.db.Close()
+}
+
+// DB exposes the raw *sql.DB for handler use.
+func (c *Client) DB() *sql.DB {
+	return c.db
+}
+
+// tlsConfigSeq generates unique names for custom TLS configs registered
+// with the go-sql-driver at runtime, so repeated Configure calls in a
+// single process don't collide on a fixed name.
+var tlsConfigSeq atomic.Uint64
+
+// ClientConfig captures everything NewPasswordClient needs from the
+// resolved provider block.
+type ClientConfig struct {
+	Endpoint string
+	Username string
+	Password string
+	TLS      string // "required", "skip-verify", "disabled", or "" (default: required)
+	TLSCA    string
+	TLSCert  string
+	TLSKey   string
+}
+
+// NewPasswordClient opens a *sql.DB configured for username/password
+// authentication. TLS mode and optional CA/client-cert paths are
+// respected. The returned client has an open connection pool capped at
+// one connection.
+func NewPasswordClient(cfg ClientConfig) (*Client, error) {
+	driverCfg := mysql.NewConfig()
+	driverCfg.User = cfg.Username
+	driverCfg.Passwd = cfg.Password
+	driverCfg.Net = "tcp"
+	driverCfg.Addr = cfg.Endpoint
+	driverCfg.AllowNativePasswords = true
+
+	tlsMode := cfg.TLS
+	if tlsMode == "" {
+		tlsMode = "required"
+	}
+	if err := applyTLSConfig(driverCfg, tlsMode, cfg); err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open("mysql", driverCfg.FormatDSN())
+	if err != nil {
+		return nil, fmt.Errorf("opening mysql connection: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	return &Client{db: db}, nil
+}
+
+// applyTLSConfig translates the TLS enum (required | skip-verify |
+// disabled) plus optional CA/cert paths into a go-sql-driver TLS
+// setting. Custom CAs and client certs are registered via
+// mysql.RegisterTLSConfig under a unique name per call.
+func applyTLSConfig(driverCfg *mysql.Config, mode string, cfg ClientConfig) error {
+	switch mode {
+	case "disabled":
+		driverCfg.TLSConfig = "false"
+		return nil
+	case "skip-verify":
+		driverCfg.TLSConfig = "skip-verify"
+		return nil
+	case "required":
+		// fall through
+	default:
+		return fmt.Errorf(`internal: unexpected tls mode %q`, mode)
+	}
+
+	hasCustom := cfg.TLSCA != "" || (cfg.TLSCert != "" || cfg.TLSKey != "")
+	if !hasCustom {
+		driverCfg.TLSConfig = "true"
+		return nil
+	}
+
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	if cfg.TLSCA != "" {
+		pem, err := os.ReadFile(cfg.TLSCA)
+		if err != nil {
+			return fmt.Errorf("reading tls_ca: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return fmt.Errorf("tls_ca %s contains no valid PEM certificates", cfg.TLSCA)
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	if (cfg.TLSCert != "") != (cfg.TLSKey != "") {
+		return fmt.Errorf("tls_cert and tls_key must be set together")
+	}
+	if cfg.TLSCert != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
+		if err != nil {
+			return fmt.Errorf("loading client cert/key: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	name := fmt.Sprintf("datastorectl-%d", tlsConfigSeq.Add(1))
+	if err := mysql.RegisterTLSConfig(name, tlsCfg); err != nil {
+		return fmt.Errorf("registering TLS config: %w", err)
+	}
+	driverCfg.TLSConfig = name
+	return nil
+}
+
+// HostFromEndpoint returns the host portion of a host:port endpoint,
+// or the full string if no port is present. Used when configuring
+// SigV4 token generation in later phases.
+func HostFromEndpoint(endpoint string) string {
+	if i := strings.LastIndex(endpoint, ":"); i >= 0 {
+		return endpoint[:i]
+	}
+	return endpoint
+}

--- a/providers/mysql/configure_test.go
+++ b/providers/mysql/configure_test.go
@@ -1,0 +1,93 @@
+package mysql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// configMap builds an *OrderedMap of string values from key-value pairs.
+func configMap(kvs ...string) *provider.OrderedMap {
+	m := provider.NewOrderedMap()
+	for i := 0; i < len(kvs); i += 2 {
+		m.Set(kvs[i], provider.StringVal(kvs[i+1]))
+	}
+	return m
+}
+
+func TestConfigure(t *testing.T) {
+	cases := []struct {
+		name      string
+		config    *provider.OrderedMap
+		errSubstr string
+	}{
+		{
+			name:      "nil config",
+			config:    nil,
+			errSubstr: "requires configuration",
+		},
+		{
+			name:      "missing endpoint",
+			config:    configMap("auth", "password", "username", "u", "password", "p"),
+			errSubstr: `"endpoint" is required`,
+		},
+		{
+			name:      "missing auth",
+			config:    configMap("endpoint", "localhost:3306", "username", "u", "password", "p"),
+			errSubstr: `"auth" is required`,
+		},
+		{
+			name:      "unknown auth mode",
+			config:    configMap("endpoint", "localhost:3306", "auth", "ldap", "username", "u", "password", "p"),
+			errSubstr: `auth must be "password" or "rds_iam"`,
+		},
+		{
+			name:      "password mode missing username",
+			config:    configMap("endpoint", "localhost:3306", "auth", "password", "password", "p"),
+			errSubstr: `"username" is required`,
+		},
+		{
+			name:      "password mode missing password",
+			config:    configMap("endpoint", "localhost:3306", "auth", "password", "username", "u"),
+			errSubstr: `"password" is required`,
+		},
+		{
+			name: "tls mode invalid",
+			config: configMap(
+				"endpoint", "localhost:3306",
+				"auth", "password",
+				"username", "u",
+				"password", "p",
+				"tls", "bogus",
+			),
+			errSubstr: `"tls" must be "required", "skip-verify", or "disabled"`,
+		},
+	}
+
+	f, _ := provider.Lookup("mysql")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := f()
+			diags := p.Configure(context.Background(), tc.config)
+			if !diags.HasErrors() {
+				t.Fatalf("expected an error diagnostic, got none")
+			}
+			found := false
+			for _, d := range diags {
+				if strings.Contains(d.Message, tc.errSubstr) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				msgs := make([]string, 0, len(diags))
+				for _, d := range diags {
+					msgs = append(msgs, d.Message)
+				}
+				t.Errorf("expected diagnostic containing %q, got: %v", tc.errSubstr, msgs)
+			}
+		})
+	}
+}

--- a/providers/mysql/provider.go
+++ b/providers/mysql/provider.go
@@ -8,6 +8,13 @@ import (
 	"github.com/MathewBravo/datastorectl/provider"
 )
 
+// validTLSModes lists the accepted values for the `tls` field.
+var validTLSModes = map[string]bool{
+	"required":    true,
+	"skip-verify": true,
+	"disabled":    true,
+}
+
 func init() {
 	provider.Register("mysql", func() provider.Provider {
 		return &Provider{
@@ -21,22 +28,157 @@ func init() {
 	})
 }
 
-// Provider implements provider.Provider for MySQL clusters. The Phase 18
-// scaffold wires registration, handler dispatch, and placeholder
-// diagnostics. Real configuration, discovery, and application land in
-// subsequent phases.
+// Provider implements provider.Provider for MySQL clusters.
 type Provider struct {
+	client   *Client
 	handlers map[string]resourceHandler
 }
 
-// Configure is not yet implemented. The scaffold returns a deterministic
-// diagnostic so integration code can detect the placeholder state
-// without crashing.
-func (p *Provider) Configure(_ context.Context, _ *provider.OrderedMap) dcl.Diagnostics {
-	return dcl.Diagnostics{{
-		Severity: dcl.SeverityError,
-		Message:  "mysql provider Configure is not implemented yet (Phase 18 scaffold)",
-	}}
+// Configure validates the provider block and opens the underlying
+// *sql.DB connection. Supported auth modes are "password" (Phase 18)
+// and "rds_iam" (Phase 24). The connection pool is sized at one.
+func (p *Provider) Configure(ctx context.Context, config *provider.OrderedMap) dcl.Diagnostics {
+	if config == nil {
+		return dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  `mysql provider requires configuration — set at minimum "endpoint", "auth", and the credentials for your chosen auth method`,
+		}}
+	}
+
+	endpoint, diags := requireStringField(config, "endpoint",
+		`"endpoint" is required and must be a non-empty string (e.g. "mysql.example.com:3306")`,
+		`add endpoint = "your-mysql-host:3306" to the mysql provider block`)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	auth, diags := requireStringField(config, "auth",
+		`"auth" is required — set it to "password" for username/password or "rds_iam" for AWS RDS IAM authentication`,
+		`add auth = "password" or auth = "rds_iam" to the mysql provider block`)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	tlsMode, diags := resolveTLSField(config)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	switch auth {
+	case "password":
+		return p.configurePasswordAuth(ctx, endpoint, tlsMode, config)
+	case "rds_iam":
+		return dcl.Diagnostics{{
+			Severity:   dcl.SeverityError,
+			Message:    `auth = "rds_iam" is not implemented yet`,
+			Suggestion: `use auth = "password" until Phase 24 lands RDS IAM support`,
+		}}
+	default:
+		return dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  fmt.Sprintf(`auth must be "password" or "rds_iam", got %q`, auth),
+		}}
+	}
+}
+
+// configurePasswordAuth validates the password-auth required fields,
+// constructs the client, and runs a sanity ping to confirm the
+// connection is live.
+func (p *Provider) configurePasswordAuth(ctx context.Context, endpoint, tlsMode string, config *provider.OrderedMap) dcl.Diagnostics {
+	username, diags := requireStringField(config, "username",
+		`"username" is required when auth is "password"`,
+		`add username = "datastorectl" to the mysql provider block`)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	password, diags := requireStringField(config, "password",
+		`"password" is required when auth is "password"`,
+		`add password = secret("env", "MYSQL_PASSWORD") to the mysql provider block`)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	cfg := ClientConfig{
+		Endpoint: endpoint,
+		Username: username,
+		Password: password,
+		TLS:      tlsMode,
+		TLSCA:    optionalString(config, "tls_ca"),
+		TLSCert:  optionalString(config, "tls_cert"),
+		TLSKey:   optionalString(config, "tls_key"),
+	}
+
+	client, err := NewPasswordClient(cfg)
+	if err != nil {
+		return dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  fmt.Sprintf("failed to create mysql client: %s", err),
+		}}
+	}
+
+	if err := client.DB().PingContext(ctx); err != nil {
+		_ = client.Close()
+		return dcl.Diagnostics{{
+			Severity:   dcl.SeverityError,
+			Message:    fmt.Sprintf("mysql connection check failed: %s", err),
+			Suggestion: "verify the endpoint is reachable, credentials are correct, and TLS settings match the server",
+		}}
+	}
+
+	p.client = client
+	return nil
+}
+
+// requireStringField fetches a required string field, producing a
+// standard diagnostic when missing or empty.
+func requireStringField(config *provider.OrderedMap, name, message, suggestion string) (string, dcl.Diagnostics) {
+	v, ok := config.Get(name)
+	if !ok || v.Kind != provider.KindString || v.Str == "" {
+		return "", dcl.Diagnostics{{
+			Severity:   dcl.SeverityError,
+			Message:    message,
+			Suggestion: suggestion,
+		}}
+	}
+	return v.Str, nil
+}
+
+// optionalString returns the string value of a field if it exists and
+// is a non-empty string, otherwise "".
+func optionalString(config *provider.OrderedMap, name string) string {
+	v, ok := config.Get(name)
+	if !ok || v.Kind != provider.KindString {
+		return ""
+	}
+	return v.Str
+}
+
+// resolveTLSField parses the optional `tls` enum, defaulting to
+// "required" when absent.
+func resolveTLSField(config *provider.OrderedMap) (string, dcl.Diagnostics) {
+	v, ok := config.Get("tls")
+	if !ok {
+		return "required", nil
+	}
+	if v.Kind != provider.KindString {
+		return "", dcl.Diagnostics{{
+			Severity: dcl.SeverityError,
+			Message:  `"tls" must be a string`,
+		}}
+	}
+	mode := v.Str
+	if mode == "" {
+		return "required", nil
+	}
+	if !validTLSModes[mode] {
+		return "", dcl.Diagnostics{{
+			Severity:   dcl.SeverityError,
+			Message:    fmt.Sprintf(`"tls" must be "required", "skip-verify", or "disabled", got %q`, mode),
+			Suggestion: `use tls = "required" to verify the server certificate (default), "skip-verify" to connect without verification, or "disabled" to connect in plaintext`,
+		}}
+	}
+	return mode, nil
 }
 
 // Discover iterates registered handlers and collects any discovered

--- a/providers/mysql/provider_test.go
+++ b/providers/mysql/provider_test.go
@@ -21,21 +21,6 @@ func TestProviderRegistered(t *testing.T) {
 	}
 }
 
-// TestConfigureReturnsNotImplemented asserts the scaffold's Configure
-// returns a deterministic "not implemented" diagnostic so callers get
-// a clear signal that the provider is a placeholder.
-func TestConfigureReturnsNotImplemented(t *testing.T) {
-	f, _ := provider.Lookup("mysql")
-	p := f()
-	diags := p.Configure(context.Background(), nil)
-	if !diags.HasErrors() {
-		t.Fatal("expected Configure to return an error diagnostic, got none")
-	}
-	if !strings.Contains(strings.ToLower(diags[0].Message), "not implemented") {
-		t.Errorf("expected diagnostic to mention 'not implemented', got: %q", diags[0].Message)
-	}
-}
-
 // TestHandlersRegisteredForAllResourceTypes probes the handlers map via
 // Validate — a registered type returns a handler-level error (scaffold
 // stub), an unregistered type returns the central "is not supported"


### PR DESCRIPTION
## Summary
- Add `github.com/go-sql-driver/mysql` as a dependency.
- `Configure` validates required fields (`endpoint`, `auth`, `username`, `password`) with per-field diagnostics and Suggestion text matching the OpenSearch provider's style.
- `auth = "password"` path opens a `*sql.DB` with max-open=1 and runs `PingContext` as a sanity check.
- `auth = "rds_iam"` returns a deferred-to-Phase-24 diagnostic.
- TLS enum (`required` default, `skip-verify`, `disabled`) maps to go-sql-driver DSN values.
- Custom CA, client cert, and client key are registered via `mysql.RegisterTLSConfig` under a unique per-call name so repeated Configure invocations don't collide.

## Test plan
- [x] `TestConfigure` table covers seven failure cases: nil config, missing endpoint, missing auth, unknown auth mode, missing username, missing password, invalid TLS mode.
- [x] `go build ./...` succeeds with the new driver dep.
- [x] `go test ./...` — all packages pass.
- [x] `go vet ./providers/mysql/...` clean.
- [ ] Successful password-auth connection against a live `mysql:8.4` container will be exercised by the integration harness in #163.

Closes #162