### PR TITLE
mysql/parse: accept role-to-user GRANT form in SHOW GRANTS

### DIFF
--- a/providers/mysql/grant.go
+++ b/providers/mysql/grant.go
@@ -214,6 +214,13 @@ func (h *grantHandler) fetchAndParseGrants(ctx context.Context, db *sql.DB, user
 			}
 			return nil, fmt.Errorf("parse grant line %q: %w", line, err)
 		}
+		// Role-to-user grants (GRANT `role` TO `user`) share the SHOW
+		// GRANTS output with privilege grants but don't map onto
+		// mysql_grant. Skip them; a future mysql_role_grant resource
+		// can consume the parsed form.
+		if s.IsRoleGrant() {
+			continue
+		}
 		out = append(out, s)
 	}
 	return out, nil

--- a/providers/mysql/parse/grant.go
+++ b/providers/mysql/parse/grant.go
@@ -7,16 +7,35 @@ import (
 )
 
 // GrantStmt is the parsed shape of a single GRANT DDL statement from
-// SHOW GRANTS output. Identity is the (User, Host, Database, Table)
-// tuple. Privileges are uppercased and sorted for deterministic diffs.
+// SHOW GRANTS output. Privilege grants populate (Privileges, Database,
+// Table); role grants populate GrantedRoles and leave Privileges empty.
+// User and Host always identify the recipient.
 type GrantStmt struct {
-	Privileges  []string // sorted, uppercased; "ALL" stands alone
-	Database    string   // "*" for global scope, or schema name
-	Table       string   // "*" for schema-level, or table name
+	Privileges  []string // sorted, uppercased; "ALL" stands alone (privilege grants only)
+	Database    string   // "*" for global scope, or schema name (privilege grants only)
+	Table       string   // "*" for schema-level, or table name (privilege grants only)
 	User        string
 	Host        string
 	GrantOption bool
+
+	// Role-grant-only fields. Populated when the GRANT is a role grant
+	// (GRANT <role> TO <user>) rather than a privilege grant. MySQL 8
+	// stores roles as users so these are standard on any cluster using
+	// roles — including every RDS Aurora master user.
+	GrantedRoles []RoleRef `json:",omitempty"`
+	AdminOption  bool      `json:",omitempty"`
 }
+
+// RoleRef is a (name, host) pair naming a role granted to a user.
+type RoleRef struct {
+	Name string
+	Host string
+}
+
+// IsRoleGrant reports whether this statement is a role-to-user grant
+// (as opposed to a privilege grant). Callers use this to decide whether
+// to treat the statement as mysql_grant state or skip it.
+func (s GrantStmt) IsRoleGrant() bool { return len(s.GrantedRoles) > 0 }
 
 // ParseGrant parses a single GRANT statement. The version argument is
 // reserved for version-specific tolerance knobs; currently unused
@@ -90,6 +109,18 @@ func (p *grantParser) parse() (GrantStmt, error) {
 		return GrantStmt{}, err
 	}
 
