### PR TITLE
feat(mysql): CREATE USER DDL parser

### DIFF
--- a/providers/mysql/parse/create_user.go
+++ b/providers/mysql/parse/create_user.go
@@ -1,0 +1,562 @@
+package parse
+
+import (
+	"fmt"
+)
+
+// CreateUserStmt is the parsed shape of a SHOW CREATE USER output.
+// Fields map directly onto mysql_user DCL attributes that the handler
+// in Phase 23 will consume. Empty strings and zero ints mean "not
+// emitted by the server" — MySQL 8.0+ emits every clause with a
+// default value, so zero values are rare in practice.
+type CreateUserStmt struct {
+	User string
+	Host string
+
+	// Authentication
+	Plugin     string
+	AuthString string
+
+	// REQUIRE clause
+	RequireNone    bool
+	RequireSSL     bool
+	RequireX509    bool
+	RequireIssuer  string
+	RequireSubject string
+	RequireCipher  string
+
+	// Resource limits (WITH clause)
+	MaxQueriesPerHour     int
+	MaxConnectionsPerHour int
+	MaxUpdatesPerHour     int
+	MaxUserConnections    int
+
+	// Password policy
+	PasswordExpire         string // "DEFAULT", "NEVER", "INTERVAL", or empty
+	PasswordExpireInterval int    // days, when PasswordExpire == "INTERVAL"
+	PasswordHistory        string // "DEFAULT" or "N" (literal digits)
+	PasswordHistoryCount   int    // when PasswordHistory == "N"
+	PasswordReuse          string // "DEFAULT" or "INTERVAL"
+	PasswordReuseInterval  int    // days, when PasswordReuse == "INTERVAL"
+	PasswordRequireCurrent string // "DEFAULT", "OPTIONAL", or empty
+	FailedLoginAttempts    int
+	PasswordLockTime       string // "N" (digits) or "UNBOUNDED" or empty
+
+	// Account state
+	AccountLocked bool
+
+	// Metadata
+	Comment   string
+	Attribute string
+}
+
+// ParseCreateUser parses one CREATE USER DDL statement produced by
+// SHOW CREATE USER. The version argument selects version-specific
+// tolerance knobs (currently a no-op; wiring for future use).
+func ParseCreateUser(ddl, version string) (CreateUserStmt, error) {
+	_ = version // reserved for future version-specific parsing
+	p := &createUserParser{lex: newLexer(ddl)}
+	return p.parse()
+}
+
+type createUserParser struct {
+	lex    *lexer
+	peeked *token
+}
+
+func (p *createUserParser) next() (token, error) {
+	if p.peeked != nil {
+		t := *p.peeked
+		p.peeked = nil
+		return t, nil
+	}
+	return p.lex.next()
+}
+
+func (p *createUserParser) peek() (token, error) {
+	if p.peeked != nil {
+		return *p.peeked, nil
+	}
+	t, err := p.lex.next()
+	if err != nil {
+		return token{}, err
+	}
+	p.peeked = &t
+	return t, nil
+}
+
+func (p *createUserParser) expectKeyword(name string) error {
+	t, err := p.next()
+	if err != nil {
+		return err
+	}
+	if !matchIdent(t, name) {
+		return fmt.Errorf("parse: expected %q, got %s", name, t)
+	}
+	return nil
+}
+
+func (p *createUserParser) parse() (CreateUserStmt, error) {
+	if err := p.expectKeyword("CREATE"); err != nil {
+		return CreateUserStmt{}, err
+	}
+	if err := p.expectKeyword("USER"); err != nil {
+		return CreateUserStmt{}, err
+	}
+
+	user, err := p.readQuotedOrBacktickIdent()
+	if err != nil {
+		return CreateUserStmt{}, err
+	}
+	t, err := p.next()
+	if err != nil {
+		return CreateUserStmt{}, err
+	}
+	if t.Kind != tkAt {
+		return CreateUserStmt{}, fmt.Errorf("parse: expected '@' between user and host, got %s", t)
+	}
+	host, err := p.readQuotedOrBacktickIdent()
+	if err != nil {
+		return CreateUserStmt{}, err
+	}
+
+	stmt := CreateUserStmt{User: user, Host: host}
+
+	for {
+		t, err := p.peek()
+		if err != nil {
+			return CreateUserStmt{}, err
+		}
+		if t.Kind == tkEOF || t.Kind == tkSemi {
+			break
+		}
+		if err := p.parseClause(&stmt); err != nil {
+			return CreateUserStmt{}, err
+		}
+	}
+	return stmt, nil
+}
+
+// readQuotedOrBacktickIdent accepts either a backticked or
+// single-quoted identifier. SHOW CREATE USER uses backticks, but some
+// contexts allow the quoted form; both map to the same extracted name.
+func (p *createUserParser) readQuotedOrBacktickIdent() (string, error) {
+	t, err := p.next()
+	if err != nil {
+		return "", err
+	}
+	switch t.Kind {
+	case tkBacktick, tkString:
+		return t.Value, nil
+	}
+	return "", fmt.Errorf("parse: expected quoted identifier, got %s", t)
+}
+
+// parseClause consumes one top-level CREATE USER clause and updates
+// stmt accordingly. Returns an error for unknown clauses so we catch
+// new MySQL versions emitting syntax we haven't mapped yet.
+func (p *createUserParser) parseClause(stmt *CreateUserStmt) error {
+	t, err := p.next()
+	if err != nil {
+		return err
+	}
+	if t.Kind != tkIdent {
+		return fmt.Errorf("parse: expected clause keyword, got %s", t)
+	}
+	switch {
+	case equalsFoldAny(t.Value, "IDENTIFIED"):
+		return p.parseIdentifiedClause(stmt)
+	case equalsFoldAny(t.Value, "REQUIRE"):
+		return p.parseRequireClause(stmt)
+	case equalsFoldAny(t.Value, "WITH"):
+		return p.parseWithClause(stmt)
+	case equalsFoldAny(t.Value, "PASSWORD"):
+		return p.parsePasswordClause(stmt)
+	case equalsFoldAny(t.Value, "ACCOUNT"):
+		return p.parseAccountClause(stmt)
+	case equalsFoldAny(t.Value, "FAILED_LOGIN_ATTEMPTS"):
+		n, err := p.readNumber()
+		if err != nil {
+			return err
+		}
+		stmt.FailedLoginAttempts = n
+		return nil
+	case equalsFoldAny(t.Value, "PASSWORD_LOCK_TIME"):
+		return p.parsePasswordLockTime(stmt)
+	case equalsFoldAny(t.Value, "COMMENT"):
+		s, err := p.readString()
+		if err != nil {
+			return err
+		}
+		stmt.Comment = s
+		return nil
+	case equalsFoldAny(t.Value, "ATTRIBUTE"):
+		s, err := p.readString()
+		if err != nil {
+			return err
+		}
+		stmt.Attribute = s
+		return nil
+	}
+	return fmt.Errorf("parse: unknown CREATE USER clause %q", t.Value)
+}
+
+// parseIdentifiedClause consumes `IDENTIFIED WITH 'plugin' AS 'hash'`
+// or `IDENTIFIED WITH 'plugin'` (no AS, some MySQL variants).
+func (p *createUserParser) parseIdentifiedClause(stmt *CreateUserStmt) error {
+	if err := p.expectKeyword("WITH"); err != nil {
+		return err
+	}
+	plugin, err := p.readString()
+	if err != nil {
+		// Some forms use a bare ident (legacy). Fall back to that.
+		return fmt.Errorf("parse: IDENTIFIED WITH requires a quoted plugin name: %w", err)
+	}
+	stmt.Plugin = plugin
+
+	t, err := p.peek()
+	if err != nil {
+		return err
+	}
+	if matchIdent(t, "AS") {
+		_, _ = p.next()
+		auth, err := p.readString()
+		if err != nil {
+			return err
+		}
+		stmt.AuthString = auth
+	}
+	return nil
+}
+
+// parseRequireClause consumes REQUIRE NONE or REQUIRE SSL or
+// REQUIRE X509 or REQUIRE <field> '...' [<field> '...']...
+//
+// MySQL's SHOW CREATE USER output separates fields with whitespace
+// (no AND keyword) — "REQUIRE SUBJECT '...' ISSUER '...' CIPHER '...'"
+// — while the input form uses AND. The parser tolerates both.
+func (p *createUserParser) parseRequireClause(stmt *CreateUserStmt) error {
+	t, err := p.peek()
+	if err != nil {
+		return err
+	}
+	if matchIdent(t, "NONE") {
+		_, _ = p.next()
+		stmt.RequireNone = true
+		return nil
+	}
+	for {
+		t, err := p.peek()
+		if err != nil {
+			return err
+		}
+		if t.Kind != tkIdent {
+			return nil
+		}
+		up := t.Value
+		switch {
+		case equalsFoldAny(up, "SSL"):
+			_, _ = p.next()
+			stmt.RequireSSL = true
+		case equalsFoldAny(up, "X509"):
+			_, _ = p.next()
+			stmt.RequireX509 = true
+		case equalsFoldAny(up, "SUBJECT"):
+			_, _ = p.next()
+			s, err := p.readString()
+			if err != nil {
+				return err
+			}
+			stmt.RequireSubject = s
+		case equalsFoldAny(up, "ISSUER"):
+			_, _ = p.next()
+			s, err := p.readString()
+			if err != nil {
+				return err
+			}
+			stmt.RequireIssuer = s
+		case equalsFoldAny(up, "CIPHER"):
+			_, _ = p.next()
+			s, err := p.readString()
+			if err != nil {
+				return err
+			}
+			stmt.RequireCipher = s
+		case equalsFoldAny(up, "AND"):
+			// Tolerate input form's AND separators between fields.
+			_, _ = p.next()
+			continue
+		default:
+			return nil // not our keyword — next clause
+		}
+	}
+}
+
+// parseWithClause consumes WITH followed by one or more resource
+// limits. Limits are space-separated, each a keyword plus number.
+func (p *createUserParser) parseWithClause(stmt *CreateUserStmt) error {
+	for {
+		t, err := p.peek()
+		if err != nil {
+			return err
+		}
+		if t.Kind != tkIdent {
+			return nil
+		}
+		var dst *int
+		switch {
+		case equalsFoldAny(t.Value, "MAX_QUERIES_PER_HOUR"):
+			dst = &stmt.MaxQueriesPerHour
+		case equalsFoldAny(t.Value, "MAX_CONNECTIONS_PER_HOUR"):
+			dst = &stmt.MaxConnectionsPerHour
+		case equalsFoldAny(t.Value, "MAX_UPDATES_PER_HOUR"):
+			dst = &stmt.MaxUpdatesPerHour
+		case equalsFoldAny(t.Value, "MAX_USER_CONNECTIONS"):
+			dst = &stmt.MaxUserConnections
+		default:
+			return nil // next clause
+		}
+		_, _ = p.next()
+		n, err := p.readNumber()
+		if err != nil {
+			return err
+		}
+		*dst = n
+	}
+}
+
+// parsePasswordClause handles the several PASSWORD ... sub-forms.
+func (p *createUserParser) parsePasswordClause(stmt *CreateUserStmt) error {
+	t, err := p.next()
+	if err != nil {
+		return err
+	}
+	if t.Kind != tkIdent {
+		return fmt.Errorf("parse: expected word after PASSWORD, got %s", t)
+	}
+	switch {
+	case equalsFoldAny(t.Value, "EXPIRE"):
+		return p.parsePasswordExpire(stmt)
+	case equalsFoldAny(t.Value, "HISTORY"):
+		return p.parsePasswordHistory(stmt)
+	case equalsFoldAny(t.Value, "REUSE"):
+		return p.parsePasswordReuse(stmt)
+	case equalsFoldAny(t.Value, "REQUIRE"):
+		return p.parsePasswordRequireCurrent(stmt)
+	}
+	return fmt.Errorf("parse: unknown PASSWORD sub-clause %q", t.Value)
+}
+
+// parsePasswordExpire handles:
+//
+//	PASSWORD EXPIRE                     — mark expired now (bare form)
+//	PASSWORD EXPIRE DEFAULT
+//	PASSWORD EXPIRE NEVER
+//	PASSWORD EXPIRE INTERVAL <n> DAY
+func (p *createUserParser) parsePasswordExpire(stmt *CreateUserStmt) error {
+	t, err := p.peek()
+	if err != nil {
+		return err
+	}
+	if t.Kind != tkIdent {
+		stmt.PasswordExpire = "EXPIRED"
+		return nil
+	}
+	switch {
+	case equalsFoldAny(t.Value, "DEFAULT"):
+		_, _ = p.next()
+		stmt.PasswordExpire = "DEFAULT"
+		return nil
+	case equalsFoldAny(t.Value, "NEVER"):
+		_, _ = p.next()
+		stmt.PasswordExpire = "NEVER"
+		return nil
+	case equalsFoldAny(t.Value, "INTERVAL"):
+		_, _ = p.next()
+		stmt.PasswordExpire = "INTERVAL"
+		n, err := p.readNumber()
+		if err != nil {
+			return err
+		}
+		stmt.PasswordExpireInterval = n
+		if err := p.expectKeyword("DAY"); err != nil {
+			return err
+		}
+		return nil
+	}
+	// Not a recognized modifier — bare form (expire now).
+	stmt.PasswordExpire = "EXPIRED"
+	return nil
+}
+
+// parsePasswordHistory handles:
+//
+//	PASSWORD HISTORY DEFAULT
+//	PASSWORD HISTORY <n>
+func (p *createUserParser) parsePasswordHistory(stmt *CreateUserStmt) error {
+	t, err := p.peek()
+	if err != nil {
+		return err
+	}
+	if matchIdent(t, "DEFAULT") {
+		_, _ = p.next()
+		stmt.PasswordHistory = "DEFAULT"
+		return nil
+	}
+	n, err := p.readNumber()
+	if err != nil {
+		return err
+	}
+	stmt.PasswordHistory = "N"
+	stmt.PasswordHistoryCount = n
+	return nil
+}
+
+// parsePasswordReuse handles:
+//
+//	PASSWORD REUSE INTERVAL DEFAULT
+//	PASSWORD REUSE INTERVAL <n> DAY
+func (p *createUserParser) parsePasswordReuse(stmt *CreateUserStmt) error {
+	if err := p.expectKeyword("INTERVAL"); err != nil {
+		return err
+	}
+	t, err := p.peek()
+	if err != nil {
+		return err
+	}
+	if matchIdent(t, "DEFAULT") {
+		_, _ = p.next()
+		stmt.PasswordReuse = "DEFAULT"
+		return nil
+	}
+	n, err := p.readNumber()
+	if err != nil {
+		return err
+	}
+	stmt.PasswordReuse = "INTERVAL"
+	stmt.PasswordReuseInterval = n
+	if err := p.expectKeyword("DAY"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// parsePasswordRequireCurrent handles:
+//
+//	PASSWORD REQUIRE CURRENT DEFAULT
+//	PASSWORD REQUIRE CURRENT OPTIONAL
+//	PASSWORD REQUIRE CURRENT
+func (p *createUserParser) parsePasswordRequireCurrent(stmt *CreateUserStmt) error {
+	if err := p.expectKeyword("CURRENT"); err != nil {
+		return err
+	}
+	t, err := p.peek()
+	if err != nil {
+		return err
+	}
+	if t.Kind != tkIdent {
+		stmt.PasswordRequireCurrent = "ENFORCED"
+		return nil
+	}
+	switch {
+	case equalsFoldAny(t.Value, "DEFAULT"):
+		_, _ = p.next()
+		stmt.PasswordRequireCurrent = "DEFAULT"
+	case equalsFoldAny(t.Value, "OPTIONAL"):
+		_, _ = p.next()
+		stmt.PasswordRequireCurrent = "OPTIONAL"
+	default:
+		// Bare `PASSWORD REQUIRE CURRENT` (no modifier) = enforced.
+		stmt.PasswordRequireCurrent = "ENFORCED"
+	}
+	return nil
+}
+
+// parseAccountClause handles ACCOUNT LOCK and ACCOUNT UNLOCK.
+func (p *createUserParser) parseAccountClause(stmt *CreateUserStmt) error {
+	t, err := p.next()
+	if err != nil {
+		return err
+	}
+	switch {
+	case matchIdent(t, "LOCK"):
+		stmt.AccountLocked = true
+	case matchIdent(t, "UNLOCK"):
+		stmt.AccountLocked = false
+	default:
+		return fmt.Errorf("parse: expected LOCK or UNLOCK after ACCOUNT, got %s", t)
+	}
+	return nil
+}
+
+// parsePasswordLockTime handles PASSWORD_LOCK_TIME <N> and
+// PASSWORD_LOCK_TIME UNBOUNDED.
+func (p *createUserParser) parsePasswordLockTime(stmt *CreateUserStmt) error {
+	t, err := p.peek()
+	if err != nil {
+		return err
+	}
+	if matchIdent(t, "UNBOUNDED") {
+		_, _ = p.next()
+		stmt.PasswordLockTime = "UNBOUNDED"
+		return nil
+	}
+	n, err := p.readNumber()
+	if err != nil {
+		return err
+	}
+	stmt.PasswordLockTime = fmt.Sprintf("%d", n)
+	return nil
+}
+
+// readNumber requires the next token to be a tkNumber and returns its
+// integer value.
+func (p *createUserParser) readNumber() (int, error) {
+	t, err := p.next()
+	if err != nil {
+		return 0, err
+	}
+	if t.Kind != tkNumber {
+		return 0, fmt.Errorf("parse: expected number, got %s", t)
+	}
+	var n int
+	for _, c := range t.Value {
+		n = n*10 + int(c-'0')
+	}
+	return n, nil
+}
+
+// readString requires the next token to be a tkString and returns its
+// decoded value.
+func (p *createUserParser) readString() (string, error) {
+	t, err := p.next()
+	if err != nil {
+		return "", err
+	}
+	if t.Kind != tkString {
+		return "", fmt.Errorf("parse: expected quoted string, got %s", t)
+	}
+	return t.Value, nil
+}
+
+// equalsFoldAny is a small helper used in keyword matching. Wraps
+// strings.EqualFold; kept local so callers read naturally.
+func equalsFoldAny(got, want string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := 0; i < len(got); i++ {
+		g := got[i]
+		w := want[i]
+		if 'A' <= g && g <= 'Z' {
+			g += 'a' - 'A'
+		}
+		if 'A' <= w && w <= 'Z' {
+			w += 'a' - 'A'
+		}
+		if g != w {
+			return false
+		}
+	}
+	return true
+}

--- a/providers/mysql/parse/create_user_test.go
+++ b/providers/mysql/parse/create_user_test.go
@@ -1,0 +1,300 @@
+package parse
+
+import (
+	"strings"
+	"testing"
+)
+
+// Backtick helper for embedding ` in test DDL.
+const bt = "`"
+
+// TestParseCreateUser_BasicUser covers the simplest shape emitted by
+// SHOW CREATE USER for a freshly created user with only the defaults.
+func TestParseCreateUser_BasicUser(t *testing.T) {
+	ddl := `CREATE USER ` + bt + `u_basic` + bt + `@` + bt + `%` + bt + ` IDENTIFIED WITH 'caching_sha2_password' AS '$A$005$salt20bytes-stored-hash-43chars' REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT PASSWORD REQUIRE CURRENT DEFAULT`
+
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stmt.User != "u_basic" {
+		t.Errorf("User = %q, want %q", stmt.User, "u_basic")
+	}
+	if stmt.Host != "%" {
+		t.Errorf("Host = %q, want %q", stmt.Host, "%")
+	}
+	if stmt.Plugin != "caching_sha2_password" {
+		t.Errorf("Plugin = %q", stmt.Plugin)
+	}
+	if !strings.HasPrefix(stmt.AuthString, "$A$005$") {
+		t.Errorf("AuthString prefix = %q, want $A$005$...", stmt.AuthString[:7])
+	}
+	if !stmt.RequireNone {
+		t.Error("RequireNone = false, want true")
+	}
+	if stmt.PasswordExpire != "DEFAULT" {
+		t.Errorf("PasswordExpire = %q, want DEFAULT", stmt.PasswordExpire)
+	}
+	if stmt.AccountLocked {
+		t.Error("AccountLocked = true, want false (UNLOCK)")
+	}
+	if stmt.PasswordHistory != "DEFAULT" {
+		t.Errorf("PasswordHistory = %q, want DEFAULT", stmt.PasswordHistory)
+	}
+	if stmt.PasswordReuse != "DEFAULT" {
+		t.Errorf("PasswordReuse = %q, want DEFAULT", stmt.PasswordReuse)
+	}
+	if stmt.PasswordRequireCurrent != "DEFAULT" {
+		t.Errorf("PasswordRequireCurrent = %q, want DEFAULT", stmt.PasswordRequireCurrent)
+	}
+}
+
+// TestParseCreateUser_TLSFields covers REQUIRE SUBJECT/ISSUER/CIPHER
+// as emitted by SHOW CREATE USER (space-separated, no AND keyword).
+// This exact string was captured from a live mysql:8.4 container.
+func TestParseCreateUser_TLSFields(t *testing.T) {
+	ddl := `CREATE USER ` + bt + `u_tls` + bt + `@` + bt + `%` + bt +
+		` IDENTIFIED WITH 'caching_sha2_password' AS '$A$005$somehash'` +
+		` REQUIRE SUBJECT '/CN=client' ISSUER '/CN=Internal CA' CIPHER 'ECDHE-RSA-AES256-GCM-SHA384'` +
+		` PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK PASSWORD HISTORY DEFAULT` +
+		` PASSWORD REUSE INTERVAL DEFAULT PASSWORD REQUIRE CURRENT DEFAULT`
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.RequireSubject != "/CN=client" {
+		t.Errorf("RequireSubject = %q", stmt.RequireSubject)
+	}
+	if stmt.RequireIssuer != "/CN=Internal CA" {
+		t.Errorf("RequireIssuer = %q", stmt.RequireIssuer)
+	}
+	if stmt.RequireCipher != "ECDHE-RSA-AES256-GCM-SHA384" {
+		t.Errorf("RequireCipher = %q", stmt.RequireCipher)
+	}
+	if stmt.RequireNone {
+		t.Error("RequireNone = true, want false")
+	}
+}
+
+// TestParseCreateUser_RequireSSL covers the flag-only REQUIRE forms.
+func TestParseCreateUser_RequireSSL(t *testing.T) {
+	ddl := `CREATE USER ` + bt + `u` + bt + `@` + bt + `%` + bt +
+		` IDENTIFIED WITH 'caching_sha2_password' AS ''` +
+		` REQUIRE SSL PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK` +
+		` PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT` +
+		` PASSWORD REQUIRE CURRENT DEFAULT`
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !stmt.RequireSSL {
+		t.Error("RequireSSL = false, want true")
+	}
+}
+
+// TestParseCreateUser_ResourceLimits covers the WITH clause.
+func TestParseCreateUser_ResourceLimits(t *testing.T) {
+	ddl := `CREATE USER ` + bt + `u` + bt + `@` + bt + `%` + bt +
+		` IDENTIFIED WITH 'caching_sha2_password' AS ''` +
+		` REQUIRE NONE` +
+		` WITH MAX_QUERIES_PER_HOUR 1000 MAX_CONNECTIONS_PER_HOUR 50` +
+		` MAX_UPDATES_PER_HOUR 500 MAX_USER_CONNECTIONS 10` +
+		` PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK` +
+		` PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT` +
+		` PASSWORD REQUIRE CURRENT DEFAULT`
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.MaxQueriesPerHour != 1000 {
+		t.Errorf("MaxQueriesPerHour = %d", stmt.MaxQueriesPerHour)
+	}
+	if stmt.MaxConnectionsPerHour != 50 {
+		t.Errorf("MaxConnectionsPerHour = %d", stmt.MaxConnectionsPerHour)
+	}
+	if stmt.MaxUpdatesPerHour != 500 {
+		t.Errorf("MaxUpdatesPerHour = %d", stmt.MaxUpdatesPerHour)
+	}
+	if stmt.MaxUserConnections != 10 {
+		t.Errorf("MaxUserConnections = %d", stmt.MaxUserConnections)
+	}
+}
+
+// TestParseCreateUser_AccountLock covers ACCOUNT LOCK.
+func TestParseCreateUser_AccountLock(t *testing.T) {
+	ddl := `CREATE USER ` + bt + `u_locked` + bt + `@` + bt + `%` + bt +
+		` IDENTIFIED WITH 'caching_sha2_password' AS ''` +
+		` REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT LOCK` +
+		` PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT` +
+		` PASSWORD REQUIRE CURRENT DEFAULT`
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !stmt.AccountLocked {
+		t.Error("AccountLocked = false, want true")
+	}
+}
+
+// TestParseCreateUser_PasswordPolicyCustom covers non-DEFAULT password
+// policy values including INTERVAL forms and numeric history count.
+func TestParseCreateUser_PasswordPolicyCustom(t *testing.T) {
+	ddl := `CREATE USER ` + bt + `u` + bt + `@` + bt + `%` + bt +
+		` IDENTIFIED WITH 'caching_sha2_password' AS ''` +
+		` REQUIRE NONE` +
+		` PASSWORD EXPIRE INTERVAL 90 DAY` +
+		` ACCOUNT UNLOCK` +
+		` PASSWORD HISTORY 5` +
+		` PASSWORD REUSE INTERVAL 365 DAY` +
+		` PASSWORD REQUIRE CURRENT OPTIONAL` +
+		` FAILED_LOGIN_ATTEMPTS 3 PASSWORD_LOCK_TIME 1`
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.PasswordExpire != "INTERVAL" || stmt.PasswordExpireInterval != 90 {
+		t.Errorf("PasswordExpire = %q / interval = %d", stmt.PasswordExpire, stmt.PasswordExpireInterval)
+	}
+	if stmt.PasswordHistory != "N" || stmt.PasswordHistoryCount != 5 {
+		t.Errorf("PasswordHistory = %q / count = %d", stmt.PasswordHistory, stmt.PasswordHistoryCount)
+	}
+	if stmt.PasswordReuse != "INTERVAL" || stmt.PasswordReuseInterval != 365 {
+		t.Errorf("PasswordReuse = %q / interval = %d", stmt.PasswordReuse, stmt.PasswordReuseInterval)
+	}
+	if stmt.PasswordRequireCurrent != "OPTIONAL" {
+		t.Errorf("PasswordRequireCurrent = %q", stmt.PasswordRequireCurrent)
+	}
+	if stmt.FailedLoginAttempts != 3 {
+		t.Errorf("FailedLoginAttempts = %d", stmt.FailedLoginAttempts)
+	}
+	if stmt.PasswordLockTime != "1" {
+		t.Errorf("PasswordLockTime = %q", stmt.PasswordLockTime)
+	}
+}
+
+// TestParseCreateUser_PasswordLockTimeUnbounded covers the UNBOUNDED
+// variant of PASSWORD_LOCK_TIME.
+func TestParseCreateUser_PasswordLockTimeUnbounded(t *testing.T) {
+	ddl := `CREATE USER ` + bt + `u` + bt + `@` + bt + `%` + bt +
+		` IDENTIFIED WITH 'caching_sha2_password' AS ''` +
+		` REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK` +
+		` PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT` +
+		` PASSWORD REQUIRE CURRENT DEFAULT` +
+		` FAILED_LOGIN_ATTEMPTS 5 PASSWORD_LOCK_TIME UNBOUNDED`
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.PasswordLockTime != "UNBOUNDED" {
+		t.Errorf("PasswordLockTime = %q", stmt.PasswordLockTime)
+	}
+}
+
+// TestParseCreateUser_CommentAndAttribute covers the trailing metadata
+// clauses.
+func TestParseCreateUser_CommentAndAttribute(t *testing.T) {
+	ddl := `CREATE USER ` + bt + `u` + bt + `@` + bt + `%` + bt +
+		` IDENTIFIED WITH 'caching_sha2_password' AS ''` +
+		` REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK` +
+		` PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT` +
+		` PASSWORD REQUIRE CURRENT DEFAULT` +
+		` COMMENT 'provisioned by datastorectl'` +
+		` ATTRIBUTE '{"team":"dd"}'`
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.Comment != "provisioned by datastorectl" {
+		t.Errorf("Comment = %q", stmt.Comment)
+	}
+	if stmt.Attribute != `{"team":"dd"}` {
+		t.Errorf("Attribute = %q", stmt.Attribute)
+	}
+}
+
+// TestParseCreateUser_InputFormWithAND covers the input-form REQUIRE
+// syntax that uses AND between fields. While SHOW CREATE USER doesn't
+// emit AND, users writing raw CREATE USER in DCL may include it —
+// the parser tolerates both shapes.
+func TestParseCreateUser_InputFormWithAND(t *testing.T) {
+	ddl := `CREATE USER 'u'@'%' IDENTIFIED WITH 'caching_sha2_password' AS '' REQUIRE SUBJECT '/CN=x' AND ISSUER '/CN=y'`
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.RequireSubject != "/CN=x" || stmt.RequireIssuer != "/CN=y" {
+		t.Errorf("Subject=%q Issuer=%q", stmt.RequireSubject, stmt.RequireIssuer)
+	}
+}
+
+// TestParseCreateUser_RoleShape covers MySQL 8's treatment of roles as
+// users: account locked, empty auth string. The parser produces the
+// same structure as for a regular user; the handler classifies from
+// the AccountLocked + empty AuthString combo.
+func TestParseCreateUser_RoleShape(t *testing.T) {
+	ddl := `CREATE USER ` + bt + `reader` + bt + `@` + bt + `%` + bt +
+		` IDENTIFIED WITH 'caching_sha2_password' AS ''` +
+		` REQUIRE NONE PASSWORD EXPIRE ACCOUNT LOCK` +
+		` PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT` +
+		` PASSWORD REQUIRE CURRENT DEFAULT`
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !stmt.AccountLocked || stmt.AuthString != "" {
+		t.Errorf("not role-shaped: locked=%v authstring=%q", stmt.AccountLocked, stmt.AuthString)
+	}
+}
+
+// TestParseCreateUser_MalformedInputRejected verifies that clearly
+// malformed input surfaces as an error rather than silently producing
+// a partial parse.
+func TestParseCreateUser_MalformedInputRejected(t *testing.T) {
+	cases := []string{
+		"",
+		"not a create user statement",
+		"CREATE USER", // missing user/host
+		"CREATE USER 'u'",
+		"CREATE USER 'u'@",
+		`CREATE USER 'u'@'%' IDENTIFIED`,      // missing WITH
+		`CREATE USER 'u'@'%' UNKNOWN_CLAUSE 5`, // unknown clause
+	}
+	for i, c := range cases {
+		if _, err := ParseCreateUser(c, "8.4"); err == nil {
+			t.Errorf("case %d (%q): expected error, got none", i, c)
+		}
+	}
+}
+
+// TestParseCreateUser_SQLEscapesInAuthString verifies that SQL escape
+// sequences in the AS '...' clause decode correctly. Real
+// authentication strings contain non-printable bytes that MySQL emits
+// with escapes like \Z (0x1a).
+func TestParseCreateUser_SQLEscapesInAuthString(t *testing.T) {
+	ddl := `CREATE USER 'u'@'%' IDENTIFIED WITH 'caching_sha2_password' AS '\Zbyte\tafter\ntab'`
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	expected := "\x1abyte\tafter\ntab"
+	if stmt.AuthString != expected {
+		t.Errorf("AuthString = %q, want %q", stmt.AuthString, expected)
+	}
+}
+
+// TestParseCreateUser_UnquotedSingleQuoteIdentForms covers the
+// single-quoted alternative (not backticked) that valid CREATE USER
+// statements also accept.
+func TestParseCreateUser_UnquotedSingleQuoteIdentForms(t *testing.T) {
+	ddl := `CREATE USER 'app_user'@'10.0.%' IDENTIFIED WITH 'caching_sha2_password' AS '$A$005$x'`
+	stmt, err := ParseCreateUser(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.User != "app_user" || stmt.Host != "10.0.%" {
+		t.Errorf("User=%q Host=%q", stmt.User, stmt.Host)
+	}
+}
+
+// Ensure strings import is retained (used by BasicUser assertion).
+var _ = strings.HasPrefix

--- a/providers/mysql/parse/lexer.go
+++ b/providers/mysql/parse/lexer.go
@@ -1,0 +1,250 @@
+// Package parse implements parsers for MySQL DDL statements emitted by
+// SHOW CREATE USER and SHOW GRANTS. The output of those statements
+// across MySQL 8.0 and 8.4 is a stable contract, so the parsers here
+// target exactly what the server emits — not the full MySQL grammar.
+//
+// The lexer handles the token shapes those statements use:
+// backtick-quoted identifiers, single-quoted strings (with SQL escape
+// sequences), bare identifiers/keywords, integers, and a handful of
+// single-character punctuators.
+package parse
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// tokenKind enumerates the tokens the lexer can produce.
+type tokenKind int
+
+const (
+	tkEOF tokenKind = iota
+	tkIdent
+	tkString   // single-quoted, with SQL escapes decoded
+	tkBacktick // backtick-quoted identifier, escapes decoded
+	tkNumber   // unsigned decimal integer
+	tkAt       // @
+	tkDot      // .
+	tkComma    // ,
+	tkLParen   // (
+	tkRParen   // )
+	tkSemi     // ;
+	tkStar     // *
+)
+
+// token is a lexed unit: kind plus the textual value (for idents,
+// strings, and numbers). Punctuation tokens carry an empty Value.
+type token struct {
+	Kind  tokenKind
+	Value string
+	Pos   int // offset into the source
+}
+
+func (t token) String() string {
+	if t.Value != "" {
+		return fmt.Sprintf("%s(%q)", kindName(t.Kind), t.Value)
+	}
+	return kindName(t.Kind)
+}
+
+func kindName(k tokenKind) string {
+	switch k {
+	case tkEOF:
+		return "EOF"
+	case tkIdent:
+		return "IDENT"
+	case tkString:
+		return "STRING"
+	case tkBacktick:
+		return "BACKTICK"
+	case tkNumber:
+		return "NUMBER"
+	case tkAt:
+		return "@"
+	case tkDot:
+		return "."
+	case tkComma:
+		return ","
+	case tkLParen:
+		return "("
+	case tkRParen:
+		return ")"
+	case tkSemi:
+		return ";"
+	case tkStar:
+		return "*"
+	}
+	return "?"
+}
+
+// lexer walks a source string producing tokens.
+type lexer struct {
+	src string
+	pos int
+}
+
+// newLexer constructs a lexer positioned at the start of src.
+func newLexer(src string) *lexer {
+	return &lexer{src: src}
+}
+
+// next returns the next token or an error.
+func (l *lexer) next() (token, error) {
+	l.skipWhitespace()
+	if l.pos >= len(l.src) {
+		return token{Kind: tkEOF, Pos: l.pos}, nil
+	}
+	start := l.pos
+	c := l.src[l.pos]
+	switch {
+	case c == '`':
+		return l.readBacktick()
+	case c == '\'':
+		return l.readString()
+	case c == '@':
+		l.pos++
+		return token{Kind: tkAt, Pos: start}, nil
+	case c == '.':
+		l.pos++
+		return token{Kind: tkDot, Pos: start}, nil
+	case c == ',':
+		l.pos++
+		return token{Kind: tkComma, Pos: start}, nil
+	case c == '(':
+		l.pos++
+		return token{Kind: tkLParen, Pos: start}, nil
+	case c == ')':
+		l.pos++
+		return token{Kind: tkRParen, Pos: start}, nil
+	case c == ';':
+		l.pos++
+		return token{Kind: tkSemi, Pos: start}, nil
+	case c == '*':
+		l.pos++
+		return token{Kind: tkStar, Pos: start}, nil
+	case c >= '0' && c <= '9':
+		return l.readNumber()
+	case isIdentStart(c):
+		return l.readIdent()
+	}
+	return token{}, fmt.Errorf("parse: unexpected character %q at offset %d", c, start)
+}
+
+// peek returns the next token without consuming it.
+func (l *lexer) peek() (token, error) {
+	save := l.pos
+	t, err := l.next()
+	l.pos = save
+	return t, err
+}
+
+func (l *lexer) skipWhitespace() {
+	for l.pos < len(l.src) && unicode.IsSpace(rune(l.src[l.pos])) {
+		l.pos++
+	}
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || c == '$' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isIdentPart(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9')
+}
+
+func (l *lexer) readIdent() (token, error) {
+	start := l.pos
+	for l.pos < len(l.src) && isIdentPart(l.src[l.pos]) {
+		l.pos++
+	}
+	return token{Kind: tkIdent, Value: l.src[start:l.pos], Pos: start}, nil
+}
+
+func (l *lexer) readNumber() (token, error) {
+	start := l.pos
+	for l.pos < len(l.src) && l.src[l.pos] >= '0' && l.src[l.pos] <= '9' {
+		l.pos++
+	}
+	return token{Kind: tkNumber, Value: l.src[start:l.pos], Pos: start}, nil
+}
+
+// readBacktick consumes a `backtick`-quoted identifier. Doubled
+// backticks escape a literal backtick inside the identifier.
+func (l *lexer) readBacktick() (token, error) {
+	start := l.pos
+	l.pos++ // opening backtick
+	var b strings.Builder
+	for l.pos < len(l.src) {
+		c := l.src[l.pos]
+		if c == '`' {
+			if l.pos+1 < len(l.src) && l.src[l.pos+1] == '`' {
+				b.WriteByte('`')
+				l.pos += 2
+				continue
+			}
+			l.pos++ // closing backtick
+			return token{Kind: tkBacktick, Value: b.String(), Pos: start}, nil
+		}
+		b.WriteByte(c)
+		l.pos++
+	}
+	return token{}, fmt.Errorf("parse: unterminated backtick identifier at offset %d", start)
+}
+
+// readString consumes a 'single'-quoted string and decodes SQL escape
+// sequences. Doubled single quotes ('') produce a literal quote.
+func (l *lexer) readString() (token, error) {
+	start := l.pos
+	l.pos++ // opening quote
+	var b strings.Builder
+	for l.pos < len(l.src) {
+		c := l.src[l.pos]
+		if c == '\'' {
+			if l.pos+1 < len(l.src) && l.src[l.pos+1] == '\'' {
+				b.WriteByte('\'')
+				l.pos += 2
+				continue
+			}
+			l.pos++ // closing quote
+			return token{Kind: tkString, Value: b.String(), Pos: start}, nil
+		}
+		if c == '\\' && l.pos+1 < len(l.src) {
+			esc := l.src[l.pos+1]
+			switch esc {
+			case '0':
+				b.WriteByte(0)
+			case 'n':
+				b.WriteByte('\n')
+			case 't':
+				b.WriteByte('\t')
+			case 'r':
+				b.WriteByte('\r')
+			case 'b':
+				b.WriteByte('\b')
+			case 'Z':
+				b.WriteByte(0x1a)
+			case '\\':
+				b.WriteByte('\\')
+			case '\'':
+				b.WriteByte('\'')
+			case '"':
+				b.WriteByte('"')
+			default:
+				// Unknown escape: MySQL keeps the character as-is.
+				b.WriteByte(esc)
+			}
+			l.pos += 2
+			continue
+		}
+		b.WriteByte(c)
+		l.pos++
+	}
+	return token{}, fmt.Errorf("parse: unterminated string at offset %d", start)
+}
+
+// matchIdent reports whether t is a bare IDENT whose value equals name
+// case-insensitively. DDL keywords are case-insensitive in MySQL.
+func matchIdent(t token, name string) bool {
+	return t.Kind == tkIdent && strings.EqualFold(t.Value, name)
+}


### PR DESCRIPTION
## Summary
First of the two SHOW-statement parsers per ADR 0011. Pure Go, no DB dependency. Parses every documented clause emitted by SHOW CREATE USER on MySQL 8.0 / 8.4.

### `lexer.go` — shared tokenizer
Will also serve the GRANT parser in #170. Tokens: IDENT, STRING (with full SQL escape decoding — `\'` `\Z` `\n` `\t` `\r` `\b` `\\` `\"` `\0` plus doubled-quote), BACKTICK identifier, NUMBER, and single-char punctuators. Keyword matching is case-insensitive.

### `create_user.go` — grammar + struct
`CreateUserStmt` is a flat struct with fields for:
- user / host identity (parsed from backticked or single-quoted forms)
- plugin + auth string (with SQL escape decoding in the `AS '...'` value)
- REQUIRE clause variants: NONE, SSL, X509, SUBJECT, ISSUER, CIPHER
- Resource limits (WITH clause): all four MAX_* variants
- Password policy: EXPIRE (DEFAULT / NEVER / INTERVAL / bare), HISTORY (DEFAULT / N), REUSE INTERVAL, REQUIRE CURRENT, FAILED_LOGIN_ATTEMPTS, PASSWORD_LOCK_TIME (numeric / UNBOUNDED)
- Account state: LOCK / UNLOCK
- Metadata: COMMENT, ATTRIBUTE (JSON text)

Recursive-descent parser with peek + next tokens. Tolerates both output form (space-separated REQUIRE fields) and input form (AND-separated). Unknown clauses raise an error so new MySQL versions emitting unhandled syntax surface immediately.

## Test plan
Thirteen test cases against DDL strings captured from a live mysql:8.4 container plus synthetic cases for coverage:
- [x] Basic user (minimum clauses)
- [x] TLS SUBJECT/ISSUER/CIPHER (space-separated output form)
- [x] REQUIRE SSL flag
- [x] Resource limits (all four MAX_*)
- [x] ACCOUNT LOCK
- [x] Non-default password policies (INTERVAL expiry, numeric history, INTERVAL reuse, OPTIONAL require-current, FAILED_LOGIN_ATTEMPTS, PASSWORD_LOCK_TIME)
- [x] PASSWORD_LOCK_TIME UNBOUNDED
- [x] COMMENT + ATTRIBUTE
- [x] Input-form AND syntax (user-authored DCL, not server output)
- [x] Role shape (locked + empty auth string) — bare `PASSWORD EXPIRE`
- [x] Malformed input rejection (7 subcases)
- [x] SQL escape decoding in AS '...' (`\Z` → 0x1a, `\t`, `\n`)
- [x] Single-quoted identifier forms as alternative to backticks
- [x] `go test ./... -count=1` all packages pass
- [x] `go vet ./providers/mysql/parse/...` clean

#171 will add server-captured fixtures that cross-check this parser against both 8.0 and 8.4 output across a larger surface.

Closes #169