### PR TITLE
feat(mysql): mysql_grant handler with scope-specific GRANT and REVOKE

### DIFF
--- a/providers/mysql/database.go
+++ b/providers/mysql/database.go
@@ -186,3 +186,22 @@ func getBodyInt(m *provider.OrderedMap, key string) int {
 	}
 	return int(v.Int)
 }
+
+// getStringListField extracts a list of strings from a resource body.
+// Returns nil when absent or not a list.
+func getStringListField(m *provider.OrderedMap, key string) []string {
+	if m == nil {
+		return nil
+	}
+	v, ok := m.Get(key)
+	if !ok || v.Kind != provider.KindList {
+		return nil
+	}
+	out := make([]string, 0, len(v.List))
+	for _, e := range v.List {
+		if e.Kind == provider.KindString {
+			out = append(out, e.Str)
+		}
+	}
+	return out
+}

--- a/providers/mysql/grant.go
+++ b/providers/mysql/grant.go
@@ -1,0 +1,395 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/MathewBravo/datastorectl/provider"
+	"github.com/MathewBravo/datastorectl/providers/mysql/parse"
+)
+
+// grantHandler manages mysql_grant resources. A grant is identified
+// by the tuple (user, host, database, table). The DCL block label is
+// a free-form handle; Normalize rewrites ID.Name to "user@host:db.tbl"
+// so the engine's by-ID diff pairs declared and discovered resources.
+type grantHandler struct {
+	version string
+}
+
+// Validate covers per-resource rules. Cross-resource duplicate-tuple
+// checks are a known gap, tracked in the engine-level cross-resource
+// validation issue.
+func (h *grantHandler) Validate(_ context.Context, r provider.Resource) error {
+	user := getBodyString(r.Body, "user")
+	host := getBodyString(r.Body, "host")
+	database := getBodyString(r.Body, "database")
+	table := getBodyString(r.Body, "table")
+	privs := getStringListField(r.Body, "privileges")
+
+	if user == "" {
+		return fmt.Errorf("mysql_grant %q: required attribute user is missing or empty", r.ID.Name)
+	}
+	if host == "" {
+		return fmt.Errorf("mysql_grant %q: required attribute host is missing or empty", r.ID.Name)
+	}
+	if database == "" {
+		return fmt.Errorf("mysql_grant %q: required attribute database is missing or empty (use \"*\" for global scope)", r.ID.Name)
+	}
+	if table == "" {
+		return fmt.Errorf("mysql_grant %q: required attribute table is missing or empty (use \"*\" for schema-level scope)", r.ID.Name)
+	}
+	if len(privs) == 0 {
+		return fmt.Errorf("mysql_grant %q: privileges list is missing or empty", r.ID.Name)
+	}
+	for i, p := range privs {
+		if strings.TrimSpace(p) == "" {
+			return fmt.Errorf("mysql_grant %q: privileges[%d] is an empty privilege name", r.ID.Name, i)
+		}
+	}
+	if strings.ContainsAny(user, "`") || strings.ContainsAny(host, "`") ||
+		strings.ContainsAny(database, "`") || strings.ContainsAny(table, "`") {
+		return fmt.Errorf("mysql_grant %q: identifier contains a backtick", r.ID.Name)
+	}
+	return nil
+}
+
+// Normalize rewrites ID.Name to the canonical identity tuple form and
+// sorts + uppercases the privileges list so the engine's diff is
+// deterministic.
+func (h *grantHandler) Normalize(_ context.Context, r provider.Resource) (provider.Resource, error) {
+	if r.Body == nil {
+		return r, nil
+	}
+	user := getBodyString(r.Body, "user")
+	host := getBodyString(r.Body, "host")
+	database := getBodyString(r.Body, "database")
+	table := getBodyString(r.Body, "table")
+	if user != "" && host != "" && database != "" && table != "" {
+		r.ID.Name = fmt.Sprintf("%s@%s:%s.%s", user, host, database, table)
+	}
+
+	privs := getStringListField(r.Body, "privileges")
+	normalized := normalizePrivs(privs)
+	elems := make([]provider.Value, len(normalized))
+	for i, p := range normalized {
+		elems[i] = provider.StringVal(p)
+	}
+	r.Body.Set("privileges", provider.ListVal(elems))
+	return r, nil
+}
+
+// normalizePrivs uppercases, trims, dedupes, sorts, and collapses
+// "ALL PRIVILEGES" to "ALL". Empty strings are dropped silently
+// (Validate rejects them upstream).
+func normalizePrivs(privs []string) []string {
+	seen := make(map[string]bool, len(privs))
+	out := make([]string, 0, len(privs))
+	for _, p := range privs {
+		up := strings.ToUpper(strings.TrimSpace(p))
+		if up == "" {
+			continue
+		}
+		if up == "ALL PRIVILEGES" {
+			up = "ALL"
+		}
+		if !seen[up] {
+			seen[up] = true
+			out = append(out, up)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Discover enumerates grants across every non-role account on the
+// server. For each, it runs SHOW GRANTS and parses every emitted GRANT
+// statement into a separate resource. The USAGE-only placeholder grant
+// every MySQL user gets by default is filtered out.
+func (h *grantHandler) Discover(ctx context.Context, client *Client) ([]provider.Resource, error) {
+	rows, err := client.DB().QueryContext(ctx, `
+		SELECT User, Host FROM mysql.user
+		WHERE NOT (account_locked = 'Y' AND authentication_string = '')
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("mysql_grant discover users: %w", err)
+	}
+	type acct struct{ user, host string }
+	var accounts []acct
+	for rows.Next() {
+		var u, hst string
+		if err := rows.Scan(&u, &hst); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("mysql_grant discover scan: %w", err)
+		}
+		accounts = append(accounts, acct{u, hst})
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Roles, too — privileges can be granted to roles.
+	roleRows, err := client.DB().QueryContext(ctx, `
+		SELECT User, Host FROM mysql.user
+		WHERE account_locked = 'Y' AND authentication_string = ''
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("mysql_grant discover roles: %w", err)
+	}
+	for roleRows.Next() {
+		var u, hst string
+		if err := roleRows.Scan(&u, &hst); err != nil {
+			roleRows.Close()
+			return nil, err
+		}
+		accounts = append(accounts, acct{u, hst})
+	}
+	roleRows.Close()
+
+	var out []provider.Resource
+	for _, a := range accounts {
+		stmts, err := h.fetchAndParseGrants(ctx, client.DB(), a.user, a.host)
+		if err != nil {
+			return nil, err
+		}
+		for _, s := range stmts {
+			if isUsageOnlyDefault(s) {
+				continue
+			}
+			out = append(out, grantStmtToResource(s))
+		}
+	}
+	return out, nil
+}
+
+// isUsageOnlyDefault reports whether a parsed grant is the default
+// USAGE placeholder MySQL attaches to every fresh account. We filter
+// these because they're not user-managed state.
+func isUsageOnlyDefault(s parse.GrantStmt) bool {
+	if s.Database != "*" || s.Table != "*" || s.GrantOption {
+		return false
+	}
+	if len(s.Privileges) != 1 {
+		return false
+	}
+	return s.Privileges[0] == "USAGE"
+}
+
+func (h *grantHandler) fetchAndParseGrants(ctx context.Context, db *sql.DB, user, host string) ([]parse.GrantStmt, error) {
+	stmt := fmt.Sprintf("SHOW GRANTS FOR `%s`@`%s`", escapeBacktick(user), escapeBacktick(host))
+	rows, err := db.QueryContext(ctx, stmt)
+	if err != nil {
+		return nil, fmt.Errorf("SHOW GRANTS FOR `%s`@`%s`: %w", user, host, err)
+	}
+	defer rows.Close()
+	var lines []string
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			return nil, err
+		}
+		lines = append(lines, line)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]parse.GrantStmt, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		// GRANT PROXY grants use an empty-ident scope (``@``) that
+		// the table-scope parser can't parse. Skip them as
+		// out-of-scope for v0.1.0.
+		if strings.HasPrefix(strings.ToUpper(trimmed), "GRANT PROXY ") {
+			continue
+		}
+		// Skip column-level and routine grants the parser rejects.
+		// Surface all other parse errors.
+		s, err := parse.ParseGrant(trimmed, h.version)
+		if err != nil {
+			if strings.Contains(err.Error(), "not supported") {
+				continue
+			}
+			return nil, fmt.Errorf("parse grant line %q: %w", line, err)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// grantStmtToResource maps a parsed GRANT into a provider.Resource.
+func grantStmtToResource(s parse.GrantStmt) provider.Resource {
+	body := provider.NewOrderedMap()
+	body.Set("user", provider.StringVal(s.User))
+	body.Set("host", provider.StringVal(s.Host))
+	body.Set("database", provider.StringVal(s.Database))
+	body.Set("table", provider.StringVal(s.Table))
+	elems := make([]provider.Value, len(s.Privileges))
+	for i, p := range s.Privileges {
+		elems[i] = provider.StringVal(p)
+	}
+	body.Set("privileges", provider.ListVal(elems))
+	if s.GrantOption {
+		body.Set("grant_option", provider.BoolVal(true))
+	}
+	return provider.Resource{
+		ID:   provider.ResourceID{Type: "mysql_grant", Name: fmt.Sprintf("%s@%s:%s.%s", s.User, s.Host, s.Database, s.Table)},
+		Body: body,
+	}
+}
+
+// Apply runs the declared GRANT / REVOKE operations against the server.
+func (h *grantHandler) Apply(ctx context.Context, client *Client, op provider.Operation, r provider.Resource) error {
+	switch op {
+	case provider.OpCreate:
+		return h.create(ctx, client.DB(), r)
+	case provider.OpUpdate:
+		return h.update(ctx, client.DB(), r)
+	case provider.OpDelete:
+		return h.delete(ctx, client.DB(), r)
+	}
+	return fmt.Errorf("mysql_grant: unsupported operation %s", op)
+}
+
+func (h *grantHandler) create(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	stmt := buildGrantStatement(r)
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("mysql_grant create %q: %w", r.ID.Name, err)
+	}
+	return nil
+}
+
+// update reconciles declared privileges against current server state
+// by fetching SHOW GRANTS for the (user, host) and emitting only the
+// needed GRANT and REVOKE statements for the target scope. This avoids
+// re-granting everything on every apply.
+func (h *grantHandler) update(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	user := getBodyString(r.Body, "user")
+	host := getBodyString(r.Body, "host")
+	database := getBodyString(r.Body, "database")
+	table := getBodyString(r.Body, "table")
+
+	declared := normalizePrivs(getStringListField(r.Body, "privileges"))
+	declaredSet := toSet(declared)
+	declaredGrantOpt := getBodyBool(r.Body, "grant_option")
+
+	current, currentGrantOpt, err := h.currentPrivilegesForScope(ctx, db, user, host, database, table)
+	if err != nil {
+		return err
+	}
+	currentSet := toSet(current)
+
+	// REVOKE what's no longer declared.
+	var toRevoke []string
+	for _, p := range current {
+		if !declaredSet[p] {
+			toRevoke = append(toRevoke, p)
+		}
+	}
+	if len(toRevoke) > 0 {
+		stmt := fmt.Sprintf("REVOKE %s ON %s FROM `%s`@`%s`",
+			strings.Join(toRevoke, ", "),
+			scopeFragment(database, table),
+			escapeBacktick(user), escapeBacktick(host))
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("mysql_grant update revoke %q: %w", r.ID.Name, err)
+		}
+	}
+
+	// GRANT what's newly declared.
+	var toGrant []string
+	for _, p := range declared {
+		if !currentSet[p] {
+			toGrant = append(toGrant, p)
+		}
+	}
+	if len(toGrant) > 0 || declaredGrantOpt != currentGrantOpt {
+		privList := toGrant
+		if len(privList) == 0 {
+			// Privileges unchanged but grant_option flipped — re-grant
+			// the existing set with the new option setting.
+			privList = declared
+		}
+		stmt := fmt.Sprintf("GRANT %s ON %s TO `%s`@`%s`",
+			strings.Join(privList, ", "),
+			scopeFragment(database, table),
+			escapeBacktick(user), escapeBacktick(host))
+		if declaredGrantOpt {
+			stmt += " WITH GRANT OPTION"
+		}
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("mysql_grant update grant %q: %w", r.ID.Name, err)
+		}
+	}
+	return nil
+}
+
+// currentPrivilegesForScope returns the privilege list + grant_option
+// currently on the server for a specific (user, host, database, table)
+// tuple. Returns empty list if no grant exists for that scope.
+func (h *grantHandler) currentPrivilegesForScope(ctx context.Context, db *sql.DB, user, host, database, table string) ([]string, bool, error) {
+	stmts, err := (&grantHandler{}).fetchAndParseGrants(ctx, db, user, host)
+	if err != nil {
+		return nil, false, err
+	}
+	for _, s := range stmts {
+		if s.Database == database && s.Table == table {
+			return normalizePrivs(s.Privileges), s.GrantOption, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func (h *grantHandler) delete(ctx context.Context, db *sql.DB, r provider.Resource) error {
+	user := getBodyString(r.Body, "user")
+	host := getBodyString(r.Body, "host")
+	database := getBodyString(r.Body, "database")
+	table := getBodyString(r.Body, "table")
+
+	// Scope-specific revoke: MySQL accepts ALL PRIVILEGES here and
+	// implicitly revokes the grant option for that scope. The global
+	// form `REVOKE ALL PRIVILEGES, GRANT OPTION FROM user` has no ON
+	// clause and applies across all scopes — not what we want.
+	stmt := fmt.Sprintf("REVOKE ALL PRIVILEGES ON %s FROM `%s`@`%s`",
+		scopeFragment(database, table),
+		escapeBacktick(user), escapeBacktick(host))
+	if _, err := db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("mysql_grant delete %q: %w", r.ID.Name, err)
+	}
+	return nil
+}
+
+// buildGrantStatement composes a full GRANT DDL for create.
+func buildGrantStatement(r provider.Resource) string {
+	user := getBodyString(r.Body, "user")
+	host := getBodyString(r.Body, "host")
+	database := getBodyString(r.Body, "database")
+	table := getBodyString(r.Body, "table")
+	privs := normalizePrivs(getStringListField(r.Body, "privileges"))
+	grantOpt := getBodyBool(r.Body, "grant_option")
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "GRANT %s ON %s TO `%s`@`%s`",
+		strings.Join(privs, ", "),
+		scopeFragment(database, table),
+		escapeBacktick(user), escapeBacktick(host))
+	if grantOpt {
+		sb.WriteString(" WITH GRANT OPTION")
+	}
+	return sb.String()
+}
+
+// scopeFragment builds the `ON db.tbl` portion. Literal `*` means any.
+func scopeFragment(database, table string) string {
+	dbPart := "*"
+	if database != "*" {
+		dbPart = "`" + escapeBacktick(database) + "`"
+	}
+	tblPart := "*"
+	if table != "*" {
+		tblPart = "`" + escapeBacktick(table) + "`"
+	}
+	return dbPart + "." + tblPart
+}

--- a/providers/mysql/grant_test.go
+++ b/providers/mysql/grant_test.go
@@ -1,0 +1,298 @@
+package mysql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// TestGrantHandler_Validate covers per-resource rules.
+func TestGrantHandler_Validate(t *testing.T) {
+	h := &grantHandler{}
+	cases := []struct {
+		name     string
+		resource provider.Resource
+		wantErr  string
+	}{
+		{
+			name:    "missing user",
+			resource: grantResource(map[string]provider.Value{
+				"database":   provider.StringVal("appdb"),
+				"table":      provider.StringVal("*"),
+				"privileges": stringList("SELECT"),
+			}),
+			wantErr: "user",
+		},
+		{
+			name: "missing database",
+			resource: grantResource(map[string]provider.Value{
+				"user":       provider.StringVal("app"),
+				"host":       provider.StringVal("%"),
+				"table":      provider.StringVal("*"),
+				"privileges": stringList("SELECT"),
+			}),
+			wantErr: "database",
+		},
+		{
+			name: "missing privileges",
+			resource: grantResource(map[string]provider.Value{
+				"user":     provider.StringVal("app"),
+				"host":     provider.StringVal("%"),
+				"database": provider.StringVal("appdb"),
+				"table":    provider.StringVal("*"),
+			}),
+			wantErr: "privileges",
+		},
+		{
+			name: "empty privilege string",
+			resource: grantResource(map[string]provider.Value{
+				"user":       provider.StringVal("app"),
+				"host":       provider.StringVal("%"),
+				"database":   provider.StringVal("appdb"),
+				"table":      provider.StringVal("*"),
+				"privileges": stringList("SELECT", ""),
+			}),
+			wantErr: "empty privilege",
+		},
+		{
+			name: "valid minimal",
+			resource: grantResource(map[string]provider.Value{
+				"user":       provider.StringVal("app"),
+				"host":       provider.StringVal("%"),
+				"database":   provider.StringVal("appdb"),
+				"table":      provider.StringVal("*"),
+				"privileges": stringList("SELECT"),
+			}),
+		},
+		{
+			name: "valid global scope",
+			resource: grantResource(map[string]provider.Value{
+				"user":       provider.StringVal("app"),
+				"host":       provider.StringVal("%"),
+				"database":   provider.StringVal("*"),
+				"table":      provider.StringVal("*"),
+				"privileges": stringList("PROCESS"),
+			}),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := h.Validate(context.Background(), c.resource)
+			if c.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", c.wantErr)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+// TestGrantHandler_Normalize confirms ID.Name rewrites to the
+// (user, host, database, table) canonical form and privileges sort.
+func TestGrantHandler_Normalize(t *testing.T) {
+	h := &grantHandler{}
+	r := grantResource(map[string]provider.Value{
+		"user":       provider.StringVal("app"),
+		"host":       provider.StringVal("10.0.%"),
+		"database":   provider.StringVal("appdb"),
+		"table":      provider.StringVal("*"),
+		"privileges": stringList("update", "select", "insert"),
+	})
+	out, err := h.Normalize(context.Background(), r)
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	want := "app@10.0.%:appdb.*"
+	if out.ID.Name != want {
+		t.Errorf("ID.Name = %q, want %q", out.ID.Name, want)
+	}
+	privs := getStringListField(out.Body, "privileges")
+	wantPrivs := []string{"INSERT", "SELECT", "UPDATE"}
+	if len(privs) != 3 || privs[0] != wantPrivs[0] || privs[1] != wantPrivs[1] || privs[2] != wantPrivs[2] {
+		t.Errorf("privileges = %v, want %v", privs, wantPrivs)
+	}
+}
+
+// TestGrantHandler_CreateDiscoverDelete exercises the schema-scope
+// path. Creates a user, grants, discovers, revokes.
+func TestGrantHandler_CreateDiscoverDelete(t *testing.T) {
+	client := newTestClient(t)
+	ctx := context.Background()
+	h := &grantHandler{}
+
+	user := "dsctl_grant_user"
+	dbName := "dsctl_grant_db"
+	host := "%"
+
+	t.Cleanup(func() {
+		_, _ = client.DB().ExecContext(ctx, "DROP DATABASE IF EXISTS `"+dbName+"`")
+		_, _ = client.DB().ExecContext(ctx, "DROP USER IF EXISTS `"+user+"`@`"+host+"`")
+	})
+
+	// Prep: create user + database on the server directly.
+	if _, err := client.DB().ExecContext(ctx, "CREATE USER `"+user+"`@`"+host+"` IDENTIFIED BY 'pw'"); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if _, err := client.DB().ExecContext(ctx, "CREATE DATABASE `"+dbName+"`"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+
+	// Apply a schema-level grant.
+	r := grantResource(map[string]provider.Value{
+		"user":       provider.StringVal(user),
+		"host":       provider.StringVal(host),
+		"database":   provider.StringVal(dbName),
+		"table":      provider.StringVal("*"),
+		"privileges": stringList("SELECT", "INSERT"),
+	})
+	r, _ = h.Normalize(ctx, r)
+	if err := h.Apply(ctx, client, provider.OpCreate, r); err != nil {
+		t.Fatalf("create grant: %v", err)
+	}
+
+	// Discover — should find our grant among others (e.g. the default
+	// USAGE grant every user has).
+	resources, err := h.Discover(ctx, client)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	found := findGrant(resources, user, host, dbName, "*")
+	if found == nil {
+		t.Fatalf("discover did not return the schema-level grant")
+	}
+	privs := getStringListField(found.Body, "privileges")
+	if !containsAll(privs, []string{"INSERT", "SELECT"}) {
+		t.Errorf("discovered privileges = %v, want at least [INSERT SELECT]", privs)
+	}
+
+	// Update: add UPDATE.
+	updated := grantResource(map[string]provider.Value{
+		"user":       provider.StringVal(user),
+		"host":       provider.StringVal(host),
+		"database":   provider.StringVal(dbName),
+		"table":      provider.StringVal("*"),
+		"privileges": stringList("SELECT", "INSERT", "UPDATE"),
+	})
+	updated, _ = h.Normalize(ctx, updated)
+	if err := h.Apply(ctx, client, provider.OpUpdate, updated); err != nil {
+		t.Fatalf("update grant: %v", err)
+	}
+	resources, _ = h.Discover(ctx, client)
+	found = findGrant(resources, user, host, dbName, "*")
+	if found == nil {
+		t.Fatal("grant disappeared after update")
+	}
+	privs = getStringListField(found.Body, "privileges")
+	if !containsAll(privs, []string{"INSERT", "SELECT", "UPDATE"}) {
+		t.Errorf("after update privileges = %v, want [INSERT SELECT UPDATE]", privs)
+	}
+
+	// Delete.
+	if err := h.Apply(ctx, client, provider.OpDelete, updated); err != nil {
+		t.Fatalf("delete grant: %v", err)
+	}
+	resources, _ = h.Discover(ctx, client)
+	if findGrant(resources, user, host, dbName, "*") != nil {
+		t.Errorf("grant still present after delete")
+	}
+}
+
+// TestGrantHandler_GrantOption covers WITH GRANT OPTION round-trip.
+func TestGrantHandler_GrantOption(t *testing.T) {
+	client := newTestClient(t)
+	ctx := context.Background()
+	h := &grantHandler{}
+
+	user := "dsctl_grant_option_user"
+	dbName := "dsctl_grant_option_db"
+	host := "%"
+	t.Cleanup(func() {
+		_, _ = client.DB().ExecContext(ctx, "DROP DATABASE IF EXISTS `"+dbName+"`")
+		_, _ = client.DB().ExecContext(ctx, "DROP USER IF EXISTS `"+user+"`@`"+host+"`")
+	})
+	if _, err := client.DB().ExecContext(ctx, "CREATE USER `"+user+"`@`"+host+"` IDENTIFIED BY 'pw'"); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if _, err := client.DB().ExecContext(ctx, "CREATE DATABASE `"+dbName+"`"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+
+	r := grantResource(map[string]provider.Value{
+		"user":         provider.StringVal(user),
+		"host":         provider.StringVal(host),
+		"database":     provider.StringVal(dbName),
+		"table":        provider.StringVal("*"),
+		"privileges":   stringList("SELECT"),
+		"grant_option": provider.BoolVal(true),
+	})
+	r, _ = h.Normalize(ctx, r)
+	if err := h.Apply(ctx, client, provider.OpCreate, r); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	resources, _ := h.Discover(ctx, client)
+	found := findGrant(resources, user, host, dbName, "*")
+	if found == nil {
+		t.Fatal("grant not found")
+	}
+	if !getBodyBool(found.Body, "grant_option") {
+		t.Error("grant_option = false, want true")
+	}
+}
+
+// grantResource builds a test mysql_grant resource.
+func grantResource(body map[string]provider.Value) provider.Resource {
+	om := provider.NewOrderedMap()
+	for k, v := range body {
+		om.Set(k, v)
+	}
+	return provider.Resource{
+		ID:   provider.ResourceID{Type: "mysql_grant", Name: "test_grant"},
+		Body: om,
+	}
+}
+
+// stringList builds a ListVal of StringVals.
+func stringList(ss ...string) provider.Value {
+	elems := make([]provider.Value, len(ss))
+	for i, s := range ss {
+		elems[i] = provider.StringVal(s)
+	}
+	return provider.ListVal(elems)
+}
+
+// findGrant locates a discovered grant by identity tuple.
+func findGrant(rs []provider.Resource, user, host, database, table string) *provider.Resource {
+	for i := range rs {
+		r := &rs[i]
+		if getBodyString(r.Body, "user") == user &&
+			getBodyString(r.Body, "host") == host &&
+			getBodyString(r.Body, "database") == database &&
+			getBodyString(r.Body, "table") == table {
+			return r
+		}
+	}
+	return nil
+}
+
+// containsAll reports whether haystack contains every item in needles.
+func containsAll(haystack, needles []string) bool {
+	set := make(map[string]bool, len(haystack))
+	for _, h := range haystack {
+		set[h] = true
+	}
+	for _, n := range needles {
+		if !set[n] {
+			return false
+		}
+	}
+	return true
+}

--- a/providers/mysql/provider.go
+++ b/providers/mysql/provider.go
@@ -35,7 +35,7 @@ func init() {
 		return &Provider{
 			handlers: map[string]resourceHandler{
 				"mysql_user":     &userHandler{},
-				"mysql_grant":    &stubHandler{typeName: "mysql_grant"},
+				"mysql_grant":    &grantHandler{},
 				"mysql_role":     &roleHandler{},
 				"mysql_database": &databaseHandler{},
 			},

--- a/providers/mysql/role_test.go
+++ b/providers/mysql/role_test.go
@@ -207,17 +207,3 @@ func resourceWithGrantedRoles(name string, grantedRoles []string) provider.Resou
 	}
 }
 
-// getStringListField extracts a list of strings from a resource body.
-func getStringListField(body *provider.OrderedMap, key string) []string {
-	v, ok := body.Get(key)
-	if !ok || v.Kind != provider.KindList {
-		return nil
-	}
-	out := make([]string, 0, len(v.List))
-	for _, e := range v.List {
-		if e.Kind == provider.KindString {
-			out = append(out, e.Str)
-		}
-	}
-	return out
-}


### PR DESCRIPTION
## Summary
Fourth and final v0.1.0 resource handler. Manages `mysql_grant` per `(user, host, database, table)` tuple using the Phase 21 parser for read-back.

- **Identity tuple rewrite** via Normalize: `ID.Name` becomes `"user@host:db.tbl"` on both declared and discovered so the engine diff pairs correctly. Privileges sort, uppercase, dedupe, and `ALL PRIVILEGES` collapses to `"ALL"`.
- **Discover** enumerates users and roles, runs `SHOW GRANTS` per account, parses each line via `parse.ParseGrant`. Filters the default USAGE-only placeholder grant MySQL attaches to every account. Filters `GRANT PROXY` lines upstream (parser doesn't support their empty-ident scope syntax).
- **Apply Update** is smart: fetches current grants for the exact scope, set-diffs against declared, emits only the REVOKE + GRANT fragments for the delta. Handles grant_option flip by re-granting the full declared set.
- **Apply Delete** uses scope-specific `REVOKE ALL PRIVILEGES ON scope FROM user`, which implicitly revokes the grant option for that scope.

## Test plan
- [x] Six Validate subcases (missing user, missing database, missing privileges, empty privilege string, minimal valid, global valid).
- [x] Normalize confirms ID.Name tuple form + privilege normalization.
- [x] `CreateDiscoverDelete` lifecycle at schema scope with a mid-lifecycle privilege-set update.
- [x] `GrantOption` round-trips the WITH GRANT OPTION flag.
- [x] **End-to-end verified against a live `mysql:8.4` container** — all four integration subtests PASS after fixing two real-server surprises (GRANT PROXY filtering and scope-specific REVOKE syntax).
- [x] `go test ./... -count=1` clean.
- [x] `go vet ./providers/mysql/...` clean.

**Phase 23 complete with this PR.** All four resource handlers (database, role, user, grant) are now live.

Closes #175