### PR TITLE
mysql/bootstrap: idempotent re-runs, stop hiding bootstrap errors

### DIFF
--- a/providers/mysql/bootstrap/bootstrap-readonly.sql
+++ b/providers/mysql/bootstrap/bootstrap-readonly.sql
@@ -21,8 +21,15 @@
 -- Before running:
 --   1. Replace <REPLACE_ME> with a strong password (32+ chars).
 --   2. Review the host pattern '%' as with the read-write variant.
+--
+-- This script is idempotent; see the note in bootstrap-readwrite.sql
+-- for the CREATE-then-ALTER pattern rationale.
 
-CREATE USER 'datastorectl-ro'@'%'
+CREATE USER IF NOT EXISTS 'datastorectl-ro'@'%'
+  IDENTIFIED WITH caching_sha2_password BY '<REPLACE_ME>'
+  REQUIRE SSL;
+
+ALTER USER IF EXISTS 'datastorectl-ro'@'%'
   IDENTIFIED WITH caching_sha2_password BY '<REPLACE_ME>'
   REQUIRE SSL;
 

--- a/providers/mysql/bootstrap/bootstrap-readwrite.sql
+++ b/providers/mysql/bootstrap/bootstrap-readwrite.sql
@@ -16,10 +16,19 @@
 --   1. Replace <REPLACE_ME> with a strong password (32+ chars).
 --   2. Review the host pattern '%' — tighten it if your network
 --      policy supports scoping (e.g. '10.0.0.0/8').
---   3. Apply against a fresh cluster or one where no prior
---      'datastorectl' account exists.
+--
+-- This script is idempotent. Re-running it against a cluster that
+-- already has the 'datastorectl' account realigns the password and
+-- TLS requirement; the read and write grants below re-grant cleanly.
 
-CREATE USER 'datastorectl'@'%'
+CREATE USER IF NOT EXISTS 'datastorectl'@'%'
+  IDENTIFIED WITH caching_sha2_password BY '<REPLACE_ME>'
+  REQUIRE SSL;
+
+-- Re-align password, plugin, and REQUIRE clause on every run so the
+-- account state is predictable regardless of what happened in prior
+-- runs. ALTER USER IF EXISTS is a no-op when the account is missing.
+ALTER USER IF EXISTS 'datastorectl'@'%'
   IDENTIFIED WITH caching_sha2_password BY '<REPLACE_ME>'
   REQUIRE SSL;
 

--- a/showcase-mysql.sh
+++ b/showcase-mysql.sh
@@ -14,8 +14,12 @@ case "${1:-help}" in
     echo "Cluster is ready."
     echo ""
     echo "Provisioning the datastorectl management account..."
+    # stderr is intentionally NOT suppressed here — bootstrap failures
+    # surface as silent auth errors later when plan tries to connect.
+    # The "Using a password on the command line" warning is expected
+    # and harmless; real errors are actual SQL failures.
     sed "s/<REPLACE_ME>/${BOOTSTRAP_PW}/" providers/mysql/bootstrap/bootstrap-readwrite.sql \
-      | docker exec -i datastorectl-mysql-1 mysql -uroot -pdatastorectl 2>/dev/null
+      | docker exec -i datastorectl-mysql-1 mysql -uroot -pdatastorectl
     echo "Bootstrap applied."
     echo ""
     echo "Building datastorectl..."


### PR DESCRIPTION
## Summary

Two foot-guns caught while prepping the hackathon demo on a laptop that already had the showcase MySQL container's volume:

1. \`bootstrap-readwrite.sql\` and \`bootstrap-readonly.sql\` used \`CREATE USER\` (not \`CREATE USER IF NOT EXISTS\`). Re-running the showcase against a cluster that already has the account — which Docker volumes make the default case — fails at CREATE USER. The account is left with its old password, which no longer matches what \`showcase-mysql.sh\` just echoed, and the next \`plan\` fails with an opaque \`Error 1045 Access denied\`.

2. \`showcase-mysql.sh\` piped the bootstrap through \`docker exec ... 2>/dev/null\`. The \`2>/dev/null\` hid the CREATE USER failure. The script printed \`Bootstrap applied.\` and exited 0 even when the bootstrap had not actually applied.

## What changed

- Both bootstrap SQL files use \`CREATE USER IF NOT EXISTS\` followed by \`ALTER USER IF EXISTS\` with the same plugin / password / REQUIRE clause. Re-running realigns the account to whatever password the script was invoked with, regardless of prior state. Comment block updated to call out idempotency explicitly.
- Bootstrap step in \`showcase-mysql.sh\` no longer suppresses stderr. The only noise the change adds is MySQL's "Using a password on the command line" warning, which is worth it — real bootstrap failures now surface immediately instead of manifesting as a 1045 three commands later.

## Test plan

- [x] Fresh cluster: \`./showcase-mysql.sh up\` → \`plan\` shows the expected 7 creates.
- [x] Existing cluster (simulates the failing case in the original bug): \`./showcase-mysql.sh up\` a second time on the same running cluster. SQL re-runs cleanly, no errors surfaced. \`plan\` still shows 7 creates with the correct password.
- [x] No change to CI or unit test expectations (both bootstrap files are dev/demo artifacts, not part of the library).