### PR TITLE
feat(mysql): self-lockout guard for non-default role cascade deletes

### DIFF
--- a/providers/mysql/account.go
+++ b/providers/mysql/account.go
@@ -12,11 +12,14 @@ import (
 
 // callerIdentity captures the authenticated MySQL principal. Fetched
 // once during Configure and cached on the provider so self-lockout
-// guards can run against stable values.
+// guards can run against stable values. GrantedRoles is the full set
+// of inbound role edges from mysql.role_edges; DefaultRoles is the
+// subset set as session defaults in mysql.default_roles.
 type callerIdentity struct {
 	User         string
 	Host         string
 	DefaultRoles []roleRef
+	GrantedRoles []roleRef
 }
 
 // roleRef identifies a role by the server's (user, host) tuple.
@@ -45,19 +48,37 @@ func fetchCallerIdentity(ctx context.Context, db *sql.DB) (callerIdentity, error
 		FROM mysql.default_roles
 		WHERE USER = ? AND HOST = ?
 	`, caller.User, caller.Host)
-	if err != nil {
-		// default_roles exists in MySQL 8.0+. If the table is missing
-		// (e.g. 5.7, unlikely here given the version gate but defensive),
-		// treat as no default roles rather than hard-fail.
-		return caller, nil
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var ru, rh string
-		if err := rows.Scan(&ru, &rh); err != nil {
-			return callerIdentity{}, err
+	if err == nil {
+		for rows.Next() {
+			var ru, rh string
+			if err := rows.Scan(&ru, &rh); err != nil {
+				rows.Close()
+				return callerIdentity{}, err
+			}
+			caller.DefaultRoles = append(caller.DefaultRoles, roleRef{User: ru, Host: rh})
 		}
-		caller.DefaultRoles = append(caller.DefaultRoles, roleRef{User: ru, Host: rh})
+		rows.Close()
+	}
+	// If mysql.default_roles is missing (e.g. 5.7, unlikely given the
+	// version gate but defensive), leave DefaultRoles empty.
+
+	// Load the full set of inbound role edges so we can guard
+	// cascade-style lockouts — DROP ROLE of a non-default role
+	// silently revokes the role's privileges from the caller.
+	edgeRows, err := db.QueryContext(ctx, `
+		SELECT FROM_USER, FROM_HOST FROM mysql.role_edges
+		WHERE TO_USER = ? AND TO_HOST = ?
+	`, caller.User, caller.Host)
+	if err == nil {
+		for edgeRows.Next() {
+			var ru, rh string
+			if err := edgeRows.Scan(&ru, &rh); err != nil {
+				edgeRows.Close()
+				return callerIdentity{}, err
+			}
+			caller.GrantedRoles = append(caller.GrantedRoles, roleRef{User: ru, Host: rh})
+		}
+		edgeRows.Close()
 	}
 	return caller, nil
 }
@@ -122,17 +143,46 @@ func classifyDefaultRoleLockout(r provider.Resource, caller callerIdentity) bool
 	if r.ID.Type != "mysql_role" {
 		return false
 	}
-	name := r.ID.Name
-	// Strip any @host suffix if Normalize has been applied.
-	if at := strings.Index(name, "@"); at >= 0 {
-		name = name[:at]
-	}
+	name := roleNameFromID(r.ID.Name)
 	for _, dr := range caller.DefaultRoles {
 		if dr.User == name {
 			return true
 		}
 	}
 	return false
+}
+
+// classifyGrantedRoleCascadeLockout returns true when r is a
+// mysql_role delete whose name matches a role granted to the caller
+// but not set as a default role. Such a delete cascades through
+// mysql.role_edges, silently revoking the role's privileges from the
+// caller. Excludes default roles to avoid double-classification — the
+// default-role case already covers them with a more specific reason.
+func classifyGrantedRoleCascadeLockout(r provider.Resource, caller callerIdentity) bool {
+	if r.ID.Type != "mysql_role" {
+		return false
+	}
+	name := roleNameFromID(r.ID.Name)
+	// Exclude default roles to keep classifications distinct.
+	for _, dr := range caller.DefaultRoles {
+		if dr.User == name {
+			return false
+		}
+	}
+	for _, gr := range caller.GrantedRoles {
+		if gr.User == name {
+			return true
+		}
+	}
+	return false
+}
+
+// roleNameFromID strips any @host suffix Normalize may have applied.
+func roleNameFromID(id string) string {
+	if at := strings.Index(id, "@"); at >= 0 {
+		return id[:at]
+	}
+	return id
 }
 
 // GuardDeletes implements provider.DeleteGuarder. It runs the three
@@ -160,6 +210,12 @@ func (p *Provider) GuardDeletes(_ context.Context, deletes []provider.Resource) 
 				Resource: r.ID,
 				Reason: fmt.Sprintf("would delete caller %s@%s's default role, breaking session auth after apply",
 					p.caller.User, p.caller.Host),
+			})
+		case classifyGrantedRoleCascadeLockout(r, p.caller):
+			guards = append(guards, provider.DeleteGuard{
+				Resource: r.ID,
+				Reason: fmt.Sprintf("would cascade-revoke role %q from caller %s@%s via mysql.role_edges",
+					roleNameFromID(r.ID.Name), p.caller.User, p.caller.Host),
 			})
 		}
 	}

--- a/providers/mysql/account_test.go
+++ b/providers/mysql/account_test.go
@@ -149,6 +149,69 @@ func TestClassifyDefaultRoleLockout(t *testing.T) {
 	}
 }
 
+// TestClassifyGrantedRoleCascadeLockout covers case 4 (non-default
+// role cascade). Role is granted to caller but not default — DROP
+// ROLE would silently cascade-revoke, breaking privileges the caller
+// currently uses.
+func TestClassifyGrantedRoleCascadeLockout(t *testing.T) {
+	caller := callerIdentity{
+		User: "datastorectl", Host: "%",
+		DefaultRoles: []roleRef{{User: "default_role", Host: "%"}},
+		GrantedRoles: []roleRef{
+			{User: "default_role", Host: "%"},
+			{User: "data_reader", Host: "%"},
+			{User: "monitor", Host: "%"},
+		},
+	}
+	cases := []struct {
+		name     string
+		resource provider.Resource
+		want     bool
+	}{
+		{
+			name: "delete granted non-default role",
+			resource: provider.Resource{
+				ID:   provider.ResourceID{Type: "mysql_role", Name: "data_reader"},
+				Body: provider.NewOrderedMap(),
+			},
+			want: true,
+		},
+		{
+			name: "delete another granted non-default role",
+			resource: provider.Resource{
+				ID:   provider.ResourceID{Type: "mysql_role", Name: "monitor"},
+				Body: provider.NewOrderedMap(),
+			},
+			want: true,
+		},
+		{
+			name: "delete default role (case 3 territory, not case 4)",
+			resource: provider.Resource{
+				ID:   provider.ResourceID{Type: "mysql_role", Name: "default_role"},
+				Body: provider.NewOrderedMap(),
+			},
+			// Classified by case 3 (default role delete), not case 4.
+			// Case 4 excludes default roles so we don't double-classify.
+			want: false,
+		},
+		{
+			name: "delete ungranted role",
+			resource: provider.Resource{
+				ID:   provider.ResourceID{Type: "mysql_role", Name: "unrelated"},
+				Body: provider.NewOrderedMap(),
+			},
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := classifyGrantedRoleCascadeLockout(c.resource, caller); got != c.want {
+				t.Errorf("classifyGrantedRoleCascadeLockout = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
 // TestGuardDeletes_Integration runs the full GuardDeletes against a
 // live cluster. Verifies caller-identity fetch and all three cases
 // fire against realistic delete sets.


### PR DESCRIPTION
## Summary
Extends #177's three-case self-lockout protection with a fourth case covering the silent `DROP ROLE` cascade.

- `callerIdentity` grows `GrantedRoles`: the full set of inbound role edges for the caller from `mysql.role_edges`. `DefaultRoles` remains the strict subset from `mysql.default_roles`.
- `classifyGrantedRoleCascadeLockout` fires when a `mysql_role` delete targets a role present in `GrantedRoles` but NOT in `DefaultRoles`. Default-role deletes keep case 3's more specific diagnostic; this case handles only the non-default cascade path.
- `GuardDeletes` dispatch extended with the fifth branch (`case 4`). Reason names the specific role.
- `fetchCallerIdentity` runs a second `mysql.role_edges` query alongside the existing `default_roles` query. Missing tables are tolerated gracefully — leaves the slice empty rather than failing Configure.

## Test plan
- [x] Four new `TestClassifyGrantedRoleCascadeLockout` subcases: granted non-default role (positive), second granted role (positive), default role (negative — owned by case 3), ungranted role (negative).
- [x] Existing `TestGuardDeletes_Integration` continues to pass with the extended caller-identity fetch.
- [x] **End-to-end verified against a live `mysql:8.4` container.**
- [x] `go test ./... -count=1` clean.
- [x] `go vet ./providers/mysql/...` clean.

**Phase 24 complete with this PR.** All three v0.1.0 safety issues closed: #176 (rds_iam), #177 (three base cases), #198 (cascade case).

Closes #198