### PR TITLE
showcase: remap MySQL host port to 3308 to avoid local conflicts

### DIFF
--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -132,13 +132,14 @@ jobs:
       - name: Bootstrap datastorectl account
         run: |
           # Run the mysql client on the runner against the
-          # port-forwarded 3306. This authenticates as root@<runner-IP>
-          # which matches root@% (password auth). Running the client
-          # inside the container matches root@localhost (socket auth)
-          # and rejects the password — that's why we don't docker exec.
+          # port-forwarded host port. This authenticates as
+          # root@<runner-IP> which matches root@% (password auth).
+          # Running the client inside the container matches
+          # root@localhost (socket auth) and rejects the password —
+          # that's why we don't docker exec.
           sed 's/<REPLACE_ME>/showcase_pw_4rEaDy/' \
               providers/mysql/bootstrap/bootstrap-readwrite.sql \
-            | mysql -h 127.0.0.1 -P 3306 -uroot -pdatastorectl
+            | mysql -h 127.0.0.1 -P 3308 -uroot -pdatastorectl
 
       - name: validate
         env:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Or a MySQL grant set:
 context "demo" {
   provider = mysql
   version  = "8.4"
-  endpoint = "localhost:3306"
+  endpoint = "localhost:3308"
   auth     = "password"
   username = "datastorectl"
   password = secret("env", "DATASTORECTL_MYSQL_PASSWORD")

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -5,7 +5,11 @@ services:
       MYSQL_ROOT_PASSWORD: datastorectl
       MYSQL_ROOT_HOST: "%"
     ports:
-      - "3306:3306"
+      # Host port 3308 (not 3306) so the showcase doesn't collide with
+      # a locally-installed MySQL or another dev project's mysql
+      # container. The in-container port stays 3306; only the host
+      # mapping is remapped. Showcase DCL points at localhost:3308.
+      - "3308:3306"
     healthcheck:
       test:
         - "CMD"

--- a/providers/mysql/README.md
+++ b/providers/mysql/README.md
@@ -22,7 +22,9 @@ docker compose -f docker-compose.mysql.yml down
 The fixture brings up a single `mysql:8.4` node with:
 - root password `datastorectl`
 - root accessible from any host (`MYSQL_ROOT_HOST=%`)
-- port `3306` exposed on the host
+- port `3308` exposed on the host (container port stays `3306`; the
+  host-side remap avoids conflicts with a locally-installed MySQL or
+  another dev project's `mysql` container)
 
 TLS uses the server-generated self-signed certs that ship with the
 image. Integration tests connect with `tls = "skip-verify"` to

--- a/testdata/showcase-mysql/resources.dcl
+++ b/testdata/showcase-mysql/resources.dcl
@@ -1,7 +1,7 @@
 context "demo" {
   provider = mysql
   version  = "8.4"
-  endpoint = "localhost:3306"
+  endpoint = "localhost:3308"
   auth     = "password"
   username = "datastorectl"
   password = secret("env", "DATASTORECTL_MYSQL_PASSWORD")


### PR DESCRIPTION
## Summary

The showcase compose file binds host port \`3306:3306\`, which collides with a locally-installed MySQL or another dev project's \`mysql\` container. Docker's failure mode is particularly unfriendly: the container may appear healthy while having silently dropped its port mapping, leaving the host unable to reach the cluster even though \`docker ps\` shows it up.

Remap the host port to \`3308\`. The in-container port stays \`3306\`, so only the host-side mapping moves. Side-updates ripple through:

- \`docker-compose.mysql.yml\` — \`3308:3306\` with a comment explaining why
- \`testdata/showcase-mysql/resources.dcl\` — endpoint becomes \`localhost:3308\`
- \`README.md\` and \`providers/mysql/README.md\` — example endpoints reflect the new port; real MySQL in production is still 3306 so only the local-dev examples change
- \`.github/workflows/showcase.yml\` — bootstrap mysql-client on the runner connects to \`-P 3308\`

## Why

Follow-up to #220. Caught on a laptop with three other MySQL containers from unrelated projects already running. After the port remap, running the showcase next to another MySQL on 3306 works without either project having to be stopped.

## Test plan

- [x] \`docker compose -f docker-compose.mysql.yml down -v && ./showcase-mysql.sh up\` on a laptop with another MySQL holding 3306 — datastorectl-mysql-1 binds cleanly on 3308.
- [x] \`plan\` against the updated showcase DCL shows the expected 7 creates.
- [x] CI path is straightforward: the runner is a fresh VM; changing 3306 to 3308 there is mechanical.