### PR TITLE
mysql/parse: accept DEFAULT ROLE clause in SHOW CREATE USER

### DIFF
--- a/providers/mysql/parse/create_user.go
+++ b/providers/mysql/parse/create_user.go
@@ -48,6 +48,20 @@ type CreateUserStmt struct {
 	// Metadata
 	Comment   string
 	Attribute string
+
+	// Default roles set on the user. Populated when SHOW CREATE USER
+	// emits a `DEFAULT ROLE <role>[, <role>]*` clause (MySQL 8 WL#988;
+	// set for every RDS Aurora `admin` user). Parsed so discover does
+	// not error; not currently surfaced as a mysql_user body attribute.
+	// omitempty so fixtures for users without default roles don't need
+	// regeneration.
+	DefaultRoles []DefaultRole `json:",omitempty"`
+}
+
+// DefaultRole is a (name, host) pair from a DEFAULT ROLE clause.
+type DefaultRole struct {
+	Name string
+	Host string
 }
 
 // ParseCreateUser parses one CREATE USER DDL statement produced by
@@ -197,6 +211,8 @@ func (p *createUserParser) parseClause(stmt *CreateUserStmt) error {
 		}
 		stmt.Attribute = s
 		return nil
+	case equalsFoldAny(t.Value, "DEFAULT"):
+		return p.parseDefaultClause(stmt)
 	}
 	return fmt.Errorf("parse: unknown CREATE USER clause %q", t.Value)
 }
@@ -487,6 +503,53 @@ func (p *createUserParser) parseAccountClause(stmt *CreateUserStmt) error {
 		return fmt.Errorf("parse: expected LOCK or UNLOCK after ACCOUNT, got %s", t)
 	}
 	return nil
+}
+
+// parseDefaultClause handles DEFAULT ROLE <role>[, <role>]*. Each role
+// is a (name, host) pair written `ident`@`ident` or 'ident'@'ident'.
+// DEFAULT appears in SHOW CREATE USER output for any user that has
+// default roles set (MySQL 8 WL#988); every RDS Aurora admin user has
+// them.
+func (p *createUserParser) parseDefaultClause(stmt *CreateUserStmt) error {
+	if err := p.expectKeyword("ROLE"); err != nil {
+		return err
+	}
+	for {
+		role, err := p.readRoleIdent()
+		if err != nil {
+			return err
+		}
+		stmt.DefaultRoles = append(stmt.DefaultRoles, role)
+
+		t, err := p.peek()
+		if err != nil {
+			return err
+		}
+		if t.Kind != tkComma {
+			return nil
+		}
+		_, _ = p.next() // consume comma, loop for next role
+	}
+}
+
+// readRoleIdent consumes one `name`@`host` (or 'name'@'host') pair.
+func (p *createUserParser) readRoleIdent() (DefaultRole, error) {
+	name, err := p.readQuotedOrBacktickIdent()
+	if err != nil {
+		return DefaultRole{}, err
+	}
+	t, err := p.next()
+	if err != nil {
+		return DefaultRole{}, err
+	}
+	if t.Kind != tkAt {
+		return DefaultRole{}, fmt.Errorf("parse: expected '@' in DEFAULT ROLE role spec, got %s", t)
+	}
+	host, err := p.readQuotedOrBacktickIdent()
+	if err != nil {
+		return DefaultRole{}, err
+	}
+	return DefaultRole{Name: name, Host: host}, nil
 }
 
 // parsePasswordLockTime handles PASSWORD_LOCK_TIME <N> and

--- a/providers/mysql/parse/create_user_test.go
+++ b/providers/mysql/parse/create_user_test.go
@@ -296,5 +296,83 @@ func TestParseCreateUser_UnquotedSingleQuoteIdentForms(t *testing.T) {
 	}
 }
 
