### PR TITLE
feat(mysql): mysql_database handler with charset and collation

### DIFF
--- a/providers/mysql/database.go
+++ b/providers/mysql/database.go
@@ -1,0 +1,166 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// databaseHandler manages mysql_database resources. A mysql_database
+// corresponds to a server-side schema created via CREATE SCHEMA. The
+// identifier comes from the DCL block label; the body carries
+// charset and collation.
+type databaseHandler struct{}
+
+// systemSchemas lists schemas the server owns and the handler must
+// never create, modify, or delete.
+var systemSchemas = map[string]bool{
+	"mysql":              true,
+	"sys":                true,
+	"performance_schema": true,
+	"information_schema": true,
+}
+
+// Validate checks the rules that don't require a server round-trip:
+// name non-empty, not a system schema, no backticks in the name.
+func (h *databaseHandler) Validate(_ context.Context, r provider.Resource) error {
+	name := r.ID.Name
+	if name == "" {
+		return fmt.Errorf("mysql_database name cannot be empty")
+	}
+	if systemSchemas[strings.ToLower(name)] {
+		return fmt.Errorf("mysql_database %q is a reserved system schema and cannot be managed", name)
+	}
+	if strings.ContainsAny(name, "`") {
+		return fmt.Errorf("mysql_database name %q contains a backtick, which is not a valid identifier character", name)
+	}
+	return nil
+}
+
+// Normalize is a no-op for mysql_database. Charset and collation come
+// back from Discover in canonical form already; no further massaging
+// is needed.
+func (h *databaseHandler) Normalize(_ context.Context, r provider.Resource) (provider.Resource, error) {
+	return r, nil
+}
+
+// Discover queries information_schema.SCHEMATA for user schemas. The
+// four system schemas are filtered out.
+func (h *databaseHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
+	rows, err := client.DB().QueryContext(ctx, `
+		SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME
+		FROM information_schema.SCHEMATA
+		WHERE SCHEMA_NAME NOT IN ('mysql','sys','performance_schema','information_schema')
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("mysql_database discover: %w", err)
+	}
+	defer rows.Close()
+
+	var out []provider.Resource
+	for rows.Next() {
+		var name, charset, collation string
+		if err := rows.Scan(&name, &charset, &collation); err != nil {
+			return nil, fmt.Errorf("mysql_database discover scan: %w", err)
+		}
+		body := provider.NewOrderedMap()
+		body.Set("charset", provider.StringVal(charset))
+		body.Set("collation", provider.StringVal(collation))
+		out = append(out, provider.Resource{
+			ID:   provider.ResourceID{Type: "mysql_database", Name: name},
+			Body: body,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("mysql_database discover iterate: %w", err)
+	}
+	return out, nil
+}
+
+// Apply executes the create/update/delete operation.
+func (h *databaseHandler) Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error {
+	switch op {
+	case provider.OpCreate:
+		return h.create(ctx, client.DB(), r)
+	case provider.OpUpdate:
+		return h.update(ctx, client.DB(), r)
+	case provider.OpDelete:
+		return h.delete(ctx, client.DB(), r)
+	}
+	return fmt.Errorf("mysql_database: unsupported operation %s", op)
+}
+
+func (h *databaseHandler) create(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	charset := getBodyString(r.Body, "charset")
+	collation := getBodyString(r.Body, "collation")
+
+	var stmt strings.Builder
+	stmt.WriteString("CREATE SCHEMA `")
+	stmt.WriteString(escapeBacktick(r.ID.Name))
+	stmt.WriteString("`")
+	if charset != "" {
+		stmt.WriteString(" DEFAULT CHARACTER SET ")
+		stmt.WriteString(charset)
+	}
+	if collation != "" {
+		stmt.WriteString(" DEFAULT COLLATE ")
+		stmt.WriteString(collation)
+	}
+	if _, err := db.ExecContext(ctx, stmt.String()); err != nil {
+		return fmt.Errorf("mysql_database create %q: %w", r.ID.Name, err)
+	}
+	return nil
+}
+
+func (h *databaseHandler) update(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	charset := getBodyString(r.Body, "charset")
+	collation := getBodyString(r.Body, "collation")
+
+	var stmt strings.Builder
+	stmt.WriteString("ALTER SCHEMA `")
+	stmt.WriteString(escapeBacktick(r.ID.Name))
+	stmt.WriteString("`")
+	if charset != "" {
+		stmt.WriteString(" DEFAULT CHARACTER SET ")
+		stmt.WriteString(charset)
+	}
+	if collation != "" {
+		stmt.WriteString(" DEFAULT COLLATE ")
+		stmt.WriteString(collation)
+	}
+	if _, err := db.ExecContext(ctx, stmt.String()); err != nil {
+		return fmt.Errorf("mysql_database update %q: %w", r.ID.Name, err)
+	}
+	return nil
+}
+
+func (h *databaseHandler) delete(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	stmt := "DROP SCHEMA `" + escapeBacktick(r.ID.Name) + "`"
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("mysql_database delete %q: %w", r.ID.Name, err)
+	}
+	return nil
+}
+
+// escapeBacktick doubles any backtick in the identifier, the MySQL
+// convention for escaping backticks inside backtick-quoted names.
+// Validate rejects backticks outright, so this is defense-in-depth.
+func escapeBacktick(s string) string {
+	return strings.ReplaceAll(s, "`", "``")
+}
+
+// getBodyString retrieves a string attribute from a resource body,
+// returning "" when absent or of the wrong kind.
+func getBodyString(m *provider.OrderedMap, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m.Get(key)
+	if !ok || v.Kind != provider.KindString {
+		return ""
+	}
+	return v.Str
+}

