### PR TITLE
engine: cross-resource validation for mysql user/host and role collisions

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -136,6 +136,18 @@ func (e *Engine) plan(ctx context.Context, file *dcl.File, configs map[string]*p
 		return nil, fmt.Errorf("normalize live: %w", err)
 	}
 
+	// 12a. Cross-resource validation. Providers that implement
+	// CrossResourceValidator see the normalized desired set scoped to
+	// the resource types they own. This catches classes of
+	// misconfiguration that per-resource Validate cannot express —
+	// e.g. two mysql_user blocks whose Normalize collapses them to the
+	// same (user, host) identity, or a mysql_user/mysql_role pair that
+	// map to the same MySQL 8 server row. Error diagnostics abort the
+	// pipeline before diff.
+	if err := validateCrossResources(ctx, normalizedDesired, providers); err != nil {
+		return nil, err
+	}
+
 	// 12b. Relabel graph nodes whose Normalize changed ResourceID.Name.
 	// mysql_user and similar providers encode a multi-dimensional
 	// identity tuple (e.g. "user@host") into ID.Name during Normalize.
@@ -273,6 +285,43 @@ func (e *Engine) DryRun(ctx context.Context, file *dcl.File, configs map[string]
 		return nil, err
 	}
 	return result.plan, nil
+}
+
+// validateCrossResources groups the normalized desired resources by their
+// owning provider and invokes CrossResourceValidator on each provider that
+// implements it. Resources whose type has no registered provider (should
+// not happen after ConfigureProviders) are skipped silently.
+//
+// Returns a formatted error when any provider returns error-severity
+// diagnostics. Warning-only diagnostics are dropped — the current pipeline
+// has no surface for plan-time warnings; adding one is a separate change.
+func validateCrossResources(ctx context.Context, resources []provider.Resource, providers map[string]provider.Provider) error {
+	byProvider := make(map[provider.Provider][]provider.Resource)
+	order := make([]provider.Provider, 0)
+	for _, r := range resources {
+		p, ok := providers[r.ID.Type]
+		if !ok {
+			continue
+		}
+		if _, seen := byProvider[p]; !seen {
+			order = append(order, p)
+		}
+		byProvider[p] = append(byProvider[p], r)
+	}
+
+	var allDiags dcl.Diagnostics
+	for _, p := range order {
+		v, ok := p.(provider.CrossResourceValidator)
+		if !ok {
+			continue
+		}
+		diags := v.ValidateResources(ctx, byProvider[p])
+		allDiags = append(allDiags, diags...)
+	}
+	if allDiags.HasErrors() {
+		return fmt.Errorf("cross-resource validation: %s", allDiags.Error())
+	}
+	return nil
 }
 
 // validateResources calls Validate on each create/update change in the plan.

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1053,6 +1053,138 @@ func (m *mockOrderingProvider) TypeOrderings() []provider.TypeOrdering {
 	return m.orderings
 }
 