+// TestParseCreateUser_DefaultRoleAurora exercises the exact DDL shape
+// AWS RDS Aurora emits for its master `admin` user. The `DEFAULT ROLE
+// <role>@<host>` clause appears mid-stream between ACCOUNT UNLOCK and
+// PASSWORD HISTORY; the parser must consume it without disturbing the
+// surrounding clauses. Surfaced by #201; tracked in #214.
+func TestParseCreateUser_DefaultRoleAurora(t *testing.T) {
+	ddl := `CREATE USER ` + bt + `admin` + bt + `@` + bt + `%` + bt +
+		` IDENTIFIED WITH 'caching_sha2_password' AS '$A$005$somehash'` +
+		` REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK` +
+		` DEFAULT ROLE ` + bt + `rds_superuser_role` + bt + `@` + bt + `%` + bt +
+		` PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT` +
+		` PASSWORD REQUIRE CURRENT DEFAULT`
+	stmt, err := ParseCreateUser(ddl, "8.0")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(stmt.DefaultRoles) != 1 {
+		t.Fatalf("DefaultRoles length = %d, want 1: %+v", len(stmt.DefaultRoles), stmt.DefaultRoles)
+	}
+	got := stmt.DefaultRoles[0]
+	if got.Name != "rds_superuser_role" || got.Host != "%" {
+		t.Errorf("DefaultRoles[0] = %+v, want {Name: rds_superuser_role, Host: %%}", got)
+	}
+	// Ensure the clause didn't swallow or confuse neighboring fields.
+	if stmt.PasswordHistory != "DEFAULT" {
+		t.Errorf("PasswordHistory = %q, want DEFAULT (clause after DEFAULT ROLE was skipped)", stmt.PasswordHistory)
+	}
+	if stmt.PasswordRequireCurrent != "DEFAULT" {
+		t.Errorf("PasswordRequireCurrent = %q, want DEFAULT", stmt.PasswordRequireCurrent)
+	}
+}
+
+// TestParseCreateUser_DefaultRoleMultiple covers the comma-separated
+// multi-role form of DEFAULT ROLE. MySQL 8 accepts DEFAULT ROLE r1, r2,
+// r3 and SHOW CREATE USER emits each with its host.
+func TestParseCreateUser_DefaultRoleMultiple(t *testing.T) {
+	ddl := `CREATE USER ` + bt + `u` + bt + `@` + bt + `%` + bt +
+		` IDENTIFIED WITH 'caching_sha2_password' AS ''` +
+		` REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK` +
+		` DEFAULT ROLE ` + bt + `reader` + bt + `@` + bt + `%` + bt +
+		`, ` + bt + `writer` + bt + `@` + bt + `%` + bt +
+		`, ` + bt + `admin` + bt + `@` + bt + `10.0.%` + bt +
+		` PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT` +
+		` PASSWORD REQUIRE CURRENT DEFAULT`
+	stmt, err := ParseCreateUser(ddl, "8.0")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(stmt.DefaultRoles) != 3 {
+		t.Fatalf("DefaultRoles length = %d, want 3: %+v", len(stmt.DefaultRoles), stmt.DefaultRoles)
+	}
+	want := []DefaultRole{
+		{Name: "reader", Host: "%"},
+		{Name: "writer", Host: "%"},
+		{Name: "admin", Host: "10.0.%"},
+	}
+	for i, w := range want {
+		if stmt.DefaultRoles[i] != w {
+			t.Errorf("DefaultRoles[%d] = %+v, want %+v", i, stmt.DefaultRoles[i], w)
+		}
+	}
+}
+
+// TestParseCreateUser_DefaultRoleSingleQuoted covers the input-form
+// variant where the role identifier uses single quotes instead of
+// backticks. CREATE USER accepts both; the parser already accepts
+// single-quoted user/host, so DEFAULT ROLE should too.
+func TestParseCreateUser_DefaultRoleSingleQuoted(t *testing.T) {
+	ddl := `CREATE USER 'u'@'%' IDENTIFIED WITH 'caching_sha2_password' AS '' REQUIRE NONE DEFAULT ROLE 'role1'@'%'`
+	stmt, err := ParseCreateUser(ddl, "8.0")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(stmt.DefaultRoles) != 1 || stmt.DefaultRoles[0].Name != "role1" {
+		t.Errorf("DefaultRoles = %+v, want [{role1 %%}]", stmt.DefaultRoles)
+	}
+}
+
 // Ensure strings import is retained (used by BasicUser assertion).
 var _ = strings.HasPrefix


### PR DESCRIPTION
## Summary

- MySQL 8's WL#988 DEFAULT ROLE clause was rejected by the CREATE USER parser as an unknown clause, blocking discover against any Aurora cluster or self-hosted MySQL 8 cluster using roles.
- Parses single roles, comma-separated multi-role lists, and both backticked and single-quoted identifiers.
- Roles are captured on \`CreateUserStmt.DefaultRoles\` with \`omitempty\` so existing fixture JSONs don't need regeneration; the mysql_user handler does not yet expose them as a body attribute.

## Why

Surfaced by #201 real-RDS verification: every RDS Aurora master user has a default role configured, so any plan against a real Aurora cluster failed immediately during discover with \`parse: unknown CREATE USER clause "DEFAULT"\`.

## Test plan

- [x] New tests: \`TestParseCreateUser_DefaultRoleAurora\` (exact Aurora DDL shape), \`TestParseCreateUser_DefaultRoleMultiple\` (comma-separated list), \`TestParseCreateUser_DefaultRoleSingleQuoted\`.
- [x] \`go test ./providers/mysql/parse/\` green.
- [x] \`go test ./...\` green (existing fixtures unchanged thanks to \`omitempty\`).
- [x] Verified against the live #201 sandbox Aurora cluster — the \`admin\` user's \`DEFAULT ROLE\` clause no longer errors; only the role-grant parser gap (#215) remains blocking discover.

Closes #214