### PR TITLE
feat(mysql): showcase-mysql.sh + testdata/showcase-mysql/resources.dcl

### DIFF
--- a/showcase-mysql.sh
+++ b/showcase-mysql.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BOOTSTRAP_PW="showcase_pw_4rEaDy"
+
+case "${1:-help}" in
+  up)
+    echo "Starting MySQL..."
+    docker compose -f docker-compose.mysql.yml up -d
+    echo "Waiting for cluster to be healthy..."
+    until docker exec datastorectl-mysql-1 mysqladmin ping -h localhost -uroot -pdatastorectl --silent 2>/dev/null; do
+      sleep 2
+    done
+    echo "Cluster is ready."
+    echo ""
+    echo "Provisioning the datastorectl management account..."
+    sed "s/<REPLACE_ME>/${BOOTSTRAP_PW}/" providers/mysql/bootstrap/bootstrap-readwrite.sql \
+      | docker exec -i datastorectl-mysql-1 mysql -uroot -pdatastorectl 2>/dev/null
+    echo "Bootstrap applied."
+    echo ""
+    echo "Building datastorectl..."
+    go build -o datastorectl ./cmd/datastorectl
+    echo "Done."
+    echo ""
+    echo "Run the showcase (export the passwords for secret() resolution):"
+    echo ""
+    echo "  export DATASTORECTL_MYSQL_PASSWORD=${BOOTSTRAP_PW}"
+    echo "  export DATASTORECTL_MYSQL_APP_PW=app_demo_pw"
+    echo "  export DATASTORECTL_MYSQL_OPS_PW=ops_demo_pw"
+    echo ""
+    echo "  ./datastorectl validate testdata/showcase-mysql/resources.dcl"
+    echo "  ./datastorectl plan     testdata/showcase-mysql/resources.dcl"
+    echo "  ./datastorectl apply    testdata/showcase-mysql/resources.dcl"
+    echo "  ./datastorectl plan     testdata/showcase-mysql/resources.dcl   # converges"
+    echo ""
+    echo "To see the self-lockout guard fire, try:"
+    echo "  ./datastorectl plan --prune testdata/showcase-mysql/resources.dcl"
+    echo ""
+    ;;
+  down)
+    echo "Stopping MySQL..."
+    docker compose -f docker-compose.mysql.yml down
+    echo "Done."
+    ;;
+  *)
+    echo "Usage: ./showcase-mysql.sh [up|down]"
+    echo ""
+    echo "  up    Start MySQL + bootstrap datastorectl account + build binary"
+    echo "  down  Stop MySQL"
+    ;;
+esac

--- a/testdata/showcase-mysql/resources.dcl
+++ b/testdata/showcase-mysql/resources.dcl
@@ -1,0 +1,98 @@
+context "demo" {
+  provider = mysql
+  version  = "8.4"
+  endpoint = "localhost:3306"
+  auth     = "password"
+  username = "datastorectl"
+  password = secret("env", "DATASTORECTL_MYSQL_PASSWORD")
+  tls      = "skip-verify"
+}
+
+# --- Schema ---
+
+mysql_database "appdb" {
+  context   = demo
+  charset   = "utf8mb4"
+  collation = "utf8mb4_0900_ai_ci"
+}
+
+# --- Users ---
+
+# App user. Cleartext password resolved from env via secret();
+# the provider rehashes against the server-chosen salt to diff.
+mysql_user "app" {
+  context  = demo
+  user     = "app"
+  host     = "%"
+  password = secret("env", "DATASTORECTL_MYSQL_APP_PW")
+}
+
+# Ops user. Second credential resolved from its own env var. Real
+# deployments would source distinct passwords per user from a secret
+# store via an appropriate secret() backend.
+mysql_user "ops" {
+  context  = demo
+  user     = "ops"
+  host     = "%"
+  password = secret("env", "DATASTORECTL_MYSQL_OPS_PW")
+}
+
+# Note on password_hash: the provider also supports
+#     password_hash = secret("env", "...")
+# for users whose mysql_native_password hashes already live in
+# Hiera or a secret store (the Puppet migration path). We don't
+# demonstrate it here because mysql_native_password is disabled by
+# default on mysql:8.4. See providers/mysql/README.md for that form.
+
+# --- Roles ---
+
+mysql_role "reader" {
+  context = demo
+}
+
+# --- Grants ---
+
+# Global monitoring access for the reader role.
+mysql_grant "reader_monitoring" {
+  context    = demo
+  user       = "reader"
+  host       = "%"
+  database   = "*"
+  table      = "*"
+  privileges = ["PROCESS", "REPLICATION CLIENT"]
+}
+
+# Schema-level data grant for the app user.
+mysql_grant "app_schema" {
+  context    = demo
+  user       = "app"
+  host       = "%"
+  database   = "appdb"
+  table      = "*"
+  privileges = ["SELECT", "INSERT", "UPDATE", "DELETE"]
+}
+
+# Schema-level grant with GRANT OPTION. Ops can further delegate
+# SELECT on appdb to other users. Table-level scope works the same
+# way — drop `table = "*"` for `table = "events"` (the table must
+# exist before the grant applies).
+mysql_grant "ops_appdb_readable" {
+  context      = demo
+  user         = "ops"
+  host         = "%"
+  database     = "appdb"
+  table        = "*"
+  privileges   = ["SELECT"]
+  grant_option = true
+}
+
+# --- Self-lockout demo note ---
+#
+# The management user (datastorectl) authenticates via the context
+# above. It holds ALL PRIVILEGES WITH GRANT OPTION globally, plus
+# mysql.* SELECTs, none of which are declared as mysql_grant blocks
+# here. That is deliberate — running `apply --prune` against this
+# config would attempt to revoke every one of those grants, which
+# the self-lockout guard catches and refuses with a clear reason.
+#
+# Try:   ./datastorectl plan --prune testdata/showcase-mysql/resources.dcl


### PR DESCRIPTION
## Summary
Ships the MySQL showcase paralleling the existing OpenSearch one. `./showcase-mysql.sh up` brings up `mysql:8.4` via Docker Compose, applies `bootstrap-readwrite.sql` with a deterministic password, builds the binary, and prints the env-var exports + validate/plan/apply sequence.

### `testdata/showcase-mysql/resources.dcl` covers every v0.1.0 shape
- One context block (`version = "8.4"`, password auth, TLS skip-verify for the self-signed mysql:8.4 cert).
- `mysql_database "appdb"` with utf8mb4.
- Two `mysql_user` blocks, each with its own `secret("env", ...)` password — demonstrates multi-credential configs.
- `mysql_role "reader"`.
- Three `mysql_grant` blocks covering the three supported scopes: global, schema, schema with `WITH GRANT OPTION`.
- Commented pointer to the `password_hash` form for Puppet/Hiera migrations (not demoed because `mysql_native_password` is disabled by default on 8.4).
- Footer note explaining how to see the self-lockout guard fire via `--prune`.

## Test plan
End-to-end verified against a live `mysql:8.4` container:
- [x] `validate` → `Valid.`
- [x] `apply` → `7 succeeded, 0 failed, 0 skipped`
- [x] Second `plan` → `0 to create, 0 to update` (convergence)
- [x] `plan --prune` → multiple self-lockout guards fire, naming the caller and blocked privilege sets
- [x] `go test ./... -count=1` all packages pass (no Go code changes in this PR)

## Unblocked by
- #206 (engine graph relabel after Normalize)
- #208 (ResourceDiffer for password/hash asymmetry)

Both shipped just now; this PR turns them into a demo.

Closes #179