### PR TITLE
feat(mysql): bootstrap-readwrite.sql and bootstrap-readonly.sql

### DIFF
--- a/providers/mysql/bootstrap/README.md
+++ b/providers/mysql/bootstrap/README.md
@@ -1,0 +1,69 @@
+# mysql bootstrap scripts
+
+SQL scripts that create the MySQL account datastorectl uses to
+manage a cluster. Two variants ship: read-write for plan/apply
+workflows, read-only for plan-only drift detection.
+
+| Script | User | Grants | Use case |
+|--------|------|--------|----------|
+| `bootstrap-readwrite.sql` | `datastorectl@%` | `ALL PRIVILEGES WITH GRANT OPTION` globally + `SELECT` on mysql schema tables | Full plan/apply runs; the default operational account |
+| `bootstrap-readonly.sql` | `datastorectl-ro@%` | `SELECT` only on mysql schema tables | CI drift detection; reviewer-level access; plan-only |
+
+Both scripts enforce `REQUIRE SSL` on the account — plaintext auth
+for a management user is not supported.
+
+## Why the read-write user needs `ALL PRIVILEGES WITH GRANT OPTION`
+
+The write-side grant matches what Puppet's `mysql` module does for
+the same reason: a tool that manages grants must itself hold every
+privilege it may pass on. Scoping down the management account below
+`ALL PRIVILEGES` would mean datastorectl couldn't grant some
+privileges downstream — the tool would fail at apply time with
+confusing partial-grant errors.
+
+This is a category constraint, not a datastorectl choice. Every
+declarative grant-management tool hits it.
+
+## Running the scripts
+
+Replace `<REPLACE_ME>` in the chosen script with a strong password,
+then apply against the cluster as the root (or equivalent) user:
+
+```
+mysql -u root -p < providers/mysql/bootstrap/bootstrap-readwrite.sql
+```
+
+After the read-write script runs, use the new credentials in a DCL
+context block:
+
+```hcl
+context "prod" {
+  provider = mysql
+  version  = "8.4"
+  endpoint = "prod.example.com:3306"
+  auth     = "password"
+  username = "datastorectl"
+  password = secret("env", "DATASTORECTL_MYSQL_PASSWORD")
+  tls      = "required"
+}
+```
+
+For the read-only variant, substitute `datastorectl-ro` and its
+password. Running `datastorectl apply` under the read-only account
+will fail at the first write with a clear MySQL permission error —
+switch to the read-write account for apply workflows.
+
+## On AWS RDS
+
+The scripts work against self-hosted MySQL and RDS. For RDS with IAM
+authentication, replace the `IDENTIFIED WITH caching_sha2_password`
+clause with:
+
+```sql
+CREATE USER 'datastorectl'@'%'
+  IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS'
+  REQUIRE SSL;
+```
+
+See `providers/mysql/README.md` for the full IAM-authentication
+setup including the required IAM policy.

--- a/providers/mysql/bootstrap/bootstrap-readonly.sql
+++ b/providers/mysql/bootstrap/bootstrap-readonly.sql
@@ -1,0 +1,36 @@
+-- datastorectl-mysql bootstrap (read-only)
+-- ------------------------------------------------------------
+-- Creates a read-only management account for plan-only workflows.
+-- Use this when:
+--   - CI runs a drift-detection `datastorectl plan` and you want to
+--     grant it the minimum privileges required.
+--   - A code reviewer runs plan against a preview cluster without
+--     elevation.
+--   - You want to see what datastorectl would change before granting
+--     the full read-write account.
+--
+-- This account can run validate and plan but NOT apply. Any apply
+-- will fail at SQL-execution time with a permission error.
+--
+-- Trust model:
+--   Narrow, read-side only. SELECT on the mysql schema tables the
+--   provider needs for Discover, plus REQUIRE SSL to prevent
+--   credential leakage. No grant option, no CREATE USER, no write
+--   privileges anywhere.
+--
+-- Before running:
+--   1. Replace <REPLACE_ME> with a strong password (32+ chars).
+--   2. Review the host pattern '%' as with the read-write variant.
+
+CREATE USER 'datastorectl-ro'@'%'
+  IDENTIFIED WITH caching_sha2_password BY '<REPLACE_ME>'
+  REQUIRE SSL;
+
+-- Read-side grants only. Mirror of the read-side grants in
+-- bootstrap-readwrite.sql.
+GRANT SELECT ON mysql.user          TO 'datastorectl-ro'@'%';
+GRANT SELECT ON mysql.db            TO 'datastorectl-ro'@'%';
+GRANT SELECT ON mysql.default_roles TO 'datastorectl-ro'@'%';
+GRANT SELECT ON mysql.role_edges    TO 'datastorectl-ro'@'%';
+
+FLUSH PRIVILEGES;

