### PR TITLE
fix(engine): relabel graph nodes after Normalize rewrites ID.Name

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -136,6 +136,23 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		return nil, fmt.Errorf("normalize live: %w", err)
 	}
 
+	// 12b. Relabel graph nodes whose Normalize changed ResourceID.Name.
+	// mysql_user and similar providers encode a multi-dimensional
+	// identity tuple (e.g. "user@host") into ID.Name during Normalize.
+	// Without this relabel, OrderPlan correlates graph layers against
+	// plan.Changes using mismatched IDs and silently drops resources
+	// whose Normalize changed their ID. We preserve reference and
+	// type-ordering edges by relabeling in place rather than rebuilding
+	// (reference edges were computed from pre-resolution RefVals that
+	// are no longer present on post-resolution resources).
+	if len(desired) == len(normalizedDesired) {
+		for i := range desired {
+			if desired[i].ID != normalizedDesired[i].ID {
+				graph.RelabelNode(desired[i].ID, normalizedDesired[i].ID)
+			}
+		}
+	}
+
 	// 13. Build full plan.
 	plan := BuildPlan(normalizedDesired, normalizedLive)
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -225,6 +225,57 @@ func TestEnginePlan(t *testing.T) {
 		}
 	})
 
+	t.Run("normalize_rewrites_id", func(t *testing.T) {
+		// Regression for #205: when a provider's Normalize rewrites
+		// ResourceID.Name (e.g. mysql_user encoding (user, host) into
+		// "user@host"), the resource must still apply end-to-end. Before
+		// the fix, the dependency graph was built pre-Normalize and
+		// OrderPlan silently dropped resources whose IDs changed.
+		var appliedIDs []provider.ResourceID
+		mock := &mockEngineProvider{
+			normalizeFn: func(_ context.Context, r provider.Resource) (provider.Resource, dcl.Diagnostics) {
+				// Rewrite Name to simulate identity-tuple encoding.
+				r.ID.Name = r.ID.Name + "@normalized"
+				return r, nil
+			},
+			applyFn: func(_ context.Context, _ provider.Operation, r provider.Resource) dcl.Diagnostics {
+				appliedIDs = append(appliedIDs, r.ID)
+				return nil
+			},
+		}
+		provider.Register("engnorm", func() provider.Provider { return mock })
+
+		file := makeFile(
+			provider.ResourceID{Type: "engnorm_role", Name: "alpha"},
+			provider.ResourceID{Type: "engnorm_role", Name: "beta"},
+		)
+
+		e := &Engine{SecretResolver: stubSecretResolver{}}
+		result, err := e.Apply(context.Background(), file, nil, PlanOptions{})
+		if err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+
+		if len(result.Results) != 2 {
+			t.Fatalf("expected 2 apply results, got %d: %+v", len(result.Results), result.Results)
+		}
+		for _, r := range result.Results {
+			if r.Status != StatusSuccess {
+				t.Errorf("expected success for %s, got %s (err=%v)", r.ID, r.Status, r.Error)
+			}
+		}
+
+		// Both applies must have seen the post-Normalize ID form.
+		if len(appliedIDs) != 2 {
+			t.Fatalf("expected 2 applyFn calls, got %d", len(appliedIDs))
+		}
+		for _, id := range appliedIDs {
+			if !strings.HasSuffix(id.Name, "@normalized") {
+				t.Errorf("applyFn saw ID.Name %q without @normalized suffix — Normalize output was bypassed", id.Name)
+			}
+		}
+	})
+
 	t.Run("normalization_affects_diff", func(t *testing.T) {
 		// Normalize uppercases string values. Desired "hello", live "HELLO" →
 		// after normalization both are "HELLO" → ChangeNoOp.

--- a/engine/graph.go
+++ b/engine/graph.go
@@ -57,3 +57,44 @@ func (g *Graph) DependsOn(id provider.ResourceID) []provider.ResourceID {
 func (g *Graph) DependedOnBy(id provider.ResourceID) []provider.ResourceID {
 	return g.reverse[id]
 }
+
+// RelabelNode renames a node while preserving every edge that touches
+// it. Used when a provider's Normalize rewrites ResourceID.Name so the
+// plan's post-Normalize IDs stay wired to the graph built from
+// reference-resolution-time IDs. No-op when old == new. No-op when
+// old is not registered.
+func (g *Graph) RelabelNode(old, new provider.ResourceID) {
+	if old == new {
+		return
+	}
+	if _, ok := g.nodes[old]; !ok {
+		return
+	}
+	delete(g.nodes, old)
+	g.nodes[new] = struct{}{}
+
+	// Forward edges: old → *.
+	deps := g.forward[old]
+	delete(g.forward, old)
+	g.forward[new] = deps
+	// Update reverse pointers that referenced `old` as a dependent.
+	for _, dep := range deps {
+		for i, parent := range g.reverse[dep] {
+			if parent == old {
+				g.reverse[dep][i] = new
+			}
+		}
+	}
+
+	// Reverse edges: * → old.
+	dependents := g.reverse[old]
+	delete(g.reverse, old)
+	g.reverse[new] = dependents
+	for _, dep := range dependents {
+		for i, child := range g.forward[dep] {
+			if child == old {
+				g.forward[dep][i] = new
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Fixes the silent-drop bug tracked in #205. When a provider's Normalize rewrites `ResourceID.Name` (e.g. mysql_user encoding `(user, host)` into `"user@host"`), OrderPlan silently drops those resources because the dependency graph was built pre-Normalize but correlated post-Normalize. Apply executes only the subset whose IDs didn't change — database and role in the mysql showcase; users and grants silently dropped.

- `engine/graph.go`: new `RelabelNode(old, new)` method. Renames in place, fixes every forward and reverse edge.
- `engine/engine.go`: after step 12 (normalize), walk `desired` and `normalizedDesired` in lockstep (NormalizeResources preserves slice order) and call RelabelNode for each pair whose ID changed. Chose relabeling over graph rebuild because reference edges were computed from pre-resolution `RefVal` bodies that are no longer present on post-resolution resources — rebuild would lose them.
- `engine/engine_test.go`: regression test `TestEnginePlan/normalize_rewrites_id`. A mock provider whose Normalize appends `@normalized` to every ID. Asserts both applies succeed and applyFn saw the post-Normalize ID form.

## Test plan
- [x] `TestEnginePlan/normalize_rewrites_id` is the direct regression guard — without the fix, applyFn is called 0 times.
- [x] Existing `graph_has_reference_edges` subtest still passes — relabeling preserves reference edges.
- [x] `go test ./... -count=1` all packages pass.
- [x] `go vet ./engine/...` clean.
- [x] **End-to-end verified against a live mysql:8.4 cluster.** mysql showcase DCL (7 resources including mysql_user and mysql_grant which rewrite IDs in Normalize) now applies all 7 rather than silently stopping at 2.

## Followup required before showcase

The engine fix unblocks applying all 7 resources but a second `plan` still reports drift because of a separate shape-matching gap: declared `mysql_user` with `password = secret(...)` and discovered `password_hash = "$A$005$..."` are structurally different. The engine's attribute-by-attribute diff sees that as drift even though `auth.Compare` would report a match. That's tracked separately — the showcase (#179) lands after that's resolved.

Closes #205