+// crossValidatingProvider is a mockEngineProvider that also implements
+// provider.CrossResourceValidator.
+type crossValidatingProvider struct {
+	mockEngineProvider
+	crossValidateFn func(ctx context.Context, resources []provider.Resource) dcl.Diagnostics
+	sawResources    []provider.Resource
+}
+
+func (c *crossValidatingProvider) ValidateResources(ctx context.Context, resources []provider.Resource) dcl.Diagnostics {
+	c.sawResources = resources
+	if c.crossValidateFn != nil {
+		return c.crossValidateFn(ctx, resources)
+	}
+	return nil
+}
+
+func TestEngine_CrossResourceValidation(t *testing.T) {
+	t.Run("blocks_plan_on_error_diagnostic", func(t *testing.T) {
+		mock := &crossValidatingProvider{
+			crossValidateFn: func(_ context.Context, _ []provider.Resource) dcl.Diagnostics {
+				return dcl.Diagnostics{{
+					Severity: dcl.SeverityError,
+					Message:  "two resources collide on identity",
+				}}
+			},
+		}
+		provider.Register("xrv1", func() provider.Provider { return mock })
+
+		file := makeFile(
+			provider.ResourceID{Type: "xrv1_svc", Name: "a"},
+			provider.ResourceID{Type: "xrv1_svc", Name: "b"},
+		)
+
+		e := &Engine{SecretResolver: stubSecretResolver{}}
+		_, _, err := e.Plan(context.Background(), file, nil, PlanOptions{})
+		if err == nil {
+			t.Fatal("expected cross-resource validation error to block plan")
+		}
+		if !strings.Contains(err.Error(), "two resources collide") {
+			t.Errorf("expected diagnostic message in error, got: %s", err.Error())
+		}
+	})
+
+	t.Run("sees_post_normalize_ids", func(t *testing.T) {
+		mock := &crossValidatingProvider{
+			mockEngineProvider: mockEngineProvider{
+				normalizeFn: func(_ context.Context, r provider.Resource) (provider.Resource, dcl.Diagnostics) {
+					r.ID.Name = r.ID.Name + "@normalized"
+					return r, nil
+				},
+			},
+		}
+		provider.Register("xrv2", func() provider.Provider { return mock })
+
+		file := makeFile(
+			provider.ResourceID{Type: "xrv2_svc", Name: "alpha"},
+			provider.ResourceID{Type: "xrv2_svc", Name: "beta"},
+		)
+
+		e := &Engine{SecretResolver: stubSecretResolver{}}
+		if _, _, err := e.Plan(context.Background(), file, nil, PlanOptions{}); err != nil {
+			t.Fatalf("unexpected plan error: %v", err)
+		}
+		if len(mock.sawResources) != 2 {
+			t.Fatalf("expected 2 resources passed to ValidateResources, got %d", len(mock.sawResources))
+		}
+		for _, r := range mock.sawResources {
+			if !strings.HasSuffix(r.ID.Name, "@normalized") {
+				t.Errorf("ValidateResources saw pre-normalize ID %q; expected @normalized suffix", r.ID.Name)
+			}
+		}
+	})
+
+	t.Run("warnings_do_not_block_plan", func(t *testing.T) {
+		mock := &crossValidatingProvider{
+			crossValidateFn: func(_ context.Context, _ []provider.Resource) dcl.Diagnostics {
+				return dcl.Diagnostics{{
+					Severity: dcl.SeverityWarning,
+					Message:  "heads-up",
+				}}
+			},
+		}
+		provider.Register("xrv3", func() provider.Provider { return mock })
+
+		file := makeFile(provider.ResourceID{Type: "xrv3_svc", Name: "a"})
+
+		e := &Engine{SecretResolver: stubSecretResolver{}}
+		if _, _, err := e.Plan(context.Background(), file, nil, PlanOptions{}); err != nil {
+			t.Errorf("warnings must not block plan, got: %v", err)
+		}
+	})
+
+	t.Run("provider_without_interface_is_skipped", func(t *testing.T) {
+		// Plain mockEngineProvider does not implement CrossResourceValidator.
+		// Pipeline must proceed without error.
+		mock := &mockEngineProvider{}
+		provider.Register("xrv4", func() provider.Provider { return mock })
+
+		file := makeFile(provider.ResourceID{Type: "xrv4_svc", Name: "a"})
+
+		e := &Engine{SecretResolver: stubSecretResolver{}}
+		if _, _, err := e.Plan(context.Background(), file, nil, PlanOptions{}); err != nil {
+			t.Errorf("provider without CrossResourceValidator must not break plan: %v", err)
+		}
+	})
+
+	t.Run("resources_scoped_to_owning_provider", func(t *testing.T) {
+		// Two providers, each owning a different resource type. The
+		// cross-validator should only see resources for types it owns.
+		mockA := &crossValidatingProvider{}
+		mockB := &mockEngineProvider{}
+		provider.Register("xrva", func() provider.Provider { return mockA })
+		provider.Register("xrvb", func() provider.Provider { return mockB })
+
+		file := makeFile(
+			provider.ResourceID{Type: "xrva_svc", Name: "1"},
+			provider.ResourceID{Type: "xrvb_svc", Name: "2"},
+		)
+
+		e := &Engine{SecretResolver: stubSecretResolver{}}
+		if _, _, err := e.Plan(context.Background(), file, nil, PlanOptions{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(mockA.sawResources) != 1 {
+			t.Fatalf("expected 1 resource for provider A, got %d", len(mockA.sawResources))
+		}
+		if mockA.sawResources[0].ID.Type != "xrva_svc" {
+			t.Errorf("provider A saw foreign type %q", mockA.sawResources[0].ID.Type)
+		}
+	})
+}
+
 func TestEnginePlan_TypeOrderings(t *testing.T) {
 	t.Run("provider_orderings_create_graph_edges", func(t *testing.T) {
 		mock := &mockOrderingProvider{

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -87,3 +87,22 @@ type TypeOrderer interface {
 type ResourceDiffer interface {
 	Equal(ctx context.Context, desired, live Resource) (bool, dcl.Diagnostics)
 }
+
+// CrossResourceValidator is an optional interface a Provider may implement
+// to run validation checks that span multiple resources. The engine calls
+// ValidateResources once per provider after Normalize (so ID.Name is in
+// canonical form) and before the plan is built, passing only the desired
+// resources whose types this provider owns.
+//
+// The canonical case is the MySQL provider catching two kinds of
+// misconfiguration that per-resource Validate cannot see: two mysql_user
+// blocks with different DCL labels but identical (user, host) tuples, and
+// a mysql_user/mysql_role pair that collapses to the same MySQL 8 server
+// row. Both surface at apply time as raw MySQL errors; catching them at
+// plan time with source-ranged diagnostics is much friendlier.
+//
+// Returning diagnostics with error severity aborts the pipeline before
+// diff. Warnings surface in the plan without blocking.
+type CrossResourceValidator interface {
+	ValidateResources(ctx context.Context, resources []Resource) dcl.Diagnostics
+}

--- a/providers/mysql/cross_validate.go
+++ b/providers/mysql/cross_validate.go
@@ -1,0 +1,178 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// ValidateResources runs MySQL-specific cross-resource checks that a
+// per-resource Validate cannot express. It catches two classes of
+// misconfiguration that would otherwise surface at apply time as raw
+// MySQL errors:
+//
+//  1. Two mysql_user blocks with different DCL labels but identical
+//     (user, host) tuples — both declarations target the same server row.
+//  2. A mysql_user and a mysql_role sharing the same effective identity
+//     (role host is always "%"). MySQL 8 stores roles in mysql.user, so
+//     the two DCL blocks would race each other for the same server row.
+//
+// Resources with missing user or host fields are skipped — per-resource
+// Validate reports those with a clearer message.
+//
+// This is invoked by the engine after Normalize, when mysql_user resource
+// IDs are already in canonical "user@host" form. The function ignores
+// types other than mysql_user and mysql_role.
+func (p *Provider) ValidateResources(_ context.Context, resources []provider.Resource) dcl.Diagnostics {
+	byIdentity := make(map[string][]entry)
+	var order []string
+
+	for _, r := range resources {
+		var user, host, kind string
+		switch r.ID.Type {
+		case "mysql_user":
+			user = getBodyString(r.Body, "user")
+			host = getBodyString(r.Body, "host")
+			kind = "user"
+		case "mysql_role":
+			// Role host is always "%" (see role.go). The role name is
+			// the block label, which Normalize does not rewrite.
+			user = r.ID.Name
+			host = roleHost
+			kind = "role"
+		default:
+			continue
+		}
+		if user == "" || host == "" {
+			continue
+		}
+		identity := user + "@" + host
+		if _, seen := byIdentity[identity]; !seen {
+			order = append(order, identity)
+		}
+		byIdentity[identity] = append(byIdentity[identity], entry{resource: r, kind: kind})
+	}
+
+	var diags dcl.Diagnostics
+	for _, identity := range order {
+		entries := byIdentity[identity]
+		if len(entries) < 2 {
+			continue
+		}
+		diags = append(diags, buildCollisionDiagnostic(identity, entries))
+	}
+	return diags
+}
+
+// buildCollisionDiagnostic composes a single error diagnostic describing
+// a set of resources that collapse onto the same MySQL server identity.
+// The diagnostic's Range points at the last occurrence so editors land
+// the cursor there; the message enumerates every block and its source
+// position so the operator can find both sides of the collision.
+func buildCollisionDiagnostic(identity string, entries []entry) dcl.Diagnostic {
+	sorted := make([]entry, len(entries))
+	copy(sorted, entries)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return compareRanges(sorted[i].resource.SourceRange, sorted[j].resource.SourceRange) < 0
+	})
+
+	user, host := splitIdentity(identity)
+	kinds := distinctKinds(sorted)
+	refs := make([]string, len(sorted))
+	for i, e := range sorted {
+		refs[i] = fmt.Sprintf("%s.%s (%s)", e.resource.ID.Type, e.resource.ID.Name, e.resource.SourceRange.Start)
+	}
+	joined := strings.Join(refs, ", ")
+
+	var message, suggestion string
+	switch {
+	case len(kinds) == 1 && kinds[0] == "user":
+		message = fmt.Sprintf(
+			"duplicate mysql_user identity user=%q host=%q declared by %s; these blocks all resolve to the same server row",
+			user, host, joined,
+		)
+		suggestion = "change the user or host on one of these blocks so each mysql_user maps to a distinct (user, host) tuple"
+	case len(kinds) == 1 && kinds[0] == "role":
+		// Shouldn't happen — the engine rejects two blocks with the same
+		// ResourceID at convert time — but guard defensively.
+		message = fmt.Sprintf(
+			"duplicate mysql_role identity name=%q declared by %s",
+			user, joined,
+		)
+		suggestion = "rename one of the mysql_role blocks so each role name is unique"
+	default:
+		message = fmt.Sprintf(
+			"mysql_user and mysql_role collide on the same MySQL 8 server row (user=%q host=%q): %s; MySQL 8 stores roles and users in the same mysql.user table, so both declarations would target the same row",
+			user, host, joined,
+		)
+		suggestion = "rename the role so it does not collide with the user, or rename the user"
+	}
+
+	return dcl.Diagnostic{
+		Severity:   dcl.SeverityError,
+		Message:    message,
+		Range:      sorted[len(sorted)-1].resource.SourceRange,
+		Suggestion: suggestion,
+	}
+}
+
+// compareRanges orders two ranges by filename, line, then column so
+// diagnostics enumerate conflicting blocks in source order.
+func compareRanges(a, b dcl.Range) int {
+	if a.Start.Filename != b.Start.Filename {
+		if a.Start.Filename < b.Start.Filename {
+			return -1
+		}
+		return 1
+	}
+	if a.Start.Line != b.Start.Line {
+		if a.Start.Line < b.Start.Line {
+			return -1
+		}
+		return 1
+	}
+	if a.Start.Column != b.Start.Column {
+		if a.Start.Column < b.Start.Column {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+// splitIdentity decomposes a "user@host" key back into its components.
+// The last "@" is the separator; MySQL usernames may not contain "@"
+// but we prefer right-split defensively.
+func splitIdentity(identity string) (string, string) {
+	i := strings.LastIndex(identity, "@")
+	if i < 0 {
+		return identity, ""
+	}
+	return identity[:i], identity[i+1:]
+}
+
+// distinctKinds returns the unique kinds ("user", "role") present in the
+// entries, order-preserving on first occurrence.
+func distinctKinds(entries []entry) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, e := range entries {
+		if seen[e.kind] {
+			continue
+		}
+		seen[e.kind] = true
+		out = append(out, e.kind)
+	}
+	return out
+}
+
+// entry pairs a colliding resource with the kind of DCL block it came
+// from so buildCollisionDiagnostic can pick the right message.
+type entry struct {
+	resource provider.Resource
+	kind     string
+}

--- a/providers/mysql/cross_validate_test.go
+++ b/providers/mysql/cross_validate_test.go
@@ -1,0 +1,190 @@
+package mysql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/MathewBravo/datastorectl/dcl"
+	"github.com/MathewBravo/datastorectl/provider"
+)
+
+// userRes builds a mysql_user resource with the given body label, user,
+// and host values. The body label matches the DCL block label pre-normalize.
+// The caller sets the ID.Name to the post-normalize canonical form
+// ("user@host") to mirror what the engine passes to ValidateResources.
+func userRes(label, user, host string, rng dcl.Range) provider.Resource {
+	body := provider.NewOrderedMap()
+	body.Set("user", provider.StringVal(user))
+	body.Set("host", provider.StringVal(host))
+	// Store the original DCL label in the body so the diagnostic can
+	// surface it. The mysql_user Normalize rewrites ID.Name; the engine
+	// invokes ValidateResources with the post-normalize form. Tests
+	// simulate that by setting ID.Name = user@host.
+	_ = label
+	return provider.Resource{
+		ID:          provider.ResourceID{Type: "mysql_user", Name: user + "@" + host},
+		Body:        body,
+		SourceRange: rng,
+	}
+}
+
+func roleRes(name string, rng dcl.Range) provider.Resource {
+	body := provider.NewOrderedMap()
+	return provider.Resource{
+		ID:          provider.ResourceID{Type: "mysql_role", Name: name},
+		Body:        body,
+		SourceRange: rng,
+	}
+}
+
+func rng(line int) dcl.Range {
+	return dcl.Range{
+		Start: dcl.Pos{Filename: "test.dcl", Line: line, Column: 1},
+		End:   dcl.Pos{Filename: "test.dcl", Line: line, Column: 10},
+	}
+}
+
+func TestProvider_ValidateResources(t *testing.T) {
+	p := &Provider{}
+
+	t.Run("no_duplicates_is_clean", func(t *testing.T) {
+		diags := p.ValidateResources(context.Background(), []provider.Resource{
+			userRes("app", "app", "%", rng(10)),
+			userRes("admin", "admin", "%", rng(20)),
+			roleRes("reporter", rng(30)),
+		})
+		if diags.HasErrors() {
+			t.Errorf("expected no errors, got: %s", diags.Error())
+		}
+	})
+
+	t.Run("same_user_different_host_is_clean", func(t *testing.T) {
+		// MySQL treats (app, %) and (app, localhost) as distinct rows.
+		diags := p.ValidateResources(context.Background(), []provider.Resource{
+			userRes("app_wildcard", "app", "%", rng(10)),
+			userRes("app_local", "app", "localhost", rng(20)),
+		})
+		if diags.HasErrors() {
+			t.Errorf("expected no errors for same-user different-host, got: %s", diags.Error())
+		}
+	})
+
+	t.Run("duplicate_user_host_tuple_errors", func(t *testing.T) {
+		diags := p.ValidateResources(context.Background(), []provider.Resource{
+			userRes("user1", "alice", "%", rng(10)),
+			userRes("user2", "alice", "%", rng(20)),
+		})
+		if !diags.HasErrors() {
+			t.Fatal("expected error for duplicate (user, host) tuple")
+		}
+		msg := diags.Error()
+		// Message must name the shared identity.
+		if !strings.Contains(msg, "alice") {
+			t.Errorf("diagnostic should mention user name, got: %s", msg)
+		}
+		if !strings.Contains(msg, "%") {
+			t.Errorf("diagnostic should mention host, got: %s", msg)
+		}
+		// Message must point at both source lines.
+		if !strings.Contains(msg, "10") || !strings.Contains(msg, "20") {
+			t.Errorf("diagnostic should reference both source lines (10 and 20), got: %s", msg)
+		}
+		// Message must include an actionable suggestion.
+		joined := msg
+		for _, d := range diags {
+			joined += " " + d.Suggestion
+		}
+		if !strings.Contains(joined, "user") && !strings.Contains(joined, "host") {
+			t.Errorf("diagnostic should suggest changing user or host, got: %s", joined)
+		}
+	})
+
+	t.Run("user_role_collision_errors", func(t *testing.T) {
+		diags := p.ValidateResources(context.Background(), []provider.Resource{
+			userRes("app_user", "app", "%", rng(10)),
+			roleRes("app", rng(20)),
+		})
+		if !diags.HasErrors() {
+			t.Fatal("expected error for mysql_user/mysql_role name collision at host %")
+		}
+		msg := diags.Error()
+		if !strings.Contains(msg, "mysql_user") || !strings.Contains(msg, "mysql_role") {
+			t.Errorf("diagnostic should mention both types, got: %s", msg)
+		}
+		if !strings.Contains(msg, "app") {
+			t.Errorf("diagnostic should include the colliding name, got: %s", msg)
+		}
+		// Must include an actionable suggestion.
+		joined := msg
+		for _, d := range diags {
+			joined += " " + d.Suggestion
+		}
+		if !strings.Contains(joined, "rename") {
+			t.Errorf("diagnostic should suggest renaming, got: %s", joined)
+		}
+	})
+
+	t.Run("three_way_collision_names_all_sources", func(t *testing.T) {
+		diags := p.ValidateResources(context.Background(), []provider.Resource{
+			userRes("u1", "svc", "%", rng(10)),
+			userRes("u2", "svc", "%", rng(20)),
+			userRes("u3", "svc", "%", rng(30)),
+		})
+		if !diags.HasErrors() {
+			t.Fatal("expected error for three-way duplicate")
+		}
+		msg := diags.Error()
+		for _, line := range []string{"10", "20", "30"} {
+			if !strings.Contains(msg, line) {
+				t.Errorf("diagnostic should reference line %s, got: %s", line, msg)
+			}
+		}
+	})
+
+	t.Run("grants_and_databases_ignored", func(t *testing.T) {
+		// mysql_grant and mysql_database participate in different
+		// identity spaces. They must not trigger false positives.
+		body := provider.NewOrderedMap()
+		body.Set("user", provider.StringVal("app"))
+		body.Set("host", provider.StringVal("%"))
+		body.Set("on", provider.StringVal("db.*"))
+		grant := provider.Resource{
+			ID:   provider.ResourceID{Type: "mysql_grant", Name: "app@%:db.*"},
+			Body: body,
+		}
+		dbBody := provider.NewOrderedMap()
+		dbBody.Set("name", provider.StringVal("app"))
+		db := provider.Resource{
+			ID:   provider.ResourceID{Type: "mysql_database", Name: "app"},
+			Body: dbBody,
+		}
+		diags := p.ValidateResources(context.Background(), []provider.Resource{
+			userRes("u", "app", "%", rng(10)),
+			grant,
+			db,
+		})
+		if diags.HasErrors() {
+			t.Errorf("grants/databases must not trigger identity collisions, got: %s", diags.Error())
+		}
+	})
+
+	t.Run("missing_user_or_host_is_deferred", func(t *testing.T) {
+		// Per-resource Validate catches missing fields. ValidateResources
+		// should skip such resources so it does not emit a confusing
+		// duplicate "@" identity.
+		body := provider.NewOrderedMap()
+		// user and host both missing.
+		r := provider.Resource{
+			ID:   provider.ResourceID{Type: "mysql_user", Name: "broken"},
+			Body: body,
+		}
+		diags := p.ValidateResources(context.Background(), []provider.Resource{
+			r,
+			userRes("u", "app", "%", rng(10)),
+		})
+		if diags.HasErrors() {
+			t.Errorf("missing fields should be deferred to per-resource Validate, got: %s", diags.Error())
+		}
+	})
+}

--- a/providers/mysql/grant.go
+++ b/providers/mysql/grant.go
@@ -19,9 +19,11 @@ type grantHandler struct {
 	version string
 }
 
-// Validate covers per-resource rules. Cross-resource duplicate-tuple
-// checks are a known gap, tracked in the engine-level cross-resource
-// validation issue.
+// Validate covers per-resource rules. User/role identity collisions
+// across blocks are handled by the provider's ValidateResources hook
+// (see cross_validate.go); grant-specific cross-resource checks (e.g.
+// a grant referencing a user/role the config does not declare) are not
+// yet implemented.
 func (h *grantHandler) Validate(_ context.Context, r provider.Resource) error {
 	user := getBodyString(r.Body, "user")
 	host := getBodyString(r.Body, "host")

--- a/providers/mysql/role.go
+++ b/providers/mysql/role.go
@@ -23,8 +23,9 @@ type roleHandler struct{}
 const roleHost = "%"
 
 // Validate covers the per-resource rules that don't need a cluster.
-// Cross-resource checks (e.g. role name colliding with a mysql_user
-// in the same config) are a future engine-level concern.
+// Cross-resource name-collision checks (mysql_role vs mysql_user both
+// targeting the same (name, "%") row) live on the provider's
+// ValidateResources — see cross_validate.go.
 func (h *roleHandler) Validate(_ context.Context, r provider.Resource) error {
 	name := r.ID.Name
 	if name == "" {


### PR DESCRIPTION
## Summary

- Adds optional `CrossResourceValidator` provider interface; engine invokes it after Normalize, scoping resources to each owning provider, before diff/plan-build.
- MySQL provider implements it to catch two classes of misconfiguration that per-resource `Validate` cannot see:
  - Two `mysql_user` blocks with different DCL labels but identical `(user, host)` tuples — both declarations target the same server row (and the existing convert-time ResourceID dup check misses it because the block labels differ).
  - `mysql_user` / `mysql_role` pairs at the same effective identity (role host is hardcoded `%`). MySQL 8 stores roles in `mysql.user`, so both blocks would fight over the same row (the apply error was `ERROR 1396 (HY000): Operation CREATE USER failed`).
- Error diagnostics are source-ranged and name every colliding block plus suggest an actionable fix.

## Why

Both failure modes were called out in the #173 / #174 rundowns as "cross-resource concerns not covered by Validate." Catching them at plan time is much friendlier than surfacing them as raw MySQL errors at apply.

## How

- `provider.CrossResourceValidator` — opt-in interface, signature `ValidateResources(ctx, []Resource) dcl.Diagnostics`.
- `engine.validateCrossResources` — groups normalized desired resources by owning provider, calls the interface on each provider that implements it, aborts the pipeline on error-severity diagnostics.
- `mysql.Provider.ValidateResources` — groups `mysql_user` and `mysql_role` resources by `user@host` identity; emits a diagnostic for any identity claimed by more than one block. Missing `user`/`host` fields are deferred to per-resource Validate (clearer message there).
- OpenSearch is untouched; the interface is additive.

## Test plan

- [x] `go test ./...` green.
- [x] `TestProvider_ValidateResources` covers: duplicate `(user, host)`, `mysql_user`/`mysql_role` collision, same-user/different-host negative, three-way duplicate, grants/databases ignored, missing-field deferral.
- [x] `TestEngine_CrossResourceValidation` covers: error blocks plan, warnings do not block, post-normalize IDs are visible, providers without the interface are skipped, resources are scoped to owning provider.

Closes #197