### PR TITLE
feat(mysql): mysql_role handler with role-to-role grants via role_edges

### DIFF
--- a/providers/mysql/provider.go
+++ b/providers/mysql/provider.go
@@ -36,7 +36,7 @@ func init() {
 			handlers: map[string]resourceHandler{
 				"mysql_user":     &stubHandler{typeName: "mysql_user"},
 				"mysql_grant":    &stubHandler{typeName: "mysql_grant"},
-				"mysql_role":     &stubHandler{typeName: "mysql_role"},
+				"mysql_role":     &roleHandler{},
 				"mysql_database": &databaseHandler{},
 			},
 		}

--- a/providers/mysql/role.go
+++ b/providers/mysql/role.go
@@ -1,0 +1,257 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// roleHandler manages mysql_role resources. MySQL 8 roles are stored
+// as users with ACCOUNT LOCK and empty authentication_string. Discover
+// filters mysql.user on those two columns; role-to-role grants live in
+// mysql.role_edges.
+//
+// v0.1.0 simplification: role host is always "%". The DCL block label
+// is the role name. If users need host-specific roles later, the body
+// can grow a host attribute without breaking this handler.
+type roleHandler struct{}
+
+const roleHost = "%"
+
+// Validate covers the per-resource rules that don't need a cluster.
+// Cross-resource checks (e.g. role name colliding with a mysql_user
+// in the same config) are a future engine-level concern.
+func (h *roleHandler) Validate(_ context.Context, r provider.Resource) error {
+	name := r.ID.Name
+	if name == "" {
+		return fmt.Errorf("mysql_role name cannot be empty")
+	}
+	if strings.ContainsAny(name, "`") {
+		return fmt.Errorf("mysql_role name %q contains a backtick, which is not a valid identifier character", name)
+	}
+	return nil
+}
+
+// Normalize sorts the granted_roles list so the engine's structural
+// diff sees a deterministic order regardless of how the user wrote
+// the DCL or what order the server returned edges in.
+func (h *roleHandler) Normalize(_ context.Context, r provider.Resource) (provider.Resource, error) {
+	if r.Body == nil {
+		return r, nil
+	}
+	v, ok := r.Body.Get("granted_roles")
+	if !ok || v.Kind != provider.KindList {
+		return r, nil
+	}
+	names := make([]string, 0, len(v.List))
+	for _, e := range v.List {
+		if e.Kind == provider.KindString {
+			names = append(names, e.Str)
+		}
+	}
+	sort.Strings(names)
+	elems := make([]provider.Value, len(names))
+	for i, n := range names {
+		elems[i] = provider.StringVal(n)
+	}
+	r.Body.Set("granted_roles", provider.ListVal(elems))
+	return r, nil
+}
+
+// Discover returns every MySQL 8 role — users with account_locked = 'Y'
+// AND authentication_string = ''. For each, it joins mysql.role_edges
+// to collect role-to-role grants (FROM_USER is the granted role,
+// TO_USER is the recipient; we want edges where TO_USER is this role).
+func (h *roleHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
+	rows, err := client.DB().QueryContext(ctx, `
+		SELECT User FROM mysql.user
+		WHERE account_locked = 'Y' AND authentication_string = ''
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("mysql_role discover: %w", err)
+	}
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("mysql_role discover scan: %w", err)
+		}
+		names = append(names, name)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("mysql_role discover iterate: %w", err)
+	}
+
+	out := make([]provider.Resource, 0, len(names))
+	for _, name := range names {
+		granted, err := h.discoverGrantedRoles(ctx, client.DB(), name)
+		if err != nil {
+			return nil, err
+		}
+		body := provider.NewOrderedMap()
+		elems := make([]provider.Value, len(granted))
+		for i, g := range granted {
+			elems[i] = provider.StringVal(g)
+		}
+		body.Set("granted_roles", provider.ListVal(elems))
+		out = append(out, provider.Resource{
+			ID:   provider.ResourceID{Type: "mysql_role", Name: name},
+			Body: body,
+		})
+	}
+	return out, nil
+}
+
+// discoverGrantedRoles reads the mysql.role_edges rows where the given
+// user is the recipient. Returns the FROM_USER names sorted.
+func (h *roleHandler) discoverGrantedRoles(ctx context.Context, db *sql.DB, recipient string) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT FROM_USER FROM mysql.role_edges
+		WHERE TO_USER = ? AND TO_HOST = ?
+	`, recipient, roleHost)
+	if err != nil {
+		return nil, fmt.Errorf("mysql_role discover edges for %q: %w", recipient, err)
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("mysql_role discover edges scan: %w", err)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// Apply dispatches by operation. Create and Update each reconcile the
+// role's existence and its granted_roles. Delete drops the role —
+// MySQL cascades role_edges rows automatically.
+func (h *roleHandler) Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error {
+	switch op {
+	case provider.OpCreate:
+		return h.create(ctx, client.DB(), r)
+	case provider.OpUpdate:
+		return h.update(ctx, client.DB(), r)
+	case provider.OpDelete:
+		return h.delete(ctx, client.DB(), r)
+	}
+	return fmt.Errorf("mysql_role: unsupported operation %s", op)
+}
+
+func (h *roleHandler) create(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	stmt := fmt.Sprintf("CREATE ROLE `%s`@`%s`", escapeBacktick(r.ID.Name), roleHost)
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("mysql_role create %q: %w", r.ID.Name, err)
+	}
+	declared := declaredGrantedRoles(r)
+	for _, grant := range declared {
+		if err := h.grantRole(ctx, db, grant, r.ID.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// update reconciles granted_roles against the server. Since the role
+// itself has no other mutable fields in v0.1.0, this is entirely a
+// role_edges reconciliation: compute the set diff between declared and
+// current, then issue GRANT / REVOKE accordingly.
+func (h *roleHandler) update(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	current, err := h.discoverGrantedRoles(ctx, db, r.ID.Name)
+	if err != nil {
+		return err
+	}
+	declared := declaredGrantedRoles(r)
+
+	declaredSet := toSet(declared)
+	currentSet := toSet(current)
+
+	// To add: declared \ current.
+	for _, name := range declared {
+		if !currentSet[name] {
+			if err := h.grantRole(ctx, db, name, r.ID.Name); err != nil {
+				return err
+			}
+		}
+	}
+	// To remove: current \ declared.
+	for _, name := range current {
+		if !declaredSet[name] {
+			if err := h.revokeRole(ctx, db, name, r.ID.Name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (h *roleHandler) delete(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	stmt := fmt.Sprintf("DROP ROLE `%s`@`%s`", escapeBacktick(r.ID.Name), roleHost)
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("mysql_role delete %q: %w", r.ID.Name, err)
+	}
+	return nil
+}
+
+// grantRole runs `GRANT granted TO recipient` — makes recipient
+// inherit granted's privileges when the role is activated.
+func (h *roleHandler) grantRole(ctx context.Context, db *sql.DB, granted, recipient string) error {
+	stmt := fmt.Sprintf("GRANT `%s`@`%s` TO `%s`@`%s`",
+		escapeBacktick(granted), roleHost,
+		escapeBacktick(recipient), roleHost)
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("mysql_role grant %q to %q: %w", granted, recipient, err)
+	}
+	return nil
+}
+
+// revokeRole runs `REVOKE granted FROM recipient`.
+func (h *roleHandler) revokeRole(ctx context.Context, db *sql.DB, granted, recipient string) error {
+	stmt := fmt.Sprintf("REVOKE `%s`@`%s` FROM `%s`@`%s`",
+		escapeBacktick(granted), roleHost,
+		escapeBacktick(recipient), roleHost)
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("mysql_role revoke %q from %q: %w", granted, recipient, err)
+	}
+	return nil
+}
+
+// declaredGrantedRoles extracts the granted_roles attribute from a
+// resource body as a sorted string slice.
+func declaredGrantedRoles(r provider.Resource) []string {
+	if r.Body == nil {
+		return nil
+	}
+	v, ok := r.Body.Get("granted_roles")
+	if !ok || v.Kind != provider.KindList {
+		return nil
+	}
+	out := make([]string, 0, len(v.List))
+	for _, e := range v.List {
+		if e.Kind == provider.KindString && e.Str != "" {
+			out = append(out, e.Str)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// toSet converts a slice to a set map for O(1) membership lookups.
+func toSet(names []string) map[string]bool {
+	m := make(map[string]bool, len(names))
+	for _, n := range names {
+		m[n] = true
+	}
+	return m
+}

--- a/providers/mysql/role_test.go
+++ b/providers/mysql/role_test.go
@@ -1,0 +1,223 @@
+package mysql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// TestRoleHandler_Validate covers per-resource rules that don't need
+// a cluster: non-empty name, no backticks in name, reasonable host.
+func TestRoleHandler_Validate(t *testing.T) {
+	h := &roleHandler{}
+	cases := []struct {
+		name     string
+		resource provider.Resource
+		wantErr  string
+	}{
+		{
+			name: "empty name",
+			resource: provider.Resource{
+				ID: provider.ResourceID{Type: "mysql_role", Name: ""},
+			},
+			wantErr: "name cannot be empty",
+		},
+		{
+			name: "backtick in name",
+			resource: provider.Resource{
+				ID: provider.ResourceID{Type: "mysql_role", Name: "bad`role"},
+			},
+			wantErr: "backtick",
+		},
+		{
+			name: "valid name",
+			resource: provider.Resource{
+				ID: provider.ResourceID{Type: "mysql_role", Name: "reader"},
+			},
+		},
+		{
+			name:     "valid name with host override",
+			resource: resourceWithBody("reader", "host", "%"),
+		},
+		{
+			name:     "valid granted_roles list",
+			resource: resourceWithGrantedRoles("advanced_reader", []string{"reader", "monitor"}),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := h.Validate(context.Background(), c.resource)
+			if c.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.wantErr)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+// TestRoleHandler_CreateDiscoverDelete runs the full role lifecycle
+// against a live cluster. Creates a role, discovers it, deletes.
+func TestRoleHandler_CreateDiscoverDelete(t *testing.T) {
+	client := newTestClient(t)
+	h := &roleHandler{}
+	ctx := context.Background()
+
+	name := "dsctl_test_reader"
+	t.Cleanup(func() {
+		_, _ = client.DB().ExecContext(ctx, "DROP ROLE IF EXISTS `"+name+"`@`%`")
+	})
+
+	r := provider.Resource{
+		ID:   provider.ResourceID{Type: "mysql_role", Name: name},
+		Body: provider.NewOrderedMap(),
+	}
+	if err := h.Apply(ctx, client, provider.OpCreate, r); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	resources, err := h.Discover(ctx, client)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if findByName(resources, name) == nil {
+		t.Fatalf("discover did not return role %q", name)
+	}
+
+	if err := h.Apply(ctx, client, provider.OpDelete, r); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	resources, _ = h.Discover(ctx, client)
+	if findByName(resources, name) != nil {
+		t.Errorf("role %q still present after delete", name)
+	}
+}
+
+// TestRoleHandler_RoleToRoleGrants exercises the granted_roles path.
+// Creates two roles, grants one to the other, rediscovers, revokes.
+func TestRoleHandler_RoleToRoleGrants(t *testing.T) {
+	client := newTestClient(t)
+	h := &roleHandler{}
+	ctx := context.Background()
+
+	parent := "dsctl_test_parent_role"
+	child := "dsctl_test_child_role"
+	t.Cleanup(func() {
+		_, _ = client.DB().ExecContext(ctx, "DROP ROLE IF EXISTS `"+child+"`@`%`, `"+parent+"`@`%`")
+	})
+
+	// Create both roles, grant parent to child via child's granted_roles.
+	parentR := provider.Resource{
+		ID:   provider.ResourceID{Type: "mysql_role", Name: parent},
+		Body: provider.NewOrderedMap(),
+	}
+	if err := h.Apply(ctx, client, provider.OpCreate, parentR); err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	childR := resourceWithGrantedRoles(child, []string{parent})
+	if err := h.Apply(ctx, client, provider.OpCreate, childR); err != nil {
+		t.Fatalf("create child with granted_role: %v", err)
+	}
+
+	resources, err := h.Discover(ctx, client)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	found := findByName(resources, child)
+	if found == nil {
+		t.Fatalf("child role not found in discovery")
+	}
+	roles := getStringListField(found.Body, "granted_roles")
+	if len(roles) != 1 || roles[0] != parent {
+		t.Errorf("granted_roles = %v, want [%q]", roles, parent)
+	}
+
+	// Update child to have no granted roles (revoke).
+	childR2 := resourceWithGrantedRoles(child, nil)
+	if err := h.Apply(ctx, client, provider.OpUpdate, childR2); err != nil {
+		t.Fatalf("update child to remove grants: %v", err)
+	}
+
+	resources, _ = h.Discover(ctx, client)
+	found = findByName(resources, child)
+	if found == nil {
+		t.Fatalf("child role disappeared after update")
+	}
+	roles = getStringListField(found.Body, "granted_roles")
+	if len(roles) != 0 {
+		t.Errorf("granted_roles after revoke = %v, want empty", roles)
+	}
+}
+
+// TestRoleHandler_DiscoverIdentifiesRolesNotUsers confirms a regular
+// user account (non-locked, non-empty auth_string) is not returned as
+// a role.
+func TestRoleHandler_DiscoverIdentifiesRolesNotUsers(t *testing.T) {
+	client := newTestClient(t)
+	h := &roleHandler{}
+	ctx := context.Background()
+
+	userName := "dsctl_test_real_user"
+	createTestUser(t, client, userName, "%", "pw")
+
+	resources, err := h.Discover(ctx, client)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	for _, r := range resources {
+		if r.ID.Name == userName {
+			t.Errorf("regular user %q incorrectly classified as role", userName)
+		}
+	}
+}
+
+// resourceWithBody builds a minimal mysql_role resource with a single
+// string-valued body field.
+func resourceWithBody(name, key, value string) provider.Resource {
+	body := provider.NewOrderedMap()
+	body.Set(key, provider.StringVal(value))
+	return provider.Resource{
+		ID:   provider.ResourceID{Type: "mysql_role", Name: name},
+		Body: body,
+	}
+}
+
+// resourceWithGrantedRoles builds a mysql_role resource with a
+// granted_roles list attribute.
+func resourceWithGrantedRoles(name string, grantedRoles []string) provider.Resource {
+	body := provider.NewOrderedMap()
+	elems := make([]provider.Value, 0, len(grantedRoles))
+	for _, r := range grantedRoles {
+		elems = append(elems, provider.StringVal(r))
+	}
+	body.Set("granted_roles", provider.ListVal(elems))
+	return provider.Resource{
+		ID:   provider.ResourceID{Type: "mysql_role", Name: name},
+		Body: body,
+	}
+}
+
+// getStringListField extracts a list of strings from a resource body.
+func getStringListField(body *provider.OrderedMap, key string) []string {
+	v, ok := body.Get(key)
+	if !ok || v.Kind != provider.KindList {
+		return nil
+	}
+	out := make([]string, 0, len(v.List))
+	for _, e := range v.List {
+		if e.Kind == provider.KindString {
+			out = append(out, e.Str)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- `roleHandler` implements the full lifecycle for `mysql_role` resources.
- Discover detects MySQL 8 roles (account-locked users with empty authentication_string) and joins `mysql.role_edges` for role-to-role grants.
- Apply runs `CREATE ROLE` / `DROP ROLE` for the role itself and `GRANT <role> TO <role>` / `REVOKE <role> FROM <role>` for `granted_roles` changes.
- Normalize sorts `granted_roles` so the structural diff is deterministic.
- Registered in place of the stub in `init()`.

## Test plan
- [x] Five Validate subcases (empty, backtick, valid, valid + host, valid + granted_roles).
- [x] `DiscoverIdentifiesRolesNotUsers` — creates a password-having user and confirms it does NOT appear as a role.
- [x] `CreateDiscoverDelete` lifecycle.
- [x] `RoleToRoleGrants` — create parent, create child with `granted_roles=[parent]`, discover to confirm, update to empty list, confirm revoke.
- [x] **End-to-end verified against a live `mysql:8.4` container** — all four integration subtests PASS.
- [x] `go test ./... -count=1` clean.
- [x] `go vet ./providers/mysql/...` clean.

Closes #173