### PR TITLE
feat(mysql): password diff dispatch and validate-time rejections

### DIFF
--- a/providers/mysql/auth/dispatch.go
+++ b/providers/mysql/auth/dispatch.go
@@ -1,0 +1,112 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Plugin names recognized by the mysql provider. These are the
+// DCL-facing values for the `auth_plugin` attribute on mysql_user.
+// PluginAWSIAM maps to the server-side AWSAuthenticationPlugin and has
+// no local authentication_string.
+const (
+	PluginCachingSHA2    = "caching_sha2_password"
+	PluginNativePassword = "mysql_native_password"
+	PluginAWSIAM         = "aws_iam"
+)
+
+// unsupportedPlugins names the plugins we deliberately reject at
+// validate time so users hit a clear diagnostic rather than a late
+// apply-time failure. Non-exhaustive; anything not in the supported
+// set falls through to a generic rejection.
+var unsupportedPlugins = map[string]bool{
+	"authentication_ldap_simple": true,
+	"authentication_ldap_sasl":   true,
+	"authentication_pam":         true,
+	"authentication_kerberos":    true,
+	"sha256_password":            true, // predecessor to caching_sha2, not targeting
+}
+
+// Declared is the password-side state of a mysql_user as declared in
+// DCL. Exactly one of Cleartext / Hash is set for password plugins;
+// both are empty for aws_iam. ValidateDeclared enforces these
+// invariants.
+type Declared struct {
+	Plugin    string
+	Cleartext string // from `password = secret(...)` — rehashed against stored salt
+	Hash      string // from `password_hash = ...` — byte-compared to stored
+}
+
+// ValidateDeclared checks the plugin-vs-password invariants. Call this
+// at validate time; errors here surface before any connection attempt.
+func ValidateDeclared(d Declared) error {
+	if d.Plugin == "" {
+		return errors.New("auth_plugin is required")
+	}
+	if unsupportedPlugins[d.Plugin] {
+		return fmt.Errorf("auth_plugin %q is not supported in this release", d.Plugin)
+	}
+
+	switch d.Plugin {
+	case PluginAWSIAM:
+		if d.Cleartext != "" || d.Hash != "" {
+			return fmt.Errorf("auth_plugin %q does not accept a local password; remove password / password_hash", d.Plugin)
+		}
+		return nil
+
+	case PluginCachingSHA2, PluginNativePassword:
+		if d.Cleartext != "" && d.Hash != "" {
+			return fmt.Errorf("cannot set both password and password_hash for auth_plugin %q", d.Plugin)
+		}
+		if d.Cleartext == "" && d.Hash == "" {
+			return fmt.Errorf("auth_plugin %q requires either password or password_hash", d.Plugin)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("auth_plugin %q is not supported in this release", d.Plugin)
+	}
+}
+
+// Compare returns true when the declared password state matches the
+// server's stored authentication_string. Dispatches by plugin:
+//
+//   - aws_iam: always matches — server delegates auth, no local hash
+//     to diff.
+//   - password_hash set: byte-compare declared hash to stored.
+//   - Cleartext + caching_sha2_password: parse salt from stored,
+//     recompute via Drepper SHA-256 crypt, byte-compare the result.
+//   - Cleartext + mysql_native_password: recompute via double-SHA1,
+//     byte-compare.
+//
+// Malformed stored input produces an error (not a silent mismatch) so
+// operators see something has gone wrong in server state.
+func Compare(d Declared, stored string) (bool, error) {
+	switch d.Plugin {
+	case PluginAWSIAM:
+		return true, nil
+
+	case PluginCachingSHA2:
+		if d.Hash != "" {
+			return d.Hash == stored, nil
+		}
+		salt, iterations, err := ExtractCachingSHA2Params(stored)
+		if err != nil {
+			return false, err
+		}
+		recomputed, err := ComputeCachingSHA2Hash(d.Cleartext, salt, iterations)
+		if err != nil {
+			return false, err
+		}
+		return recomputed == stored, nil
+
+	case PluginNativePassword:
+		if d.Hash != "" {
+			return d.Hash == stored, nil
+		}
+		return NativePasswordHash(d.Cleartext) == stored, nil
+
+	default:
+		return false, fmt.Errorf("auth_plugin %q is not supported for comparison", d.Plugin)
+	}
+}

--- a/providers/mysql/auth/dispatch_test.go
+++ b/providers/mysql/auth/dispatch_test.go
@@ -1,0 +1,163 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateDeclared covers the validate-time rejections for every
+// shape the DCL can produce. These run before any connection attempt,
+// so they don't depend on Compare being implemented correctly.
+func TestValidateDeclared(t *testing.T) {
+	cases := []struct {
+		name    string
+		decl    Declared
+		wantErr string // "" means no error expected
+	}{
+		{
+			name: "password + caching_sha2 ok",
+			decl: Declared{Plugin: PluginCachingSHA2, Cleartext: "pw"},
+		},
+		{
+			name: "password + native ok",
+			decl: Declared{Plugin: PluginNativePassword, Cleartext: "pw"},
+		},
+		{
+			name: "password_hash + caching_sha2 ok",
+			decl: Declared{Plugin: PluginCachingSHA2, Hash: "$A$005$aaaaaaaaaaaaaaaaaaaaBBBB"},
+		},
+		{
+			name: "password_hash + native ok",
+			decl: Declared{Plugin: PluginNativePassword, Hash: "*1234"},
+		},
+		{
+			name: "aws_iam alone ok",
+			decl: Declared{Plugin: PluginAWSIAM},
+		},
+		{
+			name:    "both password and hash",
+			decl:    Declared{Plugin: PluginCachingSHA2, Cleartext: "pw", Hash: "stored"},
+			wantErr: "cannot set both",
+		},
+		{
+			name:    "neither set with caching_sha2",
+			decl:    Declared{Plugin: PluginCachingSHA2},
+			wantErr: "requires either password or password_hash",
+		},
+		{
+			name:    "neither set with native",
+			decl:    Declared{Plugin: PluginNativePassword},
+			wantErr: "requires either password or password_hash",
+		},
+		{
+			name:    "password set with aws_iam",
+			decl:    Declared{Plugin: PluginAWSIAM, Cleartext: "pw"},
+			wantErr: "does not accept a local password",
+		},
+		{
+			name:    "hash set with aws_iam",
+			decl:    Declared{Plugin: PluginAWSIAM, Hash: "stored"},
+			wantErr: "does not accept a local password",
+		},
+		{
+			name:    "ldap plugin rejected",
+			decl:    Declared{Plugin: "authentication_ldap_simple"},
+			wantErr: "not supported in this release",
+		},
+		{
+			name:    "pam plugin rejected",
+			decl:    Declared{Plugin: "authentication_pam"},
+			wantErr: "not supported in this release",
+		},
+		{
+			name:    "empty plugin rejected",
+			decl:    Declared{Plugin: ""},
+			wantErr: "auth_plugin is required",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateDeclared(c.decl)
+			if c.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected nil error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.wantErr)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+// TestCompare_AWSIAMAlwaysMatches asserts the aws_iam shape skips
+// authentication_string comparison entirely — per ADR 0010, IAM users
+// have server-delegated auth with no local password to diff.
+func TestCompare_AWSIAMAlwaysMatches(t *testing.T) {
+	cases := []string{"", "anything", "garbage-not-even-a-hash"}
+	for _, stored := range cases {
+		match, err := Compare(Declared{Plugin: PluginAWSIAM}, stored)
+		if err != nil {
+			t.Errorf("aws_iam should not error on stored=%q: %v", stored, err)
+		}
+		if !match {
+			t.Errorf("aws_iam should always match; stored=%q", stored)
+		}
+	}
+}
+
+// TestCompare_PasswordHashByteCompare asserts the password_hash path
+// does a pure byte comparison with no hashing.
+func TestCompare_PasswordHashByteCompare(t *testing.T) {
+	stored := "$A$005$abcdefghijklmnopqrstBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+	if ok, err := Compare(Declared{Plugin: PluginCachingSHA2, Hash: stored}, stored); err != nil || !ok {
+		t.Errorf("expected match for identical hashes, got ok=%v err=%v", ok, err)
+	}
+	if ok, _ := Compare(Declared{Plugin: PluginCachingSHA2, Hash: stored}, "different"); ok {
+		t.Error("expected non-match for different stored")
+	}
+}
+
+// TestCompare_NativePasswordCleartextRehash uses a known-good vector:
+// the hash MySQL stores for "password" under mysql_native_password is
+// *2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19.
+func TestCompare_NativePasswordCleartextRehash(t *testing.T) {
+	stored := "*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19"
+	decl := Declared{Plugin: PluginNativePassword, Cleartext: "password"}
+	if ok, err := Compare(decl, stored); err != nil || !ok {
+		t.Errorf("expected match for correct cleartext, got ok=%v err=%v", ok, err)
+	}
+	declWrong := Declared{Plugin: PluginNativePassword, Cleartext: "notthepassword"}
+	if ok, _ := Compare(declWrong, stored); ok {
+		t.Error("expected non-match for wrong cleartext")
+	}
+}
+
+// TestCompare_CachingSHA2CleartextRehash uses the same fixture bytes
+// captured from the live cluster in caching_sha2_test.go. If this test
+// and the round-trip test agree, the dispatch is correctly wiring into
+// ComputeCachingSHA2Hash.
+func TestCompare_CachingSHA2CleartextRehash(t *testing.T) {
+	// Reuse the "password" fixture from caching_sha2_test.go.
+	stored := string(mustHex("2441243030352478500E6D7B4B075664056A54121946312511440554575349376D2E666F416875797948574F4E6452305952654C564D316B7876342F4374694A717349336C35"))
+	if ok, err := Compare(Declared{Plugin: PluginCachingSHA2, Cleartext: "password"}, stored); err != nil || !ok {
+		t.Errorf("expected match; ok=%v err=%v", ok, err)
+	}
+	if ok, _ := Compare(Declared{Plugin: PluginCachingSHA2, Cleartext: "wrong"}, stored); ok {
+		t.Error("expected non-match for wrong cleartext")
+	}
+}
+
+// TestCompare_MalformedStoredHashErrors asserts unparseable stored
+// strings produce an error (not a silent mismatch). Gives operators a
+// clear signal when the server state is corrupt.
+func TestCompare_MalformedStoredHashErrors(t *testing.T) {
+	decl := Declared{Plugin: PluginCachingSHA2, Cleartext: "pw"}
+	if _, err := Compare(decl, "not a valid hash"); err == nil {
+		t.Error("expected error on malformed stored hash")
+	}
+}


### PR DESCRIPTION
## Summary
Ties the two hash algorithms (#166, #167) into a single comparison surface.

- Plugin constants for the three DCL-facing `auth_plugin` values: `caching_sha2_password`, `mysql_native_password`, `aws_iam`.
- `Declared` struct captures the password-side of a `mysql_user`: plugin + cleartext or pre-hashed.
- `ValidateDeclared` enforces ADR 0010's invariants at validate time: `aws_iam` takes neither; the password plugins require exactly one; unsupported plugins (LDAP, PAM, Kerberos, sha256_password) produce a "not supported in this release" diagnostic.
- `Compare(declared, stored) (bool, error)` dispatches by plugin:
  - `aws_iam` → always matches (no local authentication_string to diff).
  - `password_hash` set → byte-compare declared to stored.
  - Cleartext + `caching_sha2_password` → parse salt from stored, recompute, byte-compare.
  - Cleartext + `mysql_native_password` → recompute via double-SHA1, byte-compare.
- Malformed stored input returns an error so operators see corruption instead of a silent mismatch.

## Test plan
- [x] 13 `ValidateDeclared` subcases cover every valid shape and every rejection path.
- [x] `Compare` tests cover: aws_iam-always-matches, password_hash byte compare (match and mismatch), native cleartext rehash, caching_sha2 cleartext rehash (reuses the `#167` ground-truth fixture to cross-check dispatch wiring), malformed-stored-error.
- [x] `go test ./... -count=1` all packages pass.
- [x] `go vet ./providers/mysql/auth/...` clean.

Phase 20 complete with this PR — the phase 23 user handler now has a ready `auth.Compare` / `auth.ValidateDeclared` surface to call.

Closes #168