--- a/providers/mysql/database_test.go
+++ b/providers/mysql/database_test.go
@@ -1,0 +1,197 @@
+package mysql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// TestDatabaseHandler_Validate covers the rules that can be checked
+// without a live cluster: system-schema rejection, empty-name rejection.
+func TestDatabaseHandler_Validate(t *testing.T) {
+	h := &databaseHandler{}
+	cases := []struct {
+		name      string
+		resource  provider.Resource
+		wantErr   string
+	}{
+		{
+			name: "empty name",
+			resource: provider.Resource{
+				ID: provider.ResourceID{Type: "mysql_database", Name: ""},
+			},
+			wantErr: "name cannot be empty",
+		},
+		{
+			name: "system schema mysql",
+			resource: provider.Resource{
+				ID: provider.ResourceID{Type: "mysql_database", Name: "mysql"},
+			},
+			wantErr: "is a reserved system schema",
+		},
+		{
+			name: "system schema sys",
+			resource: provider.Resource{
+				ID: provider.ResourceID{Type: "mysql_database", Name: "sys"},
+			},
+			wantErr: "is a reserved system schema",
+		},
+		{
+			name: "system schema performance_schema",
+			resource: provider.Resource{
+				ID: provider.ResourceID{Type: "mysql_database", Name: "performance_schema"},
+			},
+			wantErr: "is a reserved system schema",
+		},
+		{
+			name: "system schema information_schema",
+			resource: provider.Resource{
+				ID: provider.ResourceID{Type: "mysql_database", Name: "information_schema"},
+			},
+			wantErr: "is a reserved system schema",
+		},
+		{
+			name: "backticks in name rejected",
+			resource: provider.Resource{
+				ID: provider.ResourceID{Type: "mysql_database", Name: "bad`name"},
+			},
+			wantErr: "backtick",
+		},
+		{
+			name: "valid name passes",
+			resource: provider.Resource{
+				ID: provider.ResourceID{Type: "mysql_database", Name: "appdb"},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := h.Validate(context.Background(), c.resource)
+			if c.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.wantErr)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+// TestDatabaseHandler_DiscoverFiltersSystemSchemas confirms the four
+// system schemas (mysql, sys, performance_schema, information_schema)
+// never appear in Discover output, regardless of what the server has.
+func TestDatabaseHandler_DiscoverFiltersSystemSchemas(t *testing.T) {
+	client := newTestClient(t)
+	h := &databaseHandler{}
+	resources, err := h.Discover(context.Background(), client)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	for _, r := range resources {
+		switch r.ID.Name {
+		case "mysql", "sys", "performance_schema", "information_schema":
+			t.Errorf("system schema %q leaked into discover output", r.ID.Name)
+		}
+	}
+}
+
+// TestDatabaseHandler_CreateDiscoverDelete exercises the full lifecycle
+// against a live cluster. Creates a schema, discovers it, modifies
+// collation, re-discovers, deletes.
+func TestDatabaseHandler_CreateDiscoverDelete(t *testing.T) {
+	client := newTestClient(t)
+	h := &databaseHandler{}
+	ctx := context.Background()
+
+	dbName := "dsctl_handler_test_db"
+	t.Cleanup(func() {
+		_, _ = client.DB().ExecContext(ctx, "DROP DATABASE IF EXISTS `"+dbName+"`")
+	})
+
+	// --- Create
+	body := provider.NewOrderedMap()
+	body.Set("charset", provider.StringVal("utf8mb4"))
+	body.Set("collation", provider.StringVal("utf8mb4_0900_ai_ci"))
+	r := provider.Resource{
+		ID:   provider.ResourceID{Type: "mysql_database", Name: dbName},
+		Body: body,
+	}
+	if err := h.Apply(ctx, client, provider.OpCreate, r); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// --- Discover finds it
+	resources, err := h.Discover(ctx, client)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	found := findByName(resources, dbName)
+	if found == nil {
+		t.Fatalf("discover did not return %q; got %d other schemas", dbName, len(resources))
+	}
+	if charset := getStringField(found.Body, "charset"); charset != "utf8mb4" {
+		t.Errorf("discovered charset = %q, want utf8mb4", charset)
+	}
+
+	// --- Update collation
+	body2 := provider.NewOrderedMap()
+	body2.Set("charset", provider.StringVal("utf8mb4"))
+	body2.Set("collation", provider.StringVal("utf8mb4_unicode_ci"))
+	r.Body = body2
+	if err := h.Apply(ctx, client, provider.OpUpdate, r); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	resources, err = h.Discover(ctx, client)
+	if err != nil {
+		t.Fatalf("re-discover: %v", err)
+	}
+	found = findByName(resources, dbName)
+	if found == nil {
+		t.Fatalf("re-discover did not return %q", dbName)
+	}
+	if coll := getStringField(found.Body, "collation"); coll != "utf8mb4_unicode_ci" {
+		t.Errorf("updated collation = %q, want utf8mb4_unicode_ci", coll)
+	}
+
+	// --- Delete
+	if err := h.Apply(ctx, client, provider.OpDelete, r); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	resources, err = h.Discover(ctx, client)
+	if err != nil {
+		t.Fatalf("post-delete discover: %v", err)
+	}
+	if findByName(resources, dbName) != nil {
+		t.Errorf("schema %q still present after delete", dbName)
+	}
+}
+
+// findByName returns a pointer to the first resource whose ID.Name
+// matches, or nil.
+func findByName(rs []provider.Resource, name string) *provider.Resource {
+	for i := range rs {
+		if rs[i].ID.Name == name {
+			return &rs[i]
+		}
+	}
+	return nil
+}
+
+// getStringField fetches a string attribute from a resource body,
+// returning "" when absent or of the wrong kind.
+func getStringField(m *provider.OrderedMap, key string) string {
+	v, ok := m.Get(key)
+	if !ok || v.Kind != provider.KindString {
+		return ""
+	}
+	return v.Str
+}

--- a/providers/mysql/handler.go
+++ b/providers/mysql/handler.go
@@ -8,12 +8,14 @@ import (
 )
 
 // resourceHandler is the internal interface each resource type implements.
-// The top-level Provider dispatches to the matching handler by resource type.
+// The top-level Provider dispatches to the matching handler by resource
+// type and threads the configured *Client into Discover and Apply
+// (the two paths that actually talk to the server).
 type resourceHandler interface {
-	Discover(ctx context.Context) ([]provider.Resource, error)
+	Discover(ctx context.Context, client *Client) ([]provider.Resource, error)
 	Normalize(ctx context.Context, r provider.Resource) (provider.Resource, error)
 	Validate(ctx context.Context, r provider.Resource) error
-	Apply(ctx context.Context, op provider.Operation, r provider.Resource) error
+	Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error
 }
 
 // schemaProvider is an optional interface a handler may implement to declare
@@ -34,7 +36,7 @@ type stubHandler struct {
 	typeName string
 }
 
-func (h *stubHandler) Discover(ctx context.Context) ([]provider.Resource, error) {
+func (h *stubHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
 	return nil, errNotImplemented
 }
 
@@ -46,6 +48,6 @@ func (h *stubHandler) Validate(ctx context.Context, r provider.Resource) error {
 	return errNotImplemented
 }
 
-func (h *stubHandler) Apply(ctx context.Context, op provider.Operation, r provider.Resource) error {
+func (h *stubHandler) Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error {
 	return errNotImplemented
 }

--- a/providers/mysql/provider.go
+++ b/providers/mysql/provider.go
@@ -37,7 +37,7 @@ func init() {
 				"mysql_user":     &stubHandler{typeName: "mysql_user"},
 				"mysql_grant":    &stubHandler{typeName: "mysql_grant"},
 				"mysql_role":     &stubHandler{typeName: "mysql_role"},
-				"mysql_database": &stubHandler{typeName: "mysql_database"},
+				"mysql_database": &databaseHandler{},
 			},
 		}
 	})
@@ -314,13 +314,13 @@ func resolveTLSField(config *provider.OrderedMap) (string, dcl.Diagnostics) {
 }
 
 // Discover iterates registered handlers and collects any discovered
-// resources. In the scaffold every handler errors, so this returns an
-// aggregated diagnostics list.
+// resources. Each handler receives the shared client configured at
+// Configure time.
 func (p *Provider) Discover(ctx context.Context) ([]provider.Resource, dcl.Diagnostics) {
 	var all []provider.Resource
 	var diags dcl.Diagnostics
 	for _, h := range p.handlers {
-		resources, err := h.Discover(ctx)
+		resources, err := h.Discover(ctx, p.client)
 		if err != nil {
 			diags = append(diags, dcl.Diagnostic{Severity: dcl.SeverityError, Message: err.Error()})
 			continue
@@ -370,7 +370,7 @@ func (p *Provider) Apply(ctx context.Context, op provider.Operation, r provider.
 			Message:  fmt.Sprintf("resource type %q is not supported by the mysql provider", r.ID.Type),
 		}}
 	}
-	if err := h.Apply(ctx, op, r); err != nil {
+	if err := h.Apply(ctx, p.client, op, r); err != nil {
 		return dcl.Diagnostics{{Severity: dcl.SeverityError, Message: err.Error()}}
 	}
 	return nil


### PR DESCRIPTION
## Summary
First concrete resource handler. Also threads the shared `*Client` into the handler interface, matching the OpenSearch pattern.

### Interface update
- `resourceHandler.Discover` and `.Apply` now take `*Client` as a parameter. `Normalize` and `Validate` stay client-free.
- `stubHandler` updated to match signature; still returns `errNotImplemented`.
- `Provider.Discover` / `Provider.Apply` pass `p.client` into handler calls.

### `databaseHandler`
- **Validate:** rejects empty names, the four system schemas (`mysql`, `sys`, `performance_schema`, `information_schema`), and names containing backticks.
- **Discover:** `information_schema.SCHEMATA` query filtered to user schemas; produces resources with `charset` and `collation` body attributes.
- **Apply:** `CREATE SCHEMA` / `ALTER SCHEMA` / `DROP SCHEMA` with `DEFAULT CHARACTER SET` and `DEFAULT COLLATE` clauses. Defensive backtick-escaping in identifiers.
- **Normalize:** no-op; server returns canonical charset/collation strings already.

Registered in place of the `mysql_database` stub in `init()`.

## Test plan
- [x] Seven `Validate` subcases: empty, four system schemas, backtick rejection, valid name.
- [x] `DiscoverFiltersSystemSchemas` confirms none of the four system schemas leak into discovery output.
- [x] `CreateDiscoverDelete` exercises the full lifecycle (create → discover → update collation → re-discover → delete). Integration test, skips when no cluster.
- [x] **End-to-end verified against a live `mysql:8.4` container** — all three integration subtests PASS.
- [x] `go test ./... -count=1` — all packages pass.
- [x] `go vet ./providers/mysql/...` clean.

Closes #172