### PR TITLE
feat(mysql): implement mysql_native_password hash routine

### DIFF
--- a/providers/mysql/auth/native.go
+++ b/providers/mysql/auth/native.go
@@ -1,0 +1,29 @@
+// Package auth implements the password hashing algorithms used by
+// datastorectl's MySQL provider for stateless password diffing. The
+// functions here are pure — no database, no network — so their
+// correctness can be pinned by known-answer tests against reference
+// vectors captured from real MySQL servers.
+package auth
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"strings"
+)
+
+// NativePasswordHash computes the mysql_native_password authentication
+// string for the given cleartext. The algorithm is a double SHA-1
+// with no salt:
+//
+//	"*" + UPPER(hex(SHA1(SHA1(password))))
+//
+// An empty input returns an empty string, matching MySQL's convention
+// for passwordless accounts.
+func NativePasswordHash(cleartext string) string {
+	if cleartext == "" {
+		return ""
+	}
+	first := sha1.Sum([]byte(cleartext))
+	second := sha1.Sum(first[:])
+	return "*" + strings.ToUpper(fmt.Sprintf("%x", second))
+}

--- a/providers/mysql/auth/native_test.go
+++ b/providers/mysql/auth/native_test.go
@@ -1,0 +1,78 @@
+package auth
+
+import "testing"
+
+// TestNativePasswordHash_KnownVectors verifies the mysql_native_password
+// algorithm against reference outputs. The first two are the canonical
+// vectors cited in the MySQL Community Server documentation:
+//
+//	password  →  *2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19
+//	test      →  *94BDCEBE19083CE2A1F959FD02F964C7AF4CFC29
+//
+// The remaining three were independently computed with:
+//
+//	printf '%s' "<pw>" | openssl dgst -sha1 -binary | openssl dgst -sha1 -hex
+//
+// giving a second reference implementation. If the algorithm here
+// drifts, one of these will fail.
+func TestNativePasswordHash_KnownVectors(t *testing.T) {
+	cases := []struct {
+		cleartext string
+		expected  string
+	}{
+		{"password", "*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19"},
+		{"test", "*94BDCEBE19083CE2A1F959FD02F964C7AF4CFC29"},
+		{"datastorectl", "*4C2E8A11AE4B1FE9A01A5F752B8E8D354E288B55"},
+		{"hunter2", "*58815970BE77B3720276F63DB198B1FA42E5CC02"},
+		{"Let_me_in!2026", "*A502358028AC1F16C4FFDBF560B8F834F361C0B8"},
+	}
+	for _, c := range cases {
+		got := NativePasswordHash(c.cleartext)
+		if got != c.expected {
+			t.Errorf("NativePasswordHash(%q) = %q, want %q", c.cleartext, got, c.expected)
+		}
+	}
+}
+
+// TestNativePasswordHash_EmptyInput asserts the MySQL convention that
+// an empty password produces an empty authentication_string, matching
+// the behaviour of CREATE USER ... IDENTIFIED BY ''.
+func TestNativePasswordHash_EmptyInput(t *testing.T) {
+	if got := NativePasswordHash(""); got != "" {
+		t.Errorf("NativePasswordHash(\"\") = %q, want \"\"", got)
+	}
+}
+
+// TestNativePasswordHash_Deterministic asserts the function is pure —
+// same input always yields identical output. Drift here would quietly
+// break the diff logic.
+func TestNativePasswordHash_Deterministic(t *testing.T) {
+	const pw = "some-password-123"
+	first := NativePasswordHash(pw)
+	for i := 0; i < 5; i++ {
+		if got := NativePasswordHash(pw); got != first {
+			t.Fatalf("non-deterministic: run %d got %q, want %q", i, got, first)
+		}
+	}
+}
+
+// TestNativePasswordHash_FormatShape asserts the output format is
+// "*" + 40 uppercase hex characters (20 bytes from a single SHA-1
+// round).
+func TestNativePasswordHash_FormatShape(t *testing.T) {
+	hash := NativePasswordHash("anything")
+	if len(hash) != 41 {
+		t.Fatalf("len = %d, want 41", len(hash))
+	}
+	if hash[0] != '*' {
+		t.Errorf("prefix = %q, want '*'", hash[0])
+	}
+	for i := 1; i < len(hash); i++ {
+		r := hash[i]
+		isDigit := r >= '0' && r <= '9'
+		isUpperHex := r >= 'A' && r <= 'F'
+		if !isDigit && !isUpperHex {
+			t.Errorf("char %d = %q, want uppercase hex digit", i, r)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Creates `providers/mysql/auth/` sub-package per ADR 0010.
- `NativePasswordHash(cleartext string) string` returns `"*" + UPPER(hex(SHA1(SHA1(password))))`.
- Empty cleartext returns empty string (MySQL passwordless-account convention).
- Pure function, no DB dependency.

## Test plan
- [x] Five known-answer vectors: two canonical from MySQL docs (`"password"`, `"test"`), three independently computed with `openssl dgst -sha1` (`"datastorectl"`, `"hunter2"`, `"Let_me_in!2026"`).
- [x] Empty input → empty output.
- [x] Determinism across 5 iterations.
- [x] Output shape (`*` prefix + 40 uppercase hex chars).
- [x] `go test ./... -count=1` all packages pass.
- [x] `go vet ./providers/mysql/auth/...` clean.

Closes #166