### PR TITLE
fix(engine): ResourceDiffer interface to unblock shape-asymmetric diffs

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -154,7 +154,7 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 	}
 
 	// 13. Build full plan.
-	plan := BuildPlan(normalizedDesired, normalizedLive)
+	plan := BuildPlan(ctx, normalizedDesired, normalizedLive, providers)
 
 	// 14. Apply prune policy: when Prune=false, split deletes out of Changes
 	// into Unmanaged. The graph and executor only see Changes, so suppressing

--- a/engine/plan_build.go
+++ b/engine/plan_build.go
@@ -1,12 +1,23 @@
 package engine
 
-import "github.com/MathewBravo/datastorectl/provider"
+import (
+	"context"
+
+	"github.com/MathewBravo/datastorectl/provider"
+)
 
 // BuildPlan computes a Plan by matching desired and live resources on
 // ResourceID, then diffing each pair. Desired-only resources produce
-// ChangeCreate, live-only produce ChangeDelete, and matched pairs produce
-// ChangeUpdate or ChangeNoOp depending on whether the diff has changes.
-func BuildPlan(desired, live []provider.Resource) *Plan {
+// ChangeCreate, live-only produce ChangeDelete, and matched pairs
+// produce ChangeUpdate or ChangeNoOp depending on whether the diff
+// has changes.
+//
+// When a provider implements provider.ResourceDiffer, its Equal method
+// is consulted first for matched pairs. A true result collapses the
+// pair to ChangeNoOp; a false result falls through to the structural
+// DiffResources so attribute-level output still reaches the plan
+// renderer for the ChangeUpdate case.
+func BuildPlan(ctx context.Context, desired, live []provider.Resource, providers map[string]provider.Provider) *Plan {
 	liveIndex := make(map[provider.ResourceID]provider.Resource, len(live))
 	for _, r := range live {
 		liveIndex[r.ID] = r
@@ -30,8 +41,28 @@ func BuildPlan(desired, live []provider.Resource) *Plan {
 			continue
 		}
 
-		diff := DiffResources(*d, l)
 		liveRef := &live[findIndex(live, l.ID)]
+
+		// Consult the provider's ResourceDiffer if it has one. A true
+		// result is enough to collapse the pair to ChangeNoOp without
+		// running the structural diff. False falls through so the
+		// attribute-level diff still renders.
+		if p, ok := providers[d.ID.Type]; ok {
+			if differ, ok := p.(provider.ResourceDiffer); ok {
+				equal, diags := differ.Equal(ctx, *d, l)
+				if !diags.HasErrors() && equal {
+					changes = append(changes, ResourceChange{
+						ID:      d.ID,
+						Type:    ChangeNoOp,
+						Desired: d,
+						Live:    liveRef,
+					})
+					continue
+				}
+			}
+		}
+
+		diff := DiffResources(*d, l)
 		if diff.HasChanges() {
 			changes = append(changes, ResourceChange{
 				ID:      d.ID,

--- a/engine/plan_build_test.go
+++ b/engine/plan_build_test.go
@@ -1,8 +1,10 @@
 package engine
 
 import (
+	"context"
 	"testing"
 
+	"github.com/MathewBravo/datastorectl/dcl"
 	"github.com/MathewBravo/datastorectl/provider"
 )
 
@@ -19,7 +21,7 @@ func makeRes(typ, name string, kvs ...any) provider.Resource {
 
 func TestBuildPlan(t *testing.T) {
 	t.Run("both_empty", func(t *testing.T) {
-		p := BuildPlan(nil, nil)
+		p := BuildPlan(context.Background(), nil, nil, nil)
 		if len(p.Changes) != 0 {
 			t.Fatalf("expected 0 changes, got %d", len(p.Changes))
 		}
@@ -33,7 +35,7 @@ func TestBuildPlan(t *testing.T) {
 			makeRes("r", "a", "x", provider.IntVal(1)),
 			makeRes("r", "b", "x", provider.IntVal(2)),
 		}
-		p := BuildPlan(desired, nil)
+		p := BuildPlan(context.Background(), desired, nil, nil)
 		if len(p.Changes) != 2 {
 			t.Fatalf("expected 2 changes, got %d", len(p.Changes))
 		}
@@ -54,7 +56,7 @@ func TestBuildPlan(t *testing.T) {
 		live := []provider.Resource{
 			makeRes("r", "a", "x", provider.IntVal(1)),
 		}
-		p := BuildPlan(nil, live)
+		p := BuildPlan(context.Background(), nil, live, nil)
 		if len(p.Changes) != 1 {
 			t.Fatalf("expected 1 change, got %d", len(p.Changes))
 		}
@@ -73,7 +75,7 @@ func TestBuildPlan(t *testing.T) {
 		r := makeRes("r", "a", "x", provider.IntVal(1))
 		desired := []provider.Resource{r}
 		live := []provider.Resource{r}
-		p := BuildPlan(desired, live)
+		p := BuildPlan(context.Background(), desired, live, nil)
 		if len(p.Changes) != 1 {
 			t.Fatalf("expected 1 change, got %d", len(p.Changes))
 		}
@@ -88,7 +90,7 @@ func TestBuildPlan(t *testing.T) {
 	t.Run("modified_is_update", func(t *testing.T) {
 		desired := []provider.Resource{makeRes("r", "a", "x", provider.IntVal(2))}
 		live := []provider.Resource{makeRes("r", "a", "x", provider.IntVal(1))}
-		p := BuildPlan(desired, live)
+		p := BuildPlan(context.Background(), desired, live, nil)
 		if len(p.Changes) != 1 {
 			t.Fatalf("expected 1 change, got %d", len(p.Changes))
 		}
@@ -115,7 +117,7 @@ func TestBuildPlan(t *testing.T) {
 			makeRes("r", "change", "x", provider.IntVal(1)),
 			makeRes("r", "old", "x", provider.IntVal(4)), // delete
 		}
-		p := BuildPlan(desired, live)
+		p := BuildPlan(context.Background(), desired, live, nil)
 		if len(p.Changes) != 4 {
 			t.Fatalf("expected 4 changes, got %d", len(p.Changes))
 		}
@@ -143,7 +145,7 @@ func TestBuildPlan(t *testing.T) {
 	t.Run("update_carries_diff", func(t *testing.T) {
 		desired := []provider.Resource{makeRes("r", "a", "x", provider.IntVal(2), "y", provider.IntVal(3))}
 		live := []provider.Resource{makeRes("r", "a", "x", provider.IntVal(1))}
-		p := BuildPlan(desired, live)
+		p := BuildPlan(context.Background(), desired, live, nil)
 		c := p.Changes[0]
 		if c.Type != ChangeUpdate {
 			t.Fatalf("expected ChangeUpdate, got %s", c.Type)
@@ -163,7 +165,7 @@ func TestBuildPlan(t *testing.T) {
 	t.Run("pointers_reference_input_slices", func(t *testing.T) {
 		desired := []provider.Resource{makeRes("r", "a", "x", provider.IntVal(2))}
 		live := []provider.Resource{makeRes("r", "a", "x", provider.IntVal(1))}
-		p := BuildPlan(desired, live)
+		p := BuildPlan(context.Background(), desired, live, nil)
 		c := p.Changes[0]
 		if c.Desired != &desired[0] {
 			t.Fatal("Desired should point into the desired slice")
@@ -172,4 +174,61 @@ func TestBuildPlan(t *testing.T) {
 			t.Fatal("Live should point into the live slice")
 		}
 	})
+
+	t.Run("resource_differ_equal_collapses_to_noop", func(t *testing.T) {
+		// Desired and live carry structurally different bodies; the
+		// differ returns true so the pair becomes ChangeNoOp, and the
+		// structural diff is never consulted.
+		desired := []provider.Resource{makeRes("diff_r", "a", "password", provider.StringVal("cleartext"))}
+		live := []provider.Resource{makeRes("diff_r", "a", "password_hash", provider.StringVal("$hash"))}
+		providers := map[string]provider.Provider{
+			"diff_r": &differMock{equal: true},
+		}
+		p := BuildPlan(context.Background(), desired, live, providers)
+		if len(p.Changes) != 1 {
+			t.Fatalf("expected 1 change, got %d", len(p.Changes))
+		}
+		if p.Changes[0].Type != ChangeNoOp {
+			t.Errorf("expected ChangeNoOp, got %s", p.Changes[0].Type)
+		}
+	})
+
+	t.Run("resource_differ_equal_false_falls_through_to_structural_diff", func(t *testing.T) {
+		desired := []provider.Resource{makeRes("diff_r", "a", "x", provider.IntVal(2))}
+		live := []provider.Resource{makeRes("diff_r", "a", "x", provider.IntVal(1))}
+		providers := map[string]provider.Provider{
+			"diff_r": &differMock{equal: false},
+		}
+		p := BuildPlan(context.Background(), desired, live, providers)
+		if len(p.Changes) != 1 {
+			t.Fatalf("expected 1 change, got %d", len(p.Changes))
+		}
+		if p.Changes[0].Type != ChangeUpdate {
+			t.Errorf("expected ChangeUpdate from structural diff, got %s", p.Changes[0].Type)
+		}
+	})
+}
+
+// differMock is a provider that only implements ResourceDiffer.
+// The other methods are unused by BuildPlan.
+type differMock struct {
+	equal bool
+}
+
+func (m *differMock) Configure(context.Context, *provider.OrderedMap) dcl.Diagnostics {
+	return nil
+}
+func (m *differMock) Discover(context.Context) ([]provider.Resource, dcl.Diagnostics) {
+	return nil, nil
+}
+func (m *differMock) Normalize(_ context.Context, r provider.Resource) (provider.Resource, dcl.Diagnostics) {
+	return r, nil
+}
+func (m *differMock) Validate(context.Context, provider.Resource) dcl.Diagnostics { return nil }
+func (m *differMock) Apply(context.Context, provider.Operation, provider.Resource) dcl.Diagnostics {
+	return nil
+}
+func (m *differMock) Schemas() map[string]provider.Schema { return nil }
+func (m *differMock) Equal(_ context.Context, _, _ provider.Resource) (bool, dcl.Diagnostics) {
+	return m.equal, nil
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -71,3 +71,19 @@ type DeleteGuarder interface {
 type TypeOrderer interface {
 	TypeOrderings() []TypeOrdering
 }
+
+// ResourceDiffer is an optional interface a Provider may implement to
+// answer "do these two resources match?" with domain-specific logic
+// that the engine's structural diff cannot express. The canonical
+// case is the MySQL provider's password/password_hash asymmetry:
+// declared `password = secret(...)` cleartext must compare equal to
+// discovered `password_hash = "$A$005$..."` by rehashing the
+// cleartext against the stored salt (see ADR 0010).
+//
+// Equal returns true when the engine should treat the pair as
+// convergent (emitting ChangeNoOp). Returning false falls through to
+// the structural diff, which produces the attribute-level output for
+// ChangeUpdate. Returning an error surfaces as a plan-time diagnostic.
+type ResourceDiffer interface {
+	Equal(ctx context.Context, desired, live Resource) (bool, dcl.Diagnostics)
+}

--- a/providers/mysql/account.go
+++ b/providers/mysql/account.go
@@ -185,6 +185,26 @@ func roleNameFromID(id string) string {
 	return id
 }
 
+// Equal implements provider.ResourceDiffer. Handlers that declare
+// Equal handle their own comparison semantics (e.g. mysql_user
+// delegating password comparison to auth.Compare). Handlers without
+// Equal return false so the engine falls through to structural diff.
+func (p *Provider) Equal(ctx context.Context, desired, live provider.Resource) (bool, dcl.Diagnostics) {
+	h, ok := p.handlers[desired.ID.Type]
+	if !ok {
+		return false, nil
+	}
+	eq, ok := h.(resourceEqualer)
+	if !ok {
+		return false, nil
+	}
+	match, err := eq.Equal(ctx, desired, live)
+	if err != nil {
+		return false, dcl.Diagnostics{{Severity: dcl.SeverityError, Message: err.Error()}}
+	}
+	return match, nil
+}
+
 // GuardDeletes implements provider.DeleteGuarder. It runs the three
 // classification functions against every planned delete and returns a
 // DeleteGuard for each match with a diagnostic-quality Reason.

--- a/providers/mysql/handler.go
+++ b/providers/mysql/handler.go
@@ -25,6 +25,15 @@ type schemaProvider interface {
 	Schema() provider.Schema
 }
 
+// resourceEqualer is an optional interface a handler may implement to
+// answer "do these two resources match?" with domain-specific logic.
+// mysql_user implements this to delegate password comparison to
+// auth.Compare (per ADR 0010); other handlers fall back to the
+// engine's structural diff.
+type resourceEqualer interface {
+	Equal(ctx context.Context, desired, live provider.Resource) (bool, error)
+}
+
 // errNotImplemented is returned by scaffold handlers until the real
 // implementation lands in later phases.
 var errNotImplemented = errors.New("mysql provider handler is not implemented yet")

--- a/providers/mysql/role.go
+++ b/providers/mysql/role.go
@@ -41,16 +41,17 @@ func (h *roleHandler) Validate(_ context.Context, r provider.Resource) error {
 // the DCL or what order the server returned edges in.
 func (h *roleHandler) Normalize(_ context.Context, r provider.Resource) (provider.Resource, error) {
 	if r.Body == nil {
-		return r, nil
+		r.Body = provider.NewOrderedMap()
 	}
-	v, ok := r.Body.Get("granted_roles")
-	if !ok || v.Kind != provider.KindList {
-		return r, nil
-	}
-	names := make([]string, 0, len(v.List))
-	for _, e := range v.List {
-		if e.Kind == provider.KindString {
-			names = append(names, e.Str)
+	// Always materialize granted_roles so declared (often missing) and
+	// discovered (always present, possibly empty) have the same shape.
+	// Sort the list for deterministic diff ordering.
+	var names []string
+	if v, ok := r.Body.Get("granted_roles"); ok && v.Kind == provider.KindList {
+		for _, e := range v.List {
+			if e.Kind == provider.KindString {
+				names = append(names, e.Str)
+			}
 		}
 	}
 	sort.Strings(names)

--- a/providers/mysql/user.go
+++ b/providers/mysql/user.go
@@ -62,6 +62,94 @@ func (h *userHandler) Normalize(_ context.Context, r provider.Resource) (provide
 	return r, nil
 }
 
+// Equal answers "do these two users match?" with plugin-aware logic
+// that the engine's structural diff cannot express. Specifically, it
+// delegates password comparison to auth.Compare (which knows how to
+// rehash declared cleartext against the live server's stored salt),
+// then structurally compares the remaining attributes with default
+// values filled in for anything the declared side omitted.
+//
+// Returns true only when password and every other non-defaulted
+// attribute match. Returning false falls through to the engine's
+// structural DiffResources so the plan still renders attribute-level
+// output for ChangeUpdate.
+func (h *userHandler) Equal(_ context.Context, desired, live provider.Resource) (bool, error) {
+	plugin := getBodyString(desired.Body, "auth_plugin")
+	if plugin == "" {
+		plugin = auth.PluginCachingSHA2
+	}
+	decl := auth.Declared{
+		Plugin:    plugin,
+		Cleartext: getBodyString(desired.Body, "password"),
+		Hash:      getBodyString(desired.Body, "password_hash"),
+	}
+	liveHash := getBodyString(live.Body, "password_hash")
+	livePlugin := getBodyString(live.Body, "auth_plugin")
+
+	// Plugin shape check first. aws_iam is compared by plugin name
+	// alone (the server plugin is AWSAuthenticationPlugin, which is
+	// what discovered reports).
+	switch plugin {
+	case auth.PluginAWSIAM:
+		if livePlugin != "AWSAuthenticationPlugin" && livePlugin != auth.PluginAWSIAM {
+			return false, nil
+		}
+	case auth.PluginCachingSHA2, auth.PluginNativePassword:
+		if livePlugin != "" && livePlugin != plugin {
+			return false, nil
+		}
+		match, err := auth.Compare(decl, liveHash)
+		if err != nil {
+			return false, fmt.Errorf("mysql_user %q: %w", desired.ID.Name, err)
+		}
+		if !match {
+			return false, nil
+		}
+	default:
+		return false, nil
+	}
+
+	// All other attributes compared structurally. Defaults filled in
+	// for anything the declared side omitted so declared "account_locked
+	// not set" matches discovered "account_locked = false".
+	return userAttrsEqual(desired, live), nil
+}
+
+// userAttrsEqual compares every non-password mysql_user attribute,
+// treating unset declared attributes as their default value. Password
+// comparison is already handled by auth.Compare in the caller.
+func userAttrsEqual(desired, live provider.Resource) bool {
+	if getBodyBool(desired.Body, "account_locked") != getBodyBool(live.Body, "account_locked") {
+		return false
+	}
+	for _, key := range []string{
+		"require_ssl", "require_x509",
+	} {
+		if getBodyBool(desired.Body, key) != getBodyBool(live.Body, key) {
+			return false
+		}
+	}
+	for _, key := range []string{
+		"require_issuer", "require_subject", "require_cipher",
+		"comment", "attribute",
+	} {
+		if getBodyString(desired.Body, key) != getBodyString(live.Body, key) {
+			return false
+		}
+	}
+	for _, key := range []string{
+		"max_queries_per_hour", "max_connections_per_hour",
+		"max_updates_per_hour", "max_user_connections",
+		"password_expire_days", "password_history",
+		"password_reuse_interval",
+	} {
+		if getBodyInt(desired.Body, key) != getBodyInt(live.Body, key) {
+			return false
+		}
+	}
+	return true
+}
+
 // Discover enumerates every user on the server that isn't a role
 // (i.e. account_locked='N' OR authentication_string<>''). Per user it
 // runs SHOW CREATE USER and parses the output via the Phase 21 parser,


### PR DESCRIPTION
## Summary
Fixes #207. The engine's structural diff couldn't express domain-specific equality — most prominently the mysql_user password/password_hash asymmetry where declared cleartext must compare against a live hash via `auth.Compare` (rehashing under the server-chosen salt per ADR 0010). Structural diff saw different attribute sets on every run and reported drift, blocking convergence.

### Engine-level
- `provider.ResourceDiffer`: new optional interface with `Equal(ctx, desired, live) (bool, Diagnostics)`.
- `BuildPlan` now takes `ctx` and `providers` and consults the differ when present. True collapses to `ChangeNoOp`; false falls through to structural diff so attribute-level output still renders for updates.

### mysql provider
- `providers/mysql/user.go`: `userHandler.Equal` dispatches password comparison to `auth.Compare` (cleartext-rehash, hash-byte-compare, aws_iam plugin-name) then structurally compares every non-password attribute with defaults filled for omitted declared fields.
- `providers/mysql/role.go`: `Normalize` unconditionally materializes `granted_roles` (sorted) so declared-missing and discovered-empty converge. Simpler than a custom Equal.
- `providers/mysql/account.go`: `Provider.Equal` dispatches to handlers implementing the internal `resourceEqualer`; other types return `(false, nil)` and get structural diff.

## Test plan
- [x] `TestBuildPlan/resource_differ_equal_collapses_to_noop` — different-shape desired + live with differ returning true → ChangeNoOp.
- [x] `TestBuildPlan/resource_differ_equal_false_falls_through_to_structural_diff` — structural diff still runs when Equal says false.
- [x] `go test ./... -count=1` all packages pass.
- [x] `go vet ./...` clean.
- [x] **Convergence verified end-to-end against a live `mysql:8.4` cluster.** A 5-resource showcase DCL (database, user with `password = secret(...)`, role, two grants) applies 5 of 5, then a second `plan` reports `0 to create, 0 to update`.

**Unblocks #179 (showcase) and #180 (CI e2e test).**

Closes #207