### PR TITLE
feat(mysql): GRANT DDL parser

### DIFF
--- a/providers/mysql/parse/grant.go
+++ b/providers/mysql/parse/grant.go
@@ -1,0 +1,333 @@
+package parse
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// GrantStmt is the parsed shape of a single GRANT DDL statement from
+// SHOW GRANTS output. Identity is the (User, Host, Database, Table)
+// tuple. Privileges are uppercased and sorted for deterministic diffs.
+type GrantStmt struct {
+	Privileges  []string // sorted, uppercased; "ALL" stands alone
+	Database    string   // "*" for global scope, or schema name
+	Table       string   // "*" for schema-level, or table name
+	User        string
+	Host        string
+	GrantOption bool
+}
+
+// ParseGrant parses a single GRANT statement. The version argument is
+// reserved for version-specific tolerance knobs; currently unused
+// (MySQL 8.0 and 8.4 emit identical GRANT syntax for the scopes we
+// support).
+func ParseGrant(ddl, version string) (GrantStmt, error) {
+	_ = version
+	p := &grantParser{lex: newLexer(ddl)}
+	return p.parse()
+}
+
+// ParseGrantLines splits the output of SHOW GRANTS FOR ... on newlines
+// and parses each line as an individual GRANT statement. Blank lines
+// and leading/trailing whitespace are tolerated. A parse error on any
+// line aborts and returns the error.
+func ParseGrantLines(output, version string) ([]GrantStmt, error) {
+	var stmts []GrantStmt
+	for i, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		stmt, err := ParseGrant(trimmed, version)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", i+1, err)
+		}
+		stmts = append(stmts, stmt)
+	}
+	return stmts, nil
+}
+
+type grantParser struct {
+	lex    *lexer
+	peeked *token
+}
+
+func (p *grantParser) next() (token, error) {
+	if p.peeked != nil {
+		t := *p.peeked
+		p.peeked = nil
+		return t, nil
+	}
+	return p.lex.next()
+}
+
+func (p *grantParser) peek() (token, error) {
+	if p.peeked != nil {
+		return *p.peeked, nil
+	}
+	t, err := p.lex.next()
+	if err != nil {
+		return token{}, err
+	}
+	p.peeked = &t
+	return t, nil
+}
+
+func (p *grantParser) expectKeyword(name string) error {
+	t, err := p.next()
+	if err != nil {
+		return err
+	}
+	if !matchIdent(t, name) {
+		return fmt.Errorf("parse: expected %q, got %s", name, t)
+	}
+	return nil
+}
+
+func (p *grantParser) parse() (GrantStmt, error) {
+	if err := p.expectKeyword("GRANT"); err != nil {
+		return GrantStmt{}, err
+	}
+
+	privs, err := p.readPrivileges()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+
+	if err := p.expectKeyword("ON"); err != nil {
+		return GrantStmt{}, err
+	}
+
+	// Reject routine scopes early with a specific diagnostic.
+	t, err := p.peek()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+	if matchIdent(t, "PROCEDURE") || matchIdent(t, "FUNCTION") {
+		return GrantStmt{}, fmt.Errorf("parse: %s-scope grants are not supported in this release", strings.ToUpper(t.Value))
+	}
+
+	db, tbl, err := p.readScope()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+
+	if err := p.expectKeyword("TO"); err != nil {
+		return GrantStmt{}, err
+	}
+
+	user, err := p.readQuotedName()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+	at, err := p.next()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+	if at.Kind != tkAt {
+		return GrantStmt{}, fmt.Errorf("parse: expected '@' between user and host, got %s", at)
+	}
+	host, err := p.readQuotedName()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+
+	stmt := GrantStmt{
+		Privileges:  privs,
+		Database:    db,
+		Table:       tbl,
+		User:        user,
+		Host:        host,
+		GrantOption: false,
+	}
+
+	// Optional WITH GRANT OPTION trailer.
+	t, err = p.peek()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+	if matchIdent(t, "WITH") {
+		_, _ = p.next()
+		if err := p.expectKeyword("GRANT"); err != nil {
+			return GrantStmt{}, fmt.Errorf("parse: WITH must be followed by GRANT OPTION: %w", err)
+		}
+		if err := p.expectKeyword("OPTION"); err != nil {
+			return GrantStmt{}, err
+		}
+		stmt.GrantOption = true
+	}
+
+	// Tolerate a trailing semicolon.
+	t, err = p.peek()
+	if err == nil && t.Kind == tkSemi {
+		_, _ = p.next()
+	}
+	// Anything else trailing is an error — surfaces drift in server output.
+	t, err = p.peek()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+	if t.Kind != tkEOF {
+		return GrantStmt{}, fmt.Errorf("parse: unexpected trailing token %s", t)
+	}
+
+	return stmt, nil
+}
+
+// readPrivileges consumes the comma-separated privilege list up to
+// (but not including) the ON keyword. Privilege names can be
+// multi-word (SHOW DATABASES, REPLICATION CLIENT, CREATE TEMPORARY
+// TABLES), so we accumulate words until we hit a comma or ON. A '('
+// after a privilege name signals a column-level grant — rejected.
+//
+// Returns a sorted, uppercased slice with "ALL PRIVILEGES" normalized
+// to "ALL" for deterministic diffs.
+func (p *grantParser) readPrivileges() ([]string, error) {
+	var privs []string
+	for {
+		name, err := p.readOnePrivilege()
+		if err != nil {
+			return nil, err
+		}
+		privs = append(privs, normalizePrivilege(name))
+		t, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if t.Kind == tkComma {
+			_, _ = p.next()
+			continue
+		}
+		// Expect ON next.
+		if matchIdent(t, "ON") {
+			break
+		}
+		return nil, fmt.Errorf("parse: expected ',' or ON after privilege list, got %s", t)
+	}
+	sort.Strings(privs)
+	return dedupe(privs), nil
+}
+
+// readOnePrivilege consumes one privilege name, which may span multiple
+// idents (e.g. "SHOW DATABASES"). Stops at ',', ON, or '(' (column-level).
+func (p *grantParser) readOnePrivilege() (string, error) {
+	var words []string
+	for {
+		t, err := p.peek()
+		if err != nil {
+			return "", err
+		}
+		if t.Kind != tkIdent {
+			if len(words) == 0 {
+				return "", fmt.Errorf("parse: expected privilege name, got %s", t)
+			}
+			return strings.Join(words, " "), nil
+		}
+		if matchIdent(t, "ON") && len(words) > 0 {
+			return strings.Join(words, " "), nil
+		}
+		_, _ = p.next()
+		words = append(words, strings.ToUpper(t.Value))
+		// Check for column-list opener after this word.
+		next, err := p.peek()
+		if err != nil {
+			return "", err
+		}
+		if next.Kind == tkLParen {
+			return "", fmt.Errorf("parse: column-level grants are not supported in this release")
+		}
+		if next.Kind == tkComma || matchIdent(next, "ON") {
+			return strings.Join(words, " "), nil
+		}
+	}
+}
+
+// normalizePrivilege collapses "ALL PRIVILEGES" to "ALL" and
+// uppercases everything.
+func normalizePrivilege(name string) string {
+	up := strings.ToUpper(strings.TrimSpace(name))
+	if up == "ALL PRIVILEGES" {
+		return "ALL"
+	}
+	return up
+}
+
+// dedupe returns the slice with consecutive duplicates removed.
+// The input must already be sorted.
+func dedupe(s []string) []string {
+	if len(s) < 2 {
+		return s
+	}
+	out := s[:1]
+	for i := 1; i < len(s); i++ {
+		if s[i] != out[len(out)-1] {
+			out = append(out, s[i])
+		}
+	}
+	return out
+}
+
+// readScope consumes the ON <db>.<table> or ON *.* portion. Returns
+// (database, table) where table == "*" for schema scope and
+// database == table == "*" for global scope.
+func (p *grantParser) readScope() (string, string, error) {
+	// Read database half (before the dot).
+	t, err := p.next()
+	if err != nil {
+		return "", "", err
+	}
+	var db string
+	switch t.Kind {
+	case tkStar:
+		db = "*"
+	case tkBacktick, tkString:
+		db = t.Value
+	case tkIdent:
+		db = t.Value
+	default:
+		return "", "", fmt.Errorf("parse: expected schema name or '*', got %s", t)
+	}
+
+	// Expect '.'
+	dot, err := p.next()
+	if err != nil {
+		return "", "", err
+	}
+	if dot.Kind != tkDot {
+		return "", "", fmt.Errorf("parse: expected '.' in scope, got %s", dot)
+	}
+
+	// Read table half (after the dot).
+	t, err = p.next()
+	if err != nil {
+		return "", "", err
+	}
+	var table string
+	switch t.Kind {
+	case tkStar:
+		table = "*"
+	case tkBacktick, tkString:
+		table = t.Value
+	case tkIdent:
+		table = t.Value
+	default:
+		return "", "", fmt.Errorf("parse: expected table name or '*', got %s", t)
+	}
+
+	return db, table, nil
+}
+
+// readQuotedName accepts a backtick-quoted or single-quoted
+// identifier (user or host name).
+func (p *grantParser) readQuotedName() (string, error) {
+	t, err := p.next()
+	if err != nil {
+		return "", err
+	}
+	switch t.Kind {
+	case tkBacktick, tkString:
+		return t.Value, nil
+	}
+	return "", fmt.Errorf("parse: expected quoted name, got %s", t)
+}