+	// Role-grant detection: after GRANT, a role reference is a
+	// backtick- or single-quote-quoted identifier, while a privilege
+	// is always a bare ident (SELECT, ALL, PROCESS, REPLICATION CLIENT,
+	// ...). Peek one token; a quoted identifier means role grant.
+	t, err := p.peek()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+	if t.Kind == tkBacktick || t.Kind == tkString {
+		return p.parseRoleGrant()
+	}
+
 	privs, err := p.readPrivileges()
 	if err != nil {
 		return GrantStmt{}, err
@@ -100,7 +131,7 @@ func (p *grantParser) parse() (GrantStmt, error) {
 	}
 
 	// Reject routine scopes early with a specific diagnostic.
-	t, err := p.peek()
+	t, err = p.peek()
 	if err != nil {
 		return GrantStmt{}, err
 	}
@@ -173,6 +204,109 @@ func (p *grantParser) parse() (GrantStmt, error) {
 	}
 
 	return stmt, nil
+}
+
+// parseRoleGrant consumes the role-to-user form:
+//
+//	GRANT `role`@`host`[, `role`@`host`...] TO `user`@`host` [WITH ADMIN OPTION]
+//
+// Called after the leading GRANT keyword has been consumed and a quoted
+// identifier has been peeked. Populates GrantedRoles, AdminOption, User,
+// and Host; Privileges/Database/Table stay empty.
+func (p *grantParser) parseRoleGrant() (GrantStmt, error) {
+	var roles []RoleRef
+	for {
+		role, err := p.readRoleRef()
+		if err != nil {
+			return GrantStmt{}, err
+		}
+		roles = append(roles, role)
+		t, err := p.peek()
+		if err != nil {
+			return GrantStmt{}, err
+		}
+		if t.Kind != tkComma {
+			break
+		}
+		_, _ = p.next() // consume comma
+	}
+
+	if err := p.expectKeyword("TO"); err != nil {
+		return GrantStmt{}, err
+	}
+	user, err := p.readQuotedName()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+	at, err := p.next()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+	if at.Kind != tkAt {
+		return GrantStmt{}, fmt.Errorf("parse: expected '@' between user and host in role grant, got %s", at)
+	}
+	host, err := p.readQuotedName()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+
+	stmt := GrantStmt{
+		User:         user,
+		Host:         host,
+		GrantedRoles: roles,
+	}
+
+	// Optional WITH ADMIN OPTION trailer.
+	t, err := p.peek()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+	if matchIdent(t, "WITH") {
+		_, _ = p.next()
+		if err := p.expectKeyword("ADMIN"); err != nil {
+			return GrantStmt{}, fmt.Errorf("parse: WITH on a role grant must be followed by ADMIN OPTION: %w", err)
+		}
+		if err := p.expectKeyword("OPTION"); err != nil {
+			return GrantStmt{}, err
+		}
+		stmt.AdminOption = true
+	}
+
+	// Tolerate a trailing semicolon.
+	t, err = p.peek()
+	if err == nil && t.Kind == tkSemi {
+		_, _ = p.next()
+	}
+	t, err = p.peek()
+	if err != nil {
+		return GrantStmt{}, err
+	}
+	if t.Kind != tkEOF {
+		return GrantStmt{}, fmt.Errorf("parse: unexpected trailing token in role grant %s", t)
+	}
+
+	return stmt, nil
+}
+
+// readRoleRef consumes one `name`@`host` (or 'name'@'host') role
+// reference and returns it.
+func (p *grantParser) readRoleRef() (RoleRef, error) {
+	name, err := p.readQuotedName()
+	if err != nil {
+		return RoleRef{}, err
+	}
+	at, err := p.next()
+	if err != nil {
+		return RoleRef{}, err
+	}
+	if at.Kind != tkAt {
+		return RoleRef{}, fmt.Errorf("parse: expected '@' in role reference, got %s", at)
+	}
+	host, err := p.readQuotedName()
+	if err != nil {
+		return RoleRef{}, err
+	}
+	return RoleRef{Name: name, Host: host}, nil
 }
 
 // readPrivileges consumes the comma-separated privilege list up to

--- a/providers/mysql/parse/grant_test.go
+++ b/providers/mysql/parse/grant_test.go
@@ -198,6 +198,102 @@ func TestParseGrant_SingleQuotedIdents(t *testing.T) {
 	}
 }
 
