### PR TITLE
feat(mysql): mysql_user handler with full account-control attributes

### DIFF
--- a/providers/mysql/database.go
+++ b/providers/mysql/database.go
@@ -164,3 +164,25 @@ func getBodyString(m *provider.OrderedMap, key string) string {
 	}
 	return v.Str
 }
+
+// getBodyBool retrieves a bool attribute from a resource body.
+func getBodyBool(m *provider.OrderedMap, key string) bool {
+	if m == nil {
+		return false
+	}
+	v, ok := m.Get(key)
+	return ok && v.Kind == provider.KindBool && v.Bool
+}
+
+// getBodyInt retrieves an int attribute from a resource body as a
+// Go int, returning 0 when absent or not an integer kind.
+func getBodyInt(m *provider.OrderedMap, key string) int {
+	if m == nil {
+		return 0
+	}
+	v, ok := m.Get(key)
+	if !ok || v.Kind != provider.KindInt {
+		return 0
+	}
+	return int(v.Int)
+}

--- a/providers/mysql/provider.go
+++ b/providers/mysql/provider.go
@@ -34,7 +34,7 @@ func init() {
 	provider.Register("mysql", func() provider.Provider {
 		return &Provider{
 			handlers: map[string]resourceHandler{
-				"mysql_user":     &stubHandler{typeName: "mysql_user"},
+				"mysql_user":     &userHandler{},
 				"mysql_grant":    &stubHandler{typeName: "mysql_grant"},
 				"mysql_role":     &roleHandler{},
 				"mysql_database": &databaseHandler{},

--- a/providers/mysql/user.go
+++ b/providers/mysql/user.go
@@ -1,0 +1,308 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/MathewBravo/datastorectl/provider"
+	"github.com/MathewBravo/datastorectl/providers/mysql/auth"
+	"github.com/MathewBravo/datastorectl/providers/mysql/parse"
+)
+
+// userHandler manages mysql_user resources. A user is identified by
+// the (user, host) tuple. The DCL block label is a free-form handle;
+// Normalize rewrites ID.Name to "user@host" so the engine's by-ID
+// diff pairs declared and discovered resources correctly.
+type userHandler struct {
+	// version is set by the provider after Configure. Currently unused
+	// by user.go but plumbed for future version-gated parsing.
+	version string
+}
+
+// Validate covers per-resource rules that don't need a cluster:
+// required fields present, password shape valid, plugin supported.
+func (h *userHandler) Validate(_ context.Context, r provider.Resource) error {
+	user := getBodyString(r.Body, "user")
+	host := getBodyString(r.Body, "host")
+	if user == "" {
+		return fmt.Errorf("mysql_user %q: required attribute user is missing or empty", r.ID.Name)
+	}
+	if host == "" {
+		return fmt.Errorf("mysql_user %q: required attribute host is missing or empty", r.ID.Name)
+	}
+	if strings.ContainsAny(user, "`") || strings.ContainsAny(host, "`") {
+		return fmt.Errorf("mysql_user %q: user/host contains a backtick, which is not a valid identifier character", r.ID.Name)
+	}
+	plugin := getBodyString(r.Body, "auth_plugin")
+	if plugin == "" {
+		plugin = auth.PluginCachingSHA2
+	}
+	decl := auth.Declared{
+		Plugin:    plugin,
+		Cleartext: getBodyString(r.Body, "password"),
+		Hash:      getBodyString(r.Body, "password_hash"),
+	}
+	if err := auth.ValidateDeclared(decl); err != nil {
+		return fmt.Errorf("mysql_user %q: %w", r.ID.Name, err)
+	}
+	return nil
+}
+
+// Normalize rewrites ID.Name to the canonical "user@host" form.
+// Called on both declared (from DCL) and discovered resources, so
+// the engine's diff sees identical identities for the same server row.
+func (h *userHandler) Normalize(_ context.Context, r provider.Resource) (provider.Resource, error) {
+	user := getBodyString(r.Body, "user")
+	host := getBodyString(r.Body, "host")
+	if user != "" && host != "" {
+		r.ID.Name = user + "@" + host
+	}
+	return r, nil
+}
+
+// Discover enumerates every user on the server that isn't a role
+// (i.e. account_locked='N' OR authentication_string<>''). Per user it
+// runs SHOW CREATE USER and parses the output via the Phase 21 parser,
+// then maps CreateUserStmt fields onto body attributes.
+func (h *userHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
+	rows, err := client.DB().QueryContext(ctx, `
+		SELECT User, Host FROM mysql.user
+		WHERE NOT (account_locked = 'Y' AND authentication_string = '')
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("mysql_user discover: %w", err)
+	}
+	type userRow struct{ user, host string }
+	var rowsList []userRow
+	for rows.Next() {
+		var u, hst string
+		if err := rows.Scan(&u, &hst); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("mysql_user discover scan: %w", err)
+		}
+		rowsList = append(rowsList, userRow{u, hst})
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]provider.Resource, 0, len(rowsList))
+	for _, row := range rowsList {
+		ddl, err := h.fetchShowCreateUser(ctx, client.DB(), row.user, row.host)
+		if err != nil {
+			return nil, err
+		}
+		stmt, err := parse.ParseCreateUser(ddl, h.version)
+		if err != nil {
+			return nil, fmt.Errorf("mysql_user %q@%q: parse SHOW CREATE USER: %w", row.user, row.host, err)
+		}
+		out = append(out, createUserStmtToResource(stmt))
+	}
+	return out, nil
+}
+
+func (h *userHandler) fetchShowCreateUser(ctx context.Context, db *sql.DB, user, host string) (string, error) {
+	stmt := fmt.Sprintf("SHOW CREATE USER `%s`@`%s`", escapeBacktick(user), escapeBacktick(host))
+	row := db.QueryRowContext(ctx, stmt)
+	var ddl string
+	if err := row.Scan(&ddl); err != nil {
+		return "", fmt.Errorf("SHOW CREATE USER `%s`@`%s`: %w", user, host, err)
+	}
+	return ddl, nil
+}
+
+// createUserStmtToResource maps the parser output onto a Resource
+// whose Body attributes match the mysql_user DCL schema.
+func createUserStmtToResource(s parse.CreateUserStmt) provider.Resource {
+	body := provider.NewOrderedMap()
+	body.Set("user", provider.StringVal(s.User))
+	body.Set("host", provider.StringVal(s.Host))
+	body.Set("auth_plugin", provider.StringVal(s.Plugin))
+	if s.AuthString != "" {
+		body.Set("password_hash", provider.StringVal(s.AuthString))
+	}
+	if s.RequireSSL {
+		body.Set("require_ssl", provider.BoolVal(true))
+	}
+	if s.RequireX509 {
+		body.Set("require_x509", provider.BoolVal(true))
+	}
+	if s.RequireIssuer != "" {
+		body.Set("require_issuer", provider.StringVal(s.RequireIssuer))
+	}
+	if s.RequireSubject != "" {
+		body.Set("require_subject", provider.StringVal(s.RequireSubject))
+	}
+	if s.RequireCipher != "" {
+		body.Set("require_cipher", provider.StringVal(s.RequireCipher))
+	}
+	if s.MaxQueriesPerHour != 0 {
+		body.Set("max_queries_per_hour", provider.IntVal(int64(s.MaxQueriesPerHour)))
+	}
+	if s.MaxConnectionsPerHour != 0 {
+		body.Set("max_connections_per_hour", provider.IntVal(int64(s.MaxConnectionsPerHour)))
+	}
+	if s.MaxUpdatesPerHour != 0 {
+		body.Set("max_updates_per_hour", provider.IntVal(int64(s.MaxUpdatesPerHour)))
+	}
+	if s.MaxUserConnections != 0 {
+		body.Set("max_user_connections", provider.IntVal(int64(s.MaxUserConnections)))
+	}
+	if s.PasswordExpire == "INTERVAL" {
+		body.Set("password_expire_days", provider.IntVal(int64(s.PasswordExpireInterval)))
+	}
+	if s.PasswordHistory == "N" {
+		body.Set("password_history", provider.IntVal(int64(s.PasswordHistoryCount)))
+	}
+	if s.PasswordReuse == "INTERVAL" {
+		body.Set("password_reuse_interval", provider.IntVal(int64(s.PasswordReuseInterval)))
+	}
+	body.Set("account_locked", provider.BoolVal(s.AccountLocked))
+	if s.Comment != "" {
+		body.Set("comment", provider.StringVal(s.Comment))
+	}
+	if s.Attribute != "" {
+		body.Set("attribute", provider.StringVal(s.Attribute))
+	}
+	return provider.Resource{
+		ID:   provider.ResourceID{Type: "mysql_user", Name: s.User + "@" + s.Host},
+		Body: body,
+	}
+}
+
+// Apply dispatches create/update/delete to the appropriate builder.
+func (h *userHandler) Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error {
+	switch op {
+	case provider.OpCreate:
+		return h.create(ctx, client.DB(), r)
+	case provider.OpUpdate:
+		return h.update(ctx, client.DB(), r)
+	case provider.OpDelete:
+		return h.delete(ctx, client.DB(), r)
+	}
+	return fmt.Errorf("mysql_user: unsupported operation %s", op)
+}
+
+func (h *userHandler) create(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	stmt := buildUserStatement("CREATE USER", r)
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("mysql_user create %q: %w", r.ID.Name, err)
+	}
+	return nil
+}
+
+func (h *userHandler) update(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	stmt := buildUserStatement("ALTER USER", r)
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("mysql_user update %q: %w", r.ID.Name, err)
+	}
+	return nil
+}
+
+func (h *userHandler) delete(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	user := getBodyString(r.Body, "user")
+	host := getBodyString(r.Body, "host")
+	stmt := fmt.Sprintf("DROP USER `%s`@`%s`", escapeBacktick(user), escapeBacktick(host))
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("mysql_user delete %q: %w", r.ID.Name, err)
+	}
+	return nil
+}
+
+// buildUserStatement composes a CREATE USER or ALTER USER statement
+// with every declared clause. On update we re-emit every clause (no
+// surgical clause-by-clause diff); MySQL accepts idempotent re-issues
+// of unchanged values, so this stays simple and correct.
+func buildUserStatement(verb string, r provider.Resource) string {
+	user := getBodyString(r.Body, "user")
+	host := getBodyString(r.Body, "host")
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%s `%s`@`%s`", verb, escapeBacktick(user), escapeBacktick(host))
+
+	plugin := getBodyString(r.Body, "auth_plugin")
+	if plugin == "" {
+		plugin = auth.PluginCachingSHA2
+	}
+	cleartext := getBodyString(r.Body, "password")
+	hash := getBodyString(r.Body, "password_hash")
+
+	switch plugin {
+	case auth.PluginAWSIAM:
+		sb.WriteString(" IDENTIFIED WITH 'AWSAuthenticationPlugin' AS 'RDS'")
+	case auth.PluginNativePassword, auth.PluginCachingSHA2:
+		fmt.Fprintf(&sb, " IDENTIFIED WITH '%s'", plugin)
+		switch {
+		case hash != "":
+			fmt.Fprintf(&sb, " AS '%s'", sqlEscapeSingle(hash))
+		case cleartext != "":
+			fmt.Fprintf(&sb, " BY '%s'", sqlEscapeSingle(cleartext))
+		}
+	}
+
+	if s := getBodyString(r.Body, "require_subject"); s != "" {
+		fmt.Fprintf(&sb, " REQUIRE SUBJECT '%s'", sqlEscapeSingle(s))
+		if iss := getBodyString(r.Body, "require_issuer"); iss != "" {
+			fmt.Fprintf(&sb, " AND ISSUER '%s'", sqlEscapeSingle(iss))
+		}
+		if ciph := getBodyString(r.Body, "require_cipher"); ciph != "" {
+			fmt.Fprintf(&sb, " AND CIPHER '%s'", sqlEscapeSingle(ciph))
+		}
+	} else if getBodyBool(r.Body, "require_x509") {
+		sb.WriteString(" REQUIRE X509")
+	} else if getBodyBool(r.Body, "require_ssl") {
+		sb.WriteString(" REQUIRE SSL")
+	}
+
+	wroteWith := false
+	writeWith := func(label string, n int) {
+		if n == 0 {
+			return
+		}
+		if !wroteWith {
+			sb.WriteString(" WITH")
+			wroteWith = true
+		}
+		fmt.Fprintf(&sb, " %s %d", label, n)
+	}
+	writeWith("MAX_QUERIES_PER_HOUR", getBodyInt(r.Body, "max_queries_per_hour"))
+	writeWith("MAX_CONNECTIONS_PER_HOUR", getBodyInt(r.Body, "max_connections_per_hour"))
+	writeWith("MAX_UPDATES_PER_HOUR", getBodyInt(r.Body, "max_updates_per_hour"))
+	writeWith("MAX_USER_CONNECTIONS", getBodyInt(r.Body, "max_user_connections"))
+
+	if days := getBodyInt(r.Body, "password_expire_days"); days > 0 {
+		fmt.Fprintf(&sb, " PASSWORD EXPIRE INTERVAL %d DAY", days)
+	}
+	if hist := getBodyInt(r.Body, "password_history"); hist > 0 {
+		fmt.Fprintf(&sb, " PASSWORD HISTORY %d", hist)
+	}
+	if reuse := getBodyInt(r.Body, "password_reuse_interval"); reuse > 0 {
+		fmt.Fprintf(&sb, " PASSWORD REUSE INTERVAL %d DAY", reuse)
+	}
+
+	if getBodyBool(r.Body, "account_locked") {
+		sb.WriteString(" ACCOUNT LOCK")
+	}
+
+	if c := getBodyString(r.Body, "comment"); c != "" {
+		fmt.Fprintf(&sb, " COMMENT '%s'", sqlEscapeSingle(c))
+	}
+	if a := getBodyString(r.Body, "attribute"); a != "" {
+		fmt.Fprintf(&sb, " ATTRIBUTE '%s'", sqlEscapeSingle(a))
+	}
+
+	return sb.String()
+}
+
+// sqlEscapeSingle escapes a string to fit inside single-quoted SQL
+// literals. Only single-quote doubling is strictly needed for the
+// values we produce (passwords, hashes, subject/issuer DNs, comments,
+// JSON attribute strings); backslash escaping matches what MySQL emits
+// and keeps re-reading stable.
+func sqlEscapeSingle(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "'", "''")
+	return s
+}

--- a/providers/mysql/user_test.go
+++ b/providers/mysql/user_test.go
@@ -1,0 +1,261 @@
+package mysql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+	"github.com/MathewBravo/datastorectl/providers/mysql/auth"
+)
+
+// TestUserHandler_Validate covers rules checkable without a cluster.
+func TestUserHandler_Validate(t *testing.T) {
+	h := &userHandler{}
+	cases := []struct {
+		name     string
+		resource provider.Resource
+		wantErr  string
+	}{
+		{
+			name:     "missing user attribute",
+			resource: userResource("app", map[string]provider.Value{"host": provider.StringVal("%")}),
+			wantErr:  "user",
+		},
+		{
+			name:     "missing host attribute",
+			resource: userResource("app", map[string]provider.Value{"user": provider.StringVal("app")}),
+			wantErr:  "host",
+		},
+		{
+			name: "password and password_hash both set",
+			resource: userResource("app", map[string]provider.Value{
+				"user":          provider.StringVal("app"),
+				"host":          provider.StringVal("%"),
+				"password":      provider.StringVal("pw"),
+				"password_hash": provider.StringVal("*hash"),
+			}),
+			wantErr: "cannot set both",
+		},
+		{
+			name: "caching_sha2 with no password or hash",
+			resource: userResource("app", map[string]provider.Value{
+				"user":        provider.StringVal("app"),
+				"host":        provider.StringVal("%"),
+				"auth_plugin": provider.StringVal(auth.PluginCachingSHA2),
+			}),
+			wantErr: "requires either password",
+		},
+		{
+			name: "aws_iam with local password rejected",
+			resource: userResource("app", map[string]provider.Value{
+				"user":        provider.StringVal("app"),
+				"host":        provider.StringVal("%"),
+				"auth_plugin": provider.StringVal(auth.PluginAWSIAM),
+				"password":    provider.StringVal("pw"),
+			}),
+			wantErr: "does not accept a local password",
+		},
+		{
+			name: "unsupported plugin rejected",
+			resource: userResource("app", map[string]provider.Value{
+				"user":        provider.StringVal("app"),
+				"host":        provider.StringVal("%"),
+				"auth_plugin": provider.StringVal("authentication_ldap_simple"),
+			}),
+			wantErr: "not supported",
+		},
+		{
+			name: "valid cleartext caching_sha2",
+			resource: userResource("app", map[string]provider.Value{
+				"user":     provider.StringVal("app"),
+				"host":     provider.StringVal("%"),
+				"password": provider.StringVal("pw"),
+			}),
+		},
+		{
+			name: "valid password_hash + native",
+			resource: userResource("legacy", map[string]provider.Value{
+				"user":          provider.StringVal("legacy"),
+				"host":          provider.StringVal("%"),
+				"auth_plugin":   provider.StringVal(auth.PluginNativePassword),
+				"password_hash": provider.StringVal("*1234"),
+			}),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := h.Validate(context.Background(), c.resource)
+			if c.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.wantErr)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+// TestUserHandler_Normalize confirms Normalize rewrites ID.Name to
+// the canonical "user@host" form so declared and discovered resources
+// match under the engine's by-ID diff.
+func TestUserHandler_Normalize(t *testing.T) {
+	h := &userHandler{}
+	r := userResource("app_handle", map[string]provider.Value{
+		"user": provider.StringVal("app"),
+		"host": provider.StringVal("10.0.%"),
+	})
+	out, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if out.ID.Name != "app@10.0.%" {
+		t.Errorf("ID.Name = %q, want \"app@10.0.%%\"", out.ID.Name)
+	}
+}
+
+// TestUserHandler_CreateDiscoverDelete runs the lifecycle with a
+// cleartext password. Confirms the user appears in discovery with
+// matching attributes.
+func TestUserHandler_CreateDiscoverDelete(t *testing.T) {
+	client := newTestClient(t)
+	h := &userHandler{}
+	ctx := context.Background()
+
+	name := "dsctl_user_test"
+	host := "%"
+	t.Cleanup(func() {
+		_, _ = client.DB().ExecContext(ctx, "DROP USER IF EXISTS `"+name+"`@`"+host+"`")
+	})
+
+	r := userResource("app_handle", map[string]provider.Value{
+		"user":     provider.StringVal(name),
+		"host":     provider.StringVal(host),
+		"password": provider.StringVal("test_pw_123"),
+	})
+	r, _ = h.Normalize(ctx, r)
+
+	if err := h.Apply(ctx, client, provider.OpCreate, r); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	resources, err := h.Discover(ctx, client)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	found := findByName(resources, name+"@"+host)
+	if found == nil {
+		t.Fatalf("discover did not return %q@%q", name, host)
+	}
+	if getBodyString(found.Body, "user") != name {
+		t.Errorf("user = %q, want %q", getBodyString(found.Body, "user"), name)
+	}
+	if getBodyString(found.Body, "host") != host {
+		t.Errorf("host = %q, want %q", getBodyString(found.Body, "host"), host)
+	}
+	if getBodyString(found.Body, "auth_plugin") != auth.PluginCachingSHA2 {
+		t.Errorf("auth_plugin = %q", getBodyString(found.Body, "auth_plugin"))
+	}
+
+	if err := h.Apply(ctx, client, provider.OpDelete, r); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	resources, _ = h.Discover(ctx, client)
+	if findByName(resources, name+"@"+host) != nil {
+		t.Errorf("user %q@%q still present after delete", name, host)
+	}
+}
+
+// TestUserHandler_UpdateAttributes confirms an ALTER USER reflects
+// account_locked and resource-limit changes.
+func TestUserHandler_UpdateAttributes(t *testing.T) {
+	client := newTestClient(t)
+	h := &userHandler{}
+	ctx := context.Background()
+
+	name := "dsctl_user_update"
+	host := "%"
+	t.Cleanup(func() {
+		_, _ = client.DB().ExecContext(ctx, "DROP USER IF EXISTS `"+name+"`@`"+host+"`")
+	})
+
+	create := userResource("u", map[string]provider.Value{
+		"user":     provider.StringVal(name),
+		"host":     provider.StringVal(host),
+		"password": provider.StringVal("pw"),
+	})
+	create, _ = h.Normalize(ctx, create)
+	if err := h.Apply(ctx, client, provider.OpCreate, create); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	update := userResource("u", map[string]provider.Value{
+		"user":                  provider.StringVal(name),
+		"host":                  provider.StringVal(host),
+		"password":              provider.StringVal("pw"),
+		"account_locked":        provider.BoolVal(true),
+		"max_queries_per_hour":  provider.IntVal(1000),
+		"max_user_connections":  provider.IntVal(5),
+	})
+	update, _ = h.Normalize(ctx, update)
+	if err := h.Apply(ctx, client, provider.OpUpdate, update); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	resources, _ := h.Discover(ctx, client)
+	found := findByName(resources, name+"@"+host)
+	if found == nil {
+		t.Fatalf("user disappeared after update")
+	}
+	if !getBodyBool(found.Body, "account_locked") {
+		t.Error("account_locked = false, want true")
+	}
+	if getBodyInt(found.Body, "max_queries_per_hour") != 1000 {
+		t.Errorf("max_queries_per_hour = %d, want 1000", getBodyInt(found.Body, "max_queries_per_hour"))
+	}
+}
+
+// TestUserHandler_DiscoverFiltersRoles confirms MySQL 8 roles (users
+// with account_locked='Y' AND authentication_string='') are excluded.
+func TestUserHandler_DiscoverFiltersRoles(t *testing.T) {
+	client := newTestClient(t)
+	h := &userHandler{}
+	ctx := context.Background()
+
+	roleName := "dsctl_test_role_filter"
+	t.Cleanup(func() {
+		_, _ = client.DB().ExecContext(ctx, "DROP ROLE IF EXISTS `"+roleName+"`@`%`")
+	})
+
+	if _, err := client.DB().ExecContext(ctx, "CREATE ROLE `"+roleName+"`@`%`"); err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+
+	resources, err := h.Discover(ctx, client)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if findByName(resources, roleName+"@%") != nil {
+		t.Errorf("role %q leaked into user discovery", roleName)
+	}
+}
+
+// userResource is a test helper that builds a Resource for mysql_user.
+// The id_name is used as the initial ID.Name; Normalize will rewrite.
+func userResource(handle string, body map[string]provider.Value) provider.Resource {
+	om := provider.NewOrderedMap()
+	for k, v := range body {
+		om.Set(k, v)
+	}
+	return provider.Resource{
+		ID:   provider.ResourceID{Type: "mysql_user", Name: handle},
+		Body: om,
+	}
+}
+


### PR DESCRIPTION
## Summary
The largest handler in the provider. Manages `mysql_user` resources covering every clause the DDL parser (Phase 21) can read and every password shape the auth sub-package (Phase 20) can compare.

- **Identity** is the `(user, host)` tuple from body attributes. Normalize rewrites `ID.Name` to canonical `"user@host"` so the engine's by-ID diff pairs declared and discovered resources.
- **Validate** checks required user/host, rejects backticks, and delegates password-shape validation to `auth.ValidateDeclared`.
- **Discover** filters out MySQL 8 roles (`account_locked='Y' AND authentication_string=''`), runs `SHOW CREATE USER` per user, and parses via `parse.ParseCreateUser`.
- **Apply** uses a shared statement builder for CREATE USER and ALTER USER that emits every declared clause. Update re-emits the full set — simpler than surgical clause-by-clause diffing and equally correct.
- `getBodyBool` and `getBodyInt` helpers lifted out of the test file so user.go and future handlers share them.

## Test plan
- [x] Eight Validate subcases: missing user, missing host, both password and password_hash, caching_sha2 with neither, aws_iam with password, unsupported plugin, valid cleartext, valid password_hash.
- [x] `Normalize` rewrites `ID.Name` to `user@host`.
- [x] `CreateDiscoverDelete` lifecycle with cleartext password.
- [x] `UpdateAttributes` confirms account_locked + resource-limit changes round-trip.
- [x] `DiscoverFiltersRoles` confirms MySQL 8 roles don't leak into user discovery.
- [x] **End-to-end verified against a live `mysql:8.4` container** — all four integration subtests PASS.
- [x] `go test ./... -count=1` clean.
- [x] `go vet ./providers/mysql/...` clean.

Closes #174