--- a/providers/mysql/parse/grant_test.go
+++ b/providers/mysql/parse/grant_test.go
@@ -1,0 +1,212 @@
+package parse
+
+import (
+	"strings"
+	"testing"
+)
+
+// Real SHOW GRANTS output captured from a live mysql:8.4 container:
+//
+//   GRANT PROCESS, REPLICATION CLIENT ON *.* TO `app`@`10.0.%`
+//   GRANT SELECT, INSERT, UPDATE, DELETE ON `appdb`.* TO `app`@`10.0.%`
+//   GRANT ALL PRIVILEGES ON `appdb`.`users` TO `app`@`10.0.%` WITH GRANT OPTION
+
+func TestParseGrant_GlobalScope(t *testing.T) {
+	stmt, err := ParseGrant("GRANT PROCESS, REPLICATION CLIENT ON *.* TO `app`@`10.0.%`", "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.User != "app" || stmt.Host != "10.0.%" {
+		t.Errorf("User=%q Host=%q", stmt.User, stmt.Host)
+	}
+	if stmt.Database != "*" || stmt.Table != "*" {
+		t.Errorf("scope = (%q, %q), want (*, *)", stmt.Database, stmt.Table)
+	}
+	wantPrivs := []string{"PROCESS", "REPLICATION CLIENT"}
+	if !equalStringSlices(stmt.Privileges, wantPrivs) {
+		t.Errorf("privileges = %v, want %v", stmt.Privileges, wantPrivs)
+	}
+	if stmt.GrantOption {
+		t.Error("GrantOption = true, want false")
+	}
+}
+
+func TestParseGrant_SchemaScope(t *testing.T) {
+	stmt, err := ParseGrant("GRANT SELECT, INSERT, UPDATE, DELETE ON `appdb`.* TO `app`@`10.0.%`", "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.Database != "appdb" || stmt.Table != "*" {
+		t.Errorf("scope = (%q, %q), want (appdb, *)", stmt.Database, stmt.Table)
+	}
+	wantPrivs := []string{"DELETE", "INSERT", "SELECT", "UPDATE"} // sorted
+	if !equalStringSlices(stmt.Privileges, wantPrivs) {
+		t.Errorf("privileges = %v, want %v (should be sorted)", stmt.Privileges, wantPrivs)
+	}
+}
+
+func TestParseGrant_TableScope(t *testing.T) {
+	stmt, err := ParseGrant("GRANT ALL PRIVILEGES ON `appdb`.`users` TO `app`@`10.0.%` WITH GRANT OPTION", "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.Database != "appdb" || stmt.Table != "users" {
+		t.Errorf("scope = (%q, %q), want (appdb, users)", stmt.Database, stmt.Table)
+	}
+	// ALL PRIVILEGES normalized to ALL
+	if !equalStringSlices(stmt.Privileges, []string{"ALL"}) {
+		t.Errorf("privileges = %v, want [ALL]", stmt.Privileges)
+	}
+	if !stmt.GrantOption {
+		t.Error("GrantOption = false, want true")
+	}
+}
+
+func TestParseGrant_AllAliasNormalizedToALL(t *testing.T) {
+	// Both ALL and ALL PRIVILEGES collapse to ["ALL"] for deterministic diffs.
+	for _, form := range []string{
+		"GRANT ALL ON `db`.* TO `u`@`%`",
+		"GRANT ALL PRIVILEGES ON `db`.* TO `u`@`%`",
+	} {
+		t.Run(form, func(t *testing.T) {
+			stmt, err := ParseGrant(form, "8.4")
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if !equalStringSlices(stmt.Privileges, []string{"ALL"}) {
+				t.Errorf("privileges = %v, want [ALL]", stmt.Privileges)
+			}
+		})
+	}
+}
+
+func TestParseGrant_PrivilegesSortedAndUppercased(t *testing.T) {
+	stmt, err := ParseGrant("GRANT update, select, insert ON `db`.* TO `u`@`%`", "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !equalStringSlices(stmt.Privileges, []string{"INSERT", "SELECT", "UPDATE"}) {
+		t.Errorf("privileges = %v, want [INSERT SELECT UPDATE]", stmt.Privileges)
+	}
+}
+
+func TestParseGrant_MultiWordPrivileges(t *testing.T) {
+	ddl := "GRANT SELECT, SHOW DATABASES, CREATE TEMPORARY TABLES, REPLICATION CLIENT ON *.* TO `u`@`%`"
+	stmt, err := ParseGrant(ddl, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"CREATE TEMPORARY TABLES", "REPLICATION CLIENT", "SELECT", "SHOW DATABASES"}
+	if !equalStringSlices(stmt.Privileges, want) {
+		t.Errorf("privileges = %v, want %v", stmt.Privileges, want)
+	}
+}
+
+func TestParseGrant_ColumnGrantRejected(t *testing.T) {
+	ddl := "GRANT SELECT (id, email) ON `db`.`users` TO `u`@`%`"
+	_, err := ParseGrant(ddl, "8.4")
+	if err == nil {
+		t.Fatal("expected error for column-level grant")
+	}
+	if !strings.Contains(err.Error(), "column") {
+		t.Errorf("error should mention column-level: %v", err)
+	}
+}
+
+func TestParseGrant_RoutineGrantsRejected(t *testing.T) {
+	cases := []string{
+		"GRANT EXECUTE ON PROCEDURE `db`.`p` TO `u`@`%`",
+		"GRANT EXECUTE ON FUNCTION `db`.`f` TO `u`@`%`",
+	}
+	for _, ddl := range cases {
+		t.Run(ddl, func(t *testing.T) {
+			_, err := ParseGrant(ddl, "8.4")
+			if err == nil {
+				t.Fatalf("expected error for routine grant: %q", ddl)
+			}
+			if !strings.Contains(err.Error(), "not supported") {
+				t.Errorf("error should mention 'not supported': %v", err)
+			}
+		})
+	}
+}
+
+func TestParseGrant_MalformedInputRejected(t *testing.T) {
+	cases := []string{
+		"",
+		"NOT A GRANT STATEMENT",
+		"GRANT",
+		"GRANT SELECT",
+		"GRANT SELECT ON",
+		"GRANT SELECT ON db.tbl",
+		"GRANT SELECT ON db.tbl TO",
+		"GRANT SELECT ON db.tbl TO user", // missing @host
+	}
+	for i, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			if _, err := ParseGrant(c, "8.4"); err == nil {
+				t.Errorf("case %d (%q): expected error", i, c)
+			}
+		})
+	}
+}
+
+func TestParseGrantLines_MultiStatement(t *testing.T) {
+	output := `GRANT PROCESS, REPLICATION CLIENT ON *.* TO ` + bt + `app` + bt + `@` + bt + `10.0.%` + bt + `
+GRANT SELECT, INSERT, UPDATE, DELETE ON ` + bt + `appdb` + bt + `.* TO ` + bt + `app` + bt + `@` + bt + `10.0.%` + bt + `
+GRANT ALL PRIVILEGES ON ` + bt + `appdb` + bt + `.` + bt + `users` + bt + ` TO ` + bt + `app` + bt + `@` + bt + `10.0.%` + bt + ` WITH GRANT OPTION`
+	stmts, err := ParseGrantLines(output, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(stmts) != 3 {
+		t.Fatalf("len(stmts) = %d, want 3", len(stmts))
+	}
+	if stmts[0].Database != "*" || stmts[0].Table != "*" {
+		t.Errorf("stmts[0] scope = (%q, %q)", stmts[0].Database, stmts[0].Table)
+	}
+	if stmts[1].Database != "appdb" || stmts[1].Table != "*" {
+		t.Errorf("stmts[1] scope = (%q, %q)", stmts[1].Database, stmts[1].Table)
+	}
+	if stmts[2].Database != "appdb" || stmts[2].Table != "users" {
+		t.Errorf("stmts[2] scope = (%q, %q)", stmts[2].Database, stmts[2].Table)
+	}
+	if !stmts[2].GrantOption {
+		t.Error("stmts[2] GrantOption = false, want true")
+	}
+}
+
+func TestParseGrantLines_TolerantOfBlankLinesAndWhitespace(t *testing.T) {
+	output := "\n\n   GRANT SELECT ON `db`.* TO `u`@`%`   \n\n   GRANT INSERT ON `db`.* TO `u`@`%`\n   "
+	stmts, err := ParseGrantLines(output, "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(stmts) != 2 {
+		t.Fatalf("len(stmts) = %d, want 2", len(stmts))
+	}
+}
+
+func TestParseGrant_SingleQuotedIdents(t *testing.T) {
+	// User-authored DCL uses single quotes instead of backticks.
+	stmt, err := ParseGrant("GRANT SELECT ON 'appdb'.* TO 'app'@'10.0.%'", "8.4")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.User != "app" || stmt.Host != "10.0.%" || stmt.Database != "appdb" {
+		t.Errorf("unexpected: user=%q host=%q db=%q", stmt.User, stmt.Host, stmt.Database)
+	}
+}
+
+// equalStringSlices compares two string slices in order.
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
Second of the two SHOW-statement parsers per ADR 0011. Reuses the lexer from #169.

### `grant.go` — parser + struct

`GrantStmt` captures the (User, Host, Database, Table) identity tuple plus privilege list and WITH GRANT OPTION flag.

- `ParseGrant(ddl, version)` — single statement.
- `ParseGrantLines(output, version)` — multi-line SHOW GRANTS output, splits on newlines, tolerates blanks.

**Scope detection:**
- `*.*` → global
- `` `db`.* `` → schema
- `` `db`.`tbl` `` → table

**Privilege normalization:**
- Multi-word names (`SHOW DATABASES`, `CREATE TEMPORARY TABLES`, `REPLICATION CLIENT`) accumulated as single tokens — stops on `,` or `ON`.
- `ALL` and `ALL PRIVILEGES` collapse to canonical `"ALL"`.
- Sorted, uppercased, deduplicated for deterministic diffs.

**Rejections with specific diagnostics:**
- Column-level grants (`GRANT SELECT (col) ON ...`) → "column-level grants are not supported in this release".
- Routine grants (`ON PROCEDURE` / `ON FUNCTION`) → "not supported in this release".
- Trailing unexpected tokens → catches server-output drift.

## Test plan
Twelve test cases, three of which use fixtures captured from live `mysql:8.4`:
- [x] Global scope (`*.*`)
- [x] Schema scope (`` `db`.* ``)
- [x] Table scope with WITH GRANT OPTION
- [x] `ALL` / `ALL PRIVILEGES` alias normalization
- [x] Privilege sort + uppercase determinism
- [x] Multi-word privileges
- [x] Column-level grant rejection
- [x] Routine grant rejection (PROCEDURE and FUNCTION)
- [x] Malformed input (8 subcases)
- [x] Multi-statement line splitting
- [x] Blank-line and whitespace tolerance
- [x] Single-quoted identifier alternative to backticks
- [x] `go test ./... -count=1` all packages pass
- [x] `go vet ./providers/mysql/...` clean

Closes #170