### PR TITLE
feat(schema): extend FieldHint with MinVersion and MaxVersion

### DIFF
--- a/engine/convert.go
+++ b/engine/convert.go
@@ -174,7 +174,7 @@ func convertBody(attrs []dcl.Attribute, blocks []dcl.Block, schema *provider.Sch
 	for _, g := range groups {
 		hint := fieldHintFor(schema, g.typ)
 
-		switch hint {
+		switch hint.Kind {
 		case provider.FieldBlockList:
 			// Always produce a list, even for a single block.
 			elems := make([]provider.Value, len(g.blocks))
@@ -227,10 +227,11 @@ func convertBody(attrs []dcl.Attribute, blocks []dcl.Block, schema *provider.Sch
 }
 
 // fieldHintFor returns the FieldHint for a block type from the schema.
-// Returns 0 (no hint) if the schema is nil or doesn't contain the field.
+// Returns the zero value (Kind = 0, no constraints) if the schema is
+// nil or doesn't contain the field.
 func fieldHintFor(schema *provider.Schema, blockType string) provider.FieldHint {
 	if schema == nil || schema.Fields == nil {
-		return 0
+		return provider.FieldHint{}
 	}
 	return schema.Fields[blockType]
 }

--- a/engine/convert_test.go
+++ b/engine/convert_test.go
@@ -1256,7 +1256,7 @@ func TestConvertBlocks_schema_single_block_as_list(t *testing.T) {
 	schemas := map[string]provider.Schema{
 		"opensearch_role": {
 			Fields: map[string]provider.FieldHint{
-				"index_permissions": provider.FieldBlockList,
+				"index_permissions": {Kind: provider.FieldBlockList},
 			},
 		},
 	}
@@ -1299,7 +1299,7 @@ func TestConvertBlocks_schema_list_multiple_blocks(t *testing.T) {
 	}
 	schemas := map[string]provider.Schema{
 		"opensearch_role": {
-			Fields: map[string]provider.FieldHint{"index_permissions": provider.FieldBlockList},
+			Fields: map[string]provider.FieldHint{"index_permissions": {Kind: provider.FieldBlockList}},
 		},
 	}
 
@@ -1331,7 +1331,7 @@ func TestConvertBlocks_schema_map_single_block(t *testing.T) {
 	}
 	schemas := map[string]provider.Schema{
 		"opensearch_component_template": {
-			Fields: map[string]provider.FieldHint{"template": provider.FieldBlockMap},
+			Fields: map[string]provider.FieldHint{"template": {Kind: provider.FieldBlockMap}},
 		},
 	}
 
@@ -1359,7 +1359,7 @@ func TestConvertBlocks_schema_map_multiple_blocks_errors(t *testing.T) {
 	}
 	schemas := map[string]provider.Schema{
 		"opensearch_component_template": {
-			Fields: map[string]provider.FieldHint{"template": provider.FieldBlockMap},
+			Fields: map[string]provider.FieldHint{"template": {Kind: provider.FieldBlockMap}},
 		},
 	}
 
@@ -1385,7 +1385,7 @@ func TestConvertBlocks_schema_undeclared_block_errors(t *testing.T) {
 	}
 	schemas := map[string]provider.Schema{
 		"opensearch_role": {
-			Fields: map[string]provider.FieldHint{"index_permissions": provider.FieldBlockList},
+			Fields: map[string]provider.FieldHint{"index_permissions": {Kind: provider.FieldBlockList}},
 		},
 	}
 

--- a/engine/version.go
+++ b/engine/version.go
@@ -1,0 +1,98 @@
+package engine
+
+import (
+	"fmt"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// ValidateBlockVersions walks each declared block and emits diagnostics
+// for attributes or nested blocks whose schema version constraints
+// don't match the declared target version for that block's context.
+//
+// versionFor returns the declared version string for a block (e.g.
+// "8.0" or "8.4"). An empty string signals "no version constraint
+// applies" and skips checks for that block. This lets the OpenSearch
+// provider (which has no version-targeting model) coexist with MySQL.
+//
+// Unknown fields (not declared in the schema) are ignored — the schema
+// authority model is "silence = unconstrained."
+func ValidateBlockVersions(
+	blocks []dcl.Block,
+	schemas map[string]provider.Schema,
+	versionFor func(dcl.Block) string,
+) dcl.Diagnostics {
+	var diags dcl.Diagnostics
+	for i := range blocks {
+		block := blocks[i]
+		schema, ok := schemas[block.Type]
+		if !ok || schema.Fields == nil {
+			continue
+		}
+		version := versionFor(block)
+		if version == "" {
+			continue
+		}
+		for _, attr := range block.Attributes {
+			hint, present := schema.Fields[attr.Key]
+			if !present {
+				continue
+			}
+			if d := checkField(attr.Key, hint, version, attr.Rng); d != nil {
+				diags = append(diags, *d)
+			}
+		}
+		for j := range block.Blocks {
+			nested := block.Blocks[j]
+			hint, present := schema.Fields[nested.Type]
+			if !present {
+				continue
+			}
+			if d := checkField(nested.Type, hint, version, nested.Rng); d != nil {
+				diags = append(diags, *d)
+			}
+		}
+	}
+	return diags
+}
+
+// checkField compares the declared version against a field's
+// MinVersion/MaxVersion. Returns a diagnostic on violation, or nil.
+func checkField(name string, hint provider.FieldHint, version string, rng dcl.Range) *dcl.Diagnostic {
+	if hint.MinVersion != "" {
+		cmp, err := provider.CompareVersions(version, hint.MinVersion)
+		if err != nil {
+			return &dcl.Diagnostic{
+				Severity: dcl.SeverityError,
+				Message:  fmt.Sprintf("version comparison for %q failed: %s", name, err),
+				Range:    rng,
+			}
+		}
+		if cmp < 0 {
+			return &dcl.Diagnostic{
+				Severity: dcl.SeverityError,
+				Message:  fmt.Sprintf("%q requires version %s or later; this context targets %s", name, hint.MinVersion, version),
+				Range:    rng,
+			}
+		}
+	}
+	if hint.MaxVersion != "" {
+		cmp, err := provider.CompareVersions(version, hint.MaxVersion)
+		if err != nil {
+			return &dcl.Diagnostic{
+				Severity: dcl.SeverityError,
+				Message:  fmt.Sprintf("version comparison for %q failed: %s", name, err),
+				Range:    rng,
+			}
+		}
+		if cmp > 0 {
+			return &dcl.Diagnostic{
+				Severity: dcl.SeverityError,
+				Message:  fmt.Sprintf("%q was removed after version %s; this context targets %s", name, hint.MaxVersion, version),
+				Range:    rng,
+			}
+		}
+	}
+	return nil
+}

--- a/engine/version_test.go
+++ b/engine/version_test.go
@@ -1,0 +1,148 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// helper: build a resource block with a single attribute
+func attrBlock(typ, label, attrKey string, attrRng dcl.Range) dcl.Block {
+	return dcl.Block{
+		Type:  typ,
+		Label: label,
+		Attributes: []dcl.Attribute{
+			{Key: attrKey, Value: &dcl.LiteralBool{Value: false}, Rng: attrRng},
+		},
+	}
+}
+
+func TestValidateBlockVersions_NoConstraintsPass(t *testing.T) {
+	blocks := []dcl.Block{attrBlock("mysql_user", "app", "account_locked", dcl.Range{})}
+	schemas := map[string]provider.Schema{
+		"mysql_user": {Fields: map[string]provider.FieldHint{}},
+	}
+	diags := ValidateBlockVersions(blocks, schemas, func(dcl.Block) string { return "8.4" })
+	if diags.HasErrors() {
+		t.Errorf("expected no errors, got: %v", diags)
+	}
+}
+
+func TestValidateBlockVersions_EmptyVersionSkips(t *testing.T) {
+	blocks := []dcl.Block{attrBlock("mysql_user", "app", "account_locked", dcl.Range{})}
+	schemas := map[string]provider.Schema{
+		"mysql_user": {Fields: map[string]provider.FieldHint{
+			"account_locked": {MinVersion: "8.0"},
+		}},
+	}
+	// Empty version signals "no context version available" — skip checks.
+	diags := ValidateBlockVersions(blocks, schemas, func(dcl.Block) string { return "" })
+	if diags.HasErrors() {
+		t.Errorf("expected no errors when version is empty, got: %v", diags)
+	}
+}
+
+func TestValidateBlockVersions_MinVersionViolated(t *testing.T) {
+	blocks := []dcl.Block{attrBlock("mysql_user", "app", "account_locked", dcl.Range{})}
+	schemas := map[string]provider.Schema{
+		"mysql_user": {Fields: map[string]provider.FieldHint{
+			"account_locked": {MinVersion: "8.0"},
+		}},
+	}
+	diags := ValidateBlockVersions(blocks, schemas, func(dcl.Block) string { return "5.7" })
+	if !diags.HasErrors() {
+		t.Fatalf("expected an error, got none")
+	}
+	msg := diags[0].Message
+	if !strings.Contains(msg, "account_locked") || !strings.Contains(msg, "8.0") || !strings.Contains(msg, "5.7") {
+		t.Errorf("expected diagnostic to mention field, MinVersion, and declared version; got: %q", msg)
+	}
+}
+
+func TestValidateBlockVersions_MaxVersionViolated(t *testing.T) {
+	blocks := []dcl.Block{attrBlock("mysql_user", "app", "old_plugin", dcl.Range{})}
+	schemas := map[string]provider.Schema{
+		"mysql_user": {Fields: map[string]provider.FieldHint{
+			"old_plugin": {MaxVersion: "8.0"},
+		}},
+	}
+	diags := ValidateBlockVersions(blocks, schemas, func(dcl.Block) string { return "8.4" })
+	if !diags.HasErrors() {
+		t.Fatalf("expected an error, got none")
+	}
+	if !strings.Contains(diags[0].Message, "old_plugin") {
+		t.Errorf("expected diagnostic to mention field; got: %q", diags[0].Message)
+	}
+}
+
+func TestValidateBlockVersions_InsideBoundsPass(t *testing.T) {
+	blocks := []dcl.Block{attrBlock("mysql_user", "app", "windowed", dcl.Range{})}
+	schemas := map[string]provider.Schema{
+		"mysql_user": {Fields: map[string]provider.FieldHint{
+			"windowed": {MinVersion: "8.0", MaxVersion: "8.4"},
+		}},
+	}
+	diags := ValidateBlockVersions(blocks, schemas, func(dcl.Block) string { return "8.2" })
+	if diags.HasErrors() {
+		t.Errorf("expected no errors (inside bounds), got: %v", diags)
+	}
+}
+
+func TestValidateBlockVersions_UnknownFieldIgnored(t *testing.T) {
+	blocks := []dcl.Block{attrBlock("mysql_user", "app", "completely_unknown", dcl.Range{})}
+	schemas := map[string]provider.Schema{
+		"mysql_user": {Fields: map[string]provider.FieldHint{}},
+	}
+	diags := ValidateBlockVersions(blocks, schemas, func(dcl.Block) string { return "8.4" })
+	if diags.HasErrors() {
+		t.Errorf("expected no errors when field has no schema entry, got: %v", diags)
+	}
+}
+
+func TestValidateBlockVersions_NestedBlockConstraint(t *testing.T) {
+	blocks := []dcl.Block{
+		{
+			Type:  "mysql_user",
+			Label: "app",
+			Blocks: []dcl.Block{
+				{Type: "restricted_sub_block", Rng: dcl.Range{}},
+			},
+		},
+	}
+	schemas := map[string]provider.Schema{
+		"mysql_user": {Fields: map[string]provider.FieldHint{
+			"restricted_sub_block": {Kind: provider.FieldBlockList, MinVersion: "8.4"},
+		}},
+	}
+	diags := ValidateBlockVersions(blocks, schemas, func(dcl.Block) string { return "8.0" })
+	if !diags.HasErrors() {
+		t.Fatalf("expected error for nested block below MinVersion, got none")
+	}
+	if !strings.Contains(diags[0].Message, "restricted_sub_block") {
+		t.Errorf("expected nested block name in diagnostic; got: %q", diags[0].Message)
+	}
+}
+
+func TestValidateBlockVersions_MultipleResourcesDifferentVersions(t *testing.T) {
+	blocks := []dcl.Block{
+		attrBlock("mysql_user", "a", "newfield", dcl.Range{}),
+		attrBlock("mysql_user", "b", "newfield", dcl.Range{}),
+	}
+	schemas := map[string]provider.Schema{
+		"mysql_user": {Fields: map[string]provider.FieldHint{
+			"newfield": {MinVersion: "8.4"},
+		}},
+	}
+	// a → 8.0 (fails), b → 8.4 (passes)
+	diags := ValidateBlockVersions(blocks, schemas, func(b dcl.Block) string {
+		if b.Label == "a" {
+			return "8.0"
+		}
+		return "8.4"
+	})
+	if len(diags) != 1 {
+		t.Fatalf("expected exactly 1 diagnostic, got %d: %v", len(diags), diags)
+	}
+}

--- a/provider/schema.go
+++ b/provider/schema.go
@@ -1,21 +1,102 @@
 package provider
 
-// FieldHint tells the DCL converter how to represent a nested block group.
-type FieldHint int
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// FieldKind tells the DCL converter how to represent a nested block
+// group. The zero value means "no block hint" — used for scalar
+// attributes that only carry version constraints.
+type FieldKind int
 
 const (
 	// FieldBlockList means the block should always produce a ListVal,
 	// even when only one block of that type appears.
-	FieldBlockList FieldHint = iota + 1
+	FieldBlockList FieldKind = iota + 1
 
 	// FieldBlockMap means the block should always produce a MapVal,
 	// even when multiple blocks of that type appear (which would be an error).
 	FieldBlockMap
 )
 
-// Schema declares the expected structure for a resource type's nested blocks.
-// The converter uses these hints to choose ListVal vs MapVal instead of
-// guessing from occurrence count.
+// FieldHint is the per-field schema annotation. Kind determines list
+// vs map rendering for nested blocks; MinVersion and MaxVersion gate
+// the field against the context's declared target version (ADR 0009).
+// Empty version strings mean "no constraint on this end."
+type FieldHint struct {
+	Kind       FieldKind
+	MinVersion string
+	MaxVersion string
+}
+
+// Schema declares the expected structure for a resource type's fields.
+// The converter uses Kind hints for list vs map; the engine uses
+// version constraints for validate-time gating.
 type Schema struct {
 	Fields map[string]FieldHint
+}
+
+// CompareVersions compares two semantic-version strings by major.minor
+// (patch and suffixes are ignored). Returns -1 / 0 / 1 in the usual
+// sense. An empty string on either side is treated as "no constraint,"
+// which yields 0.
+func CompareVersions(a, b string) (int, error) {
+	if a == "" || b == "" {
+		return 0, nil
+	}
+	aMajor, aMinor, err := parseMajorMinor(a)
+	if err != nil {
+		return 0, fmt.Errorf("version %q: %w", a, err)
+	}
+	bMajor, bMinor, err := parseMajorMinor(b)
+	if err != nil {
+		return 0, fmt.Errorf("version %q: %w", b, err)
+	}
+	switch {
+	case aMajor < bMajor:
+		return -1, nil
+	case aMajor > bMajor:
+		return 1, nil
+	case aMinor < bMinor:
+		return -1, nil
+	case aMinor > bMinor:
+		return 1, nil
+	default:
+		return 0, nil
+	}
+}
+
+// parseMajorMinor extracts the major and minor components from a
+// version string. Trailing patch, pre-release, and build suffixes are
+// tolerated and ignored.
+func parseMajorMinor(v string) (major, minor int, err error) {
+	// Strip suffix after any non-digit-or-dot character (e.g., "-rds").
+	clean := v
+	for i, r := range v {
+		if r == '-' || r == '+' {
+			clean = v[:i]
+			break
+		}
+	}
+	parts := strings.Split(clean, ".")
+	if len(parts) < 2 {
+		return 0, 0, fmt.Errorf("must be major.minor (got %q)", v)
+	}
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("major %q not a number", parts[0])
+	}
+	if major < 0 {
+		return 0, 0, fmt.Errorf("major %d cannot be negative", major)
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("minor %q not a number", parts[1])
+	}
+	if minor < 0 {
+		return 0, 0, fmt.Errorf("minor %d cannot be negative", minor)
+	}
+	return major, minor, nil
 }

--- a/provider/schema_test.go
+++ b/provider/schema_test.go
@@ -1,0 +1,74 @@
+package provider
+
+import "testing"
+
+// TestFieldHint_VersionFields asserts the FieldHint struct carries
+// optional MinVersion and MaxVersion annotations alongside the block
+// Kind. These are the inputs to the validate-time version gating from
+// ADR 0009.
+func TestFieldHint_VersionFields(t *testing.T) {
+	h := FieldHint{
+		Kind:       FieldBlockList,
+		MinVersion: "8.0",
+		MaxVersion: "8.4",
+	}
+	if h.Kind != FieldBlockList {
+		t.Errorf("Kind = %v, want FieldBlockList", h.Kind)
+	}
+	if h.MinVersion != "8.0" || h.MaxVersion != "8.4" {
+		t.Errorf("version bounds = (%q, %q), want (\"8.0\", \"8.4\")", h.MinVersion, h.MaxVersion)
+	}
+}
+
+// TestFieldHint_ScalarFieldVersionOnly covers the case where a scalar
+// attribute has a version constraint but no block kind (Kind = 0).
+func TestFieldHint_ScalarFieldVersionOnly(t *testing.T) {
+	h := FieldHint{MinVersion: "8.0"}
+	if h.Kind != 0 {
+		t.Errorf("Kind = %v, want 0 (no block hint)", h.Kind)
+	}
+	if h.MinVersion != "8.0" {
+		t.Errorf("MinVersion = %q, want \"8.0\"", h.MinVersion)
+	}
+}
+
+// TestCompareVersions verifies the semantic (not lexical) comparison of
+// major.minor strings used by the version-gating logic.
+func TestCompareVersions(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"8.0", "8.0", 0},
+		{"8.0", "8.4", -1},
+		{"8.4", "8.0", 1},
+		{"5.7", "8.0", -1},
+		{"8.0", "10.0", -1}, // numeric, not lexical — 10 > 8
+		{"10.0", "8.0", 1},
+		{"8.0.5", "8.0", 0},    // patch ignored for major.minor comparison
+		{"8.4.5-rds", "8.4", 0}, // suffixes tolerated
+		{"", "8.0", 0},          // empty treated as "no constraint"
+		{"8.0", "", 0},
+	}
+	for _, c := range cases {
+		got, err := CompareVersions(c.a, c.b)
+		if err != nil {
+			t.Errorf("CompareVersions(%q, %q) error: %v", c.a, c.b, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("CompareVersions(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// TestCompareVersions_MalformedInput asserts malformed version strings
+// return an error so callers produce clear diagnostics.
+func TestCompareVersions_MalformedInput(t *testing.T) {
+	cases := []string{"not-a-version", "8", "8.x", "8.-1"}
+	for _, v := range cases {
+		if _, err := CompareVersions(v, "8.0"); err == nil {
+			t.Errorf("CompareVersions(%q, ...) expected error, got nil", v)
+		}
+	}
+}

--- a/providers/opensearch/component_template.go
+++ b/providers/opensearch/component_template.go
@@ -18,7 +18,7 @@ type componentTemplateHandler struct{}
 func (h *componentTemplateHandler) Schema() provider.Schema {
 	return provider.Schema{
 		Fields: map[string]provider.FieldHint{
-			"template": provider.FieldBlockMap,
+			"template": {Kind: provider.FieldBlockMap},
 		},
 	}
 }

--- a/providers/opensearch/composable_index_template.go
+++ b/providers/opensearch/composable_index_template.go
@@ -18,7 +18,7 @@ type composableIndexTemplateHandler struct{}
 func (h *composableIndexTemplateHandler) Schema() provider.Schema {
 	return provider.Schema{
 		Fields: map[string]provider.FieldHint{
-			"template": provider.FieldBlockMap,
+			"template": {Kind: provider.FieldBlockMap},
 		},
 	}
 }

--- a/providers/opensearch/role.go
+++ b/providers/opensearch/role.go
@@ -18,8 +18,8 @@ type roleHandler struct{}
 func (h *roleHandler) Schema() provider.Schema {
 	return provider.Schema{
 		Fields: map[string]provider.FieldHint{
-			"index_permissions":  provider.FieldBlockList,
-			"tenant_permissions": provider.FieldBlockList,
+			"index_permissions":  {Kind: provider.FieldBlockList},
+			"tenant_permissions": {Kind: provider.FieldBlockList},
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- Refactor `provider.FieldHint` from `int` enum to a struct (`Kind` + `MinVersion` + `MaxVersion`). The old enum is preserved as `provider.FieldKind`.
- Add `provider.CompareVersions` helper: semantic `major.minor` compare, tolerates patch and suffix components (`"8.4.5-rds"` matches `"8.4"`). Rejects malformed input.
- Add `engine.ValidateBlockVersions` pre-pass that walks DCL blocks and emits source-ranged diagnostics for attributes and nested blocks whose version bounds don't match the declared target.
- Mechanical call-site updates to struct-literal form in the three OpenSearch handlers that declare Schemas, plus the convert tests.
- Empty `versionFor()` return = "no constraints apply" — keeps the OpenSearch provider (no version model) compatible.

## Test plan
- [x] `provider`: `TestFieldHint_VersionFields`, `TestFieldHint_ScalarFieldVersionOnly`, `TestCompareVersions` (10 cases), `TestCompareVersions_MalformedInput` (4 cases).
- [x] `engine`: `TestValidateBlockVersions` across 8 scenarios: no-constraint, empty-version-skip, min violated, max violated, inside bounds, unknown field ignored, nested block, multi-context.
- [x] All existing tests pass: `go test ./... -count=1`.
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.

The MySQL context-version plumbing (wiring `versionFor` to read a context's declared `version` attribute) lands with #165.

Closes #164