### PR TITLE
mysql: point rds_iam 1045 error at rds-db:connect and AWSAuthenticationPlugin

### DIFF
--- a/providers/mysql/provider.go
+++ b/providers/mysql/provider.go
@@ -296,7 +296,7 @@ func (p *Provider) configureRDSIAMAuth(ctx context.Context, endpoint, tlsMode st
 		return dcl.Diagnostics{{
 			Severity:   dcl.SeverityError,
 			Message:    fmt.Sprintf("mysql rds_iam connection check failed: %s", err),
-			Suggestion: "verify the RDS endpoint is reachable, the IAM user is enabled on the DB, and TLS is accepted",
+			Suggestion: rdsIAMPingSuggestion(err),
 		}}
 	}
 

--- a/providers/mysql/rds_iam_hint.go
+++ b/providers/mysql/rds_iam_hint.go
@@ -1,0 +1,21 @@
+package mysql
+
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// rdsIAMPingSuggestion picks a diagnostic suggestion for a failed RDS
+// IAM connection check. A MySQL 1045 (access denied) under rds_iam
+// auth almost always means the signing principal is missing
+// rds-db:connect on the target DB user, or the server-side user was
+// not created with AWSAuthenticationPlugin. Other errors get the
+// generic endpoint/TLS hint.
+func rdsIAMPingSuggestion(err error) string {
+	var me *mysql.MySQLError
+	if errors.As(err, &me) && me.Number == 1045 {
+		return `for rds_iam auth, Error 1045 almost always means the signing principal is missing rds-db:connect on this DB user, or the server-side user is not IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS'; verify the IAM policy resource ARN matches arn:aws:rds-db:<region>:<account>:dbuser:<cluster-resource-id>/<username>`
+	}
+	return "verify the RDS endpoint is reachable, the IAM user is enabled on the DB, and TLS is accepted"
+}

--- a/providers/mysql/rds_iam_hint_test.go
+++ b/providers/mysql/rds_iam_hint_test.go
@@ -1,0 +1,53 @@
+package mysql
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+func TestRDSIAMPingSuggestion(t *testing.T) {
+	t.Run("1045_points_at_rds_db_connect", func(t *testing.T) {
+		got := rdsIAMPingSuggestion(&mysql.MySQLError{
+			Number:  1045,
+			Message: "Access denied for user 'datastorectl_iam'@'x.x.x.x' (using password: YES)",
+		})
+		for _, want := range []string{"rds-db:connect", "AWSAuthenticationPlugin"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("suggestion missing %q\ngot: %s", want, got)
+			}
+		}
+	})
+
+	t.Run("wrapped_1045_also_matches", func(t *testing.T) {
+		// The Go mysql driver may surface the 1045 wrapped via driver.ErrBadConn
+		// retry logic or a fmt.Errorf chain — errors.As must unwrap.
+		inner := &mysql.MySQLError{Number: 1045, Message: "Access denied"}
+		wrapped := fmt.Errorf("opening mysql connection: %w", inner)
+		got := rdsIAMPingSuggestion(wrapped)
+		if !strings.Contains(got, "rds-db:connect") {
+			t.Errorf("wrapped 1045 should still map to IAM suggestion; got: %s", got)
+		}
+	})
+
+	t.Run("non_1045_mysql_error_uses_generic", func(t *testing.T) {
+		// 2003 is "Can't connect to MySQL server" — real endpoint/TLS problem.
+		got := rdsIAMPingSuggestion(&mysql.MySQLError{Number: 2003, Message: "Can't connect"})
+		if strings.Contains(got, "rds-db:connect") {
+			t.Errorf("non-1045 should not mention rds-db:connect; got: %s", got)
+		}
+		if !strings.Contains(got, "endpoint") {
+			t.Errorf("generic suggestion should mention endpoint; got: %s", got)
+		}
+	})
+
+	t.Run("non_mysql_error_uses_generic", func(t *testing.T) {
+		got := rdsIAMPingSuggestion(errors.New("i/o timeout"))
+		if strings.Contains(got, "rds-db:connect") {
+			t.Errorf("non-MySQL error should not mention rds-db:connect; got: %s", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- \`auth = \"rds_iam\"\` connection failures surface as MySQL 1045 at the PingContext check. The existing suggestion text was copied from the password-auth path and pointed at endpoint/TLS — the wrong direction for IAM failures.
- New helper \`rdsIAMPingSuggestion\` unwraps \`*mysql.MySQLError\` and, when the error number is 1045, returns an IAM-aware suggestion pointing at the two real causes: missing \`rds-db:connect\` on the signing principal, or a server-side user that isn't \`IDENTIFIED WITH AWSAuthenticationPlugin\`.
- Non-1045 errors (e.g. 2003 can't-connect) keep the existing endpoint/TLS hint.

## Why

Surfaced by the #201 real-RDS verification. When I detached the inline policy on the test IAM user and ran \`datastorectl plan\`, the CLI said:

\`\`\`
mysql rds_iam connection check failed: Error 1045 (28000): Access denied ...
  (verify the RDS endpoint is reachable, the IAM user is enabled on the DB, and TLS is accepted)
\`\`\`

The actual cause was an IAM policy one keystroke away. A user not already familiar with RDS IAM would have looked at the wrong things for a long time.

## Test plan

- [x] Unit tests cover: 1045 direct, 1045 wrapped via \`fmt.Errorf(\"%w\", ...)\`, non-1045 MySQL error (2003), non-MySQL error (generic \`errors.New\`).
- [x] \`go test ./...\` green.
- Integration test path is the same; the behaviour is visible to anyone who hits the 1045 case.

Closes #218