+// TestParseGrant_RoleGrantAurora exercises the exact shape AWS RDS
+// Aurora's SHOW GRANTS emits for its master `admin` user. Role-to-user
+// grants have no privilege names and no ON clause. Surfaced by #201;
+// tracked in #215.
+func TestParseGrant_RoleGrantAurora(t *testing.T) {
+	stmt, err := ParseGrant("GRANT `rds_superuser_role`@`%` TO `admin`@`%`", "8.0")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !stmt.IsRoleGrant() {
+		t.Error("IsRoleGrant() = false, want true")
+	}
+	if len(stmt.Privileges) != 0 {
+		t.Errorf("Privileges = %v, want empty for role grant", stmt.Privileges)
+	}
+	if len(stmt.GrantedRoles) != 1 {
+		t.Fatalf("GrantedRoles length = %d, want 1", len(stmt.GrantedRoles))
+	}
+	got := stmt.GrantedRoles[0]
+	if got.Name != "rds_superuser_role" || got.Host != "%" {
+		t.Errorf("GrantedRoles[0] = %+v, want {rds_superuser_role %%}", got)
+	}
+	if stmt.User != "admin" || stmt.Host != "%" {
+		t.Errorf("recipient = %q@%q, want admin@%%", stmt.User, stmt.Host)
+	}
+}
+
+// TestParseGrant_RoleGrantMultiple covers comma-separated roles.
+func TestParseGrant_RoleGrantMultiple(t *testing.T) {
+	stmt, err := ParseGrant("GRANT `reader`@`%`, `writer`@`%` TO `alice`@`10.0.%`", "8.0")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !stmt.IsRoleGrant() {
+		t.Error("IsRoleGrant() = false, want true")
+	}
+	if len(stmt.GrantedRoles) != 2 {
+		t.Fatalf("GrantedRoles length = %d, want 2: %+v", len(stmt.GrantedRoles), stmt.GrantedRoles)
+	}
+	if stmt.GrantedRoles[0].Name != "reader" || stmt.GrantedRoles[1].Name != "writer" {
+		t.Errorf("GrantedRoles names = %+v", stmt.GrantedRoles)
+	}
+}
+
+// TestParseGrant_RoleGrantWithAdminOption covers the WITH ADMIN OPTION
+// trailer that MySQL 8 allows on role grants (symmetric with WITH GRANT
+// OPTION on privilege grants).
+func TestParseGrant_RoleGrantWithAdminOption(t *testing.T) {
+	stmt, err := ParseGrant("GRANT `admin_role`@`%` TO `ops`@`%` WITH ADMIN OPTION", "8.0")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !stmt.IsRoleGrant() {
+		t.Error("IsRoleGrant() = false, want true")
+	}
+	if !stmt.AdminOption {
+		t.Error("AdminOption = false, want true")
+	}
+}
+
+// TestParseGrant_PrivilegeGrantUnchanged is a regression check: the
+// existing privilege-grant paths must stay exactly as before — no
+// GrantedRoles populated, IsRoleGrant() false.
+func TestParseGrant_PrivilegeGrantUnchanged(t *testing.T) {
+	stmt, err := ParseGrant("GRANT SELECT ON `appdb`.* TO `app`@`%`", "8.0")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if stmt.IsRoleGrant() {
+		t.Error("IsRoleGrant() = true on a privilege grant")
+	}
+	if len(stmt.GrantedRoles) != 0 {
+		t.Errorf("GrantedRoles = %+v, want empty on a privilege grant", stmt.GrantedRoles)
+	}
+}
+
+// TestParseGrantLines_MixedPrivilegeAndRole confirms ParseGrantLines
+// returns both forms interleaved without error, preserving line order.
+func TestParseGrantLines_MixedPrivilegeAndRole(t *testing.T) {
+	output := "GRANT USAGE ON *.* TO `admin`@`%`\n" +
+		"GRANT `rds_superuser_role`@`%` TO `admin`@`%`"
+	stmts, err := ParseGrantLines(output, "8.0")
+	if err != nil {
+		t.Fatalf("ParseGrantLines: %v", err)
+	}
+	if len(stmts) != 2 {
+		t.Fatalf("got %d stmts, want 2", len(stmts))
+	}
+	if stmts[0].IsRoleGrant() {
+		t.Error("first line should be a privilege grant")
+	}
+	if !stmts[1].IsRoleGrant() {
+		t.Error("second line should be a role grant")
+	}
+}
+
 // equalStringSlices compares two string slices in order.
 func equalStringSlices(a, b []string) bool {
 	if len(a) != len(b) {


### PR DESCRIPTION
## Summary

- SHOW GRANTS emits role grants as \`GRANT \\\`role\\\`@\\\`host\\\` TO \\\`user\\\`@\\\`host\\\`\` — no privilege names, no ON clause. The existing parser rejected the backticked role where a privilege was expected, blocking discover against any MySQL 8 cluster using roles (every RDS Aurora master user has one).
- Parser now detects the role-grant form by peeking for a quoted identifier after GRANT (privileges are always bare idents).
- New fields on \`GrantStmt\`: \`GrantedRoles []RoleRef\`, \`AdminOption bool\`, and a \`IsRoleGrant()\` helper.
- The \`mysql_grant\` handler's Discover skips role grants rather than emitting them — a future \`mysql_role_grant\` resource can consume the parsed form.

## Why

Surfaced by #201 real-RDS verification. Was the last blocker preventing discover against real Aurora (#214 handled the other side). Without this, every plan against a real Aurora cluster dies on the admin user's \`GRANT \\\`rds_superuser_role\\\`@\\\`%\\\` TO \\\`admin\\\`@\\\`%\\\`\` line.

## Test plan

- [x] Unit tests: exact Aurora repro line, comma-separated multi-role, WITH ADMIN OPTION trailer, and a regression check that privilege-grant paths are byte-for-byte unchanged. Plus ParseGrantLines with mixed privilege+role lines.
- [x] \`go test ./...\` green. Existing grant fixtures unchanged thanks to \`omitempty\` on the new fields.
- [x] End-to-end verified against the live #201 Aurora sandbox: with this PR stacked on #216, \`datastorectl plan\` produces the full four-handler changeset (\`mysql_database\`, \`mysql_user\`, \`mysql_role\`, \`mysql_grant\`) — the #201 "round-trip" acceptance criterion is unblocked.

## Ordering note

Best merged after #216 (they're independent, but both are needed for the #201 verification to proceed end-to-end).

Closes #215