--- a/providers/mysql/bootstrap/bootstrap-readwrite.sql
+++ b/providers/mysql/bootstrap/bootstrap-readwrite.sql
@@ -1,0 +1,39 @@
+-- datastorectl-mysql bootstrap (read-write)
+-- ------------------------------------------------------------
+-- Creates the management account datastorectl expects when it runs
+-- with auth = "password" or auth = "rds_iam" in plan/apply mode.
+-- The grants here mirror ADR 0011's required-privileges list and
+-- correspond to what the self-lockout guard (#177, #198) watches.
+--
+-- Trust model:
+--   This user holds ALL PRIVILEGES ... WITH GRANT OPTION globally.
+--   That is intentional — a tool that manages grants must itself hold
+--   every privilege it may pass on. Puppet's mysql module operates
+--   under the same constraint. Keep the password in a secrets store
+--   and gate connections with REQUIRE SSL.
+--
+-- Before running:
+--   1. Replace <REPLACE_ME> with a strong password (32+ chars).
+--   2. Review the host pattern '%' — tighten it if your network
+--      policy supports scoping (e.g. '10.0.0.0/8').
+--   3. Apply against a fresh cluster or one where no prior
+--      'datastorectl' account exists.
+
+CREATE USER 'datastorectl'@'%'
+  IDENTIFIED WITH caching_sha2_password BY '<REPLACE_ME>'
+  REQUIRE SSL;
+
+-- Read-side grants for Discover.
+GRANT SELECT ON mysql.user         TO 'datastorectl'@'%';
+GRANT SELECT ON mysql.db           TO 'datastorectl'@'%';
+GRANT SELECT ON mysql.default_roles TO 'datastorectl'@'%';
+GRANT SELECT ON mysql.role_edges   TO 'datastorectl'@'%';
+
+-- Write-side grants for Apply. ALL PRIVILEGES covers CREATE USER,
+-- CREATE/DROP ROLE, CREATE/DROP SCHEMA, GRANT/REVOKE at every scope.
+-- SYSTEM_USER is the 8.0+ dynamic privilege needed to manage other
+-- accounts that themselves hold SYSTEM_USER.
+GRANT ALL PRIVILEGES ON *.* TO 'datastorectl'@'%' WITH GRANT OPTION;
+GRANT SYSTEM_USER ON *.* TO 'datastorectl'@'%';
+
+FLUSH PRIVILEGES;


### PR DESCRIPTION
## Summary
Ships the two SQL scripts that create the datastorectl management account per ADR 0011.

| Script | User | Grants | Use case |
|--------|------|--------|----------|
| `bootstrap-readwrite.sql` | `datastorectl@%` | ALL PRIVILEGES WITH GRANT OPTION + mysql.* SELECT | Full plan/apply |
| `bootstrap-readonly.sql` | `datastorectl-ro@%` | mysql.* SELECT only | CI drift detection, reviewer access, plan-only |

Both enforce `REQUIRE SSL`. Both use a `<REPLACE_ME>` password placeholder with explicit pre-run guidance.

`providers/mysql/bootstrap/README.md` explains the trust model (specifically why the read-write user needs `ALL PRIVILEGES WITH GRANT OPTION` — a category constraint inherited from every declarative grant-management tool) and documents the RDS IAM substitution for the authentication clause.

## Test plan
- [x] Both scripts apply cleanly against a fresh `mysql:8.4` container.
- [x] `SHOW GRANTS FOR 'datastorectl'@'%'` after readwrite apply returns the expected static + dynamic privilege expansion (34 static privileges, 45 dynamic privileges, WITH GRANT OPTION on both, plus the four mysql.* SELECTs).
- [x] `SHOW GRANTS FOR 'datastorectl-ro'@'%'` returns only USAGE + the four mysql.* SELECTs.
- [x] `go test ./... -count=1` unaffected (scripts aren't consumed by Go code).

